### PR TITLE
fix(bd-import-github-issues): use --body-file= instead of $(cat …)

### DIFF
--- a/home/commands/bd-import-github-issues.md
+++ b/home/commands/bd-import-github-issues.md
@@ -123,10 +123,10 @@ Proceed with the above mapping?
 
 ### Step 4: Create the beads
 
-**Don't pass descriptions inline.** GitHub bodies routinely contain quotes, apostrophes, code fences, multi-line shell output — escaping all that into a single `--description="..."` argument is brittle and breaks differently each time. Instead:
+**Don't pass descriptions inline.** GitHub bodies routinely contain quotes, apostrophes, code fences, multi-line shell output — escaping all that into a single `--description="..."` argument is brittle and breaks differently each time. `$(cat …)` substitution is a partial fix but can still trip Claude Code's harness re-prompt heuristic by surfacing multi-line content in the rendered command. Use `bd create --body-file=PATH` instead — bd reads the description directly from the file and the command line stays a single static line that matches the `Bash(bd *)` glob rule cleanly.
 
 1. For each confirmed candidate, write the full description to a temp file using the `Write` tool: `/tmp/bead-desc-<gh_number>.md`. The file content is plain text, no shell-escaping needed.
-2. Then run `bd create` with `--description="$(cat /tmp/bead-desc-<gh_number>.md)"`.
+2. Then run `bd create` with `--body-file=/tmp/bead-desc-<gh_number>.md` — no shell substitution involved.
 
 Description file template:
 
@@ -144,7 +144,7 @@ Then for each confirmed candidate, in order:
 ```sh
 bd create \
   --title="<decoded gh title>" \
-  --description="$(cat /tmp/bead-desc-<n>.md)" \
+  --body-file=/tmp/bead-desc-<n>.md \
   --type=<inferred or overridden> \
   --priority=<inferred or overridden>
 ```


### PR DESCRIPTION
## Summary

`bd create` supports `--body-file=PATH` directly. Switching from `--description="$(cat /tmp/foo.md)"` to `--body-file=/tmp/foo.md` eliminates the shell substitution that surfaces multi-line content in the rendered command line — which sometimes triggered Claude Code's harness re-prompt heuristic even though `Bash(bd *)` is glob-allowed in `~/.claude/settings.json`.

Same outcome (description loaded from a file, no escaping, no shell-escaping brittleness), but now the command is a single static line that matches the glob cleanly.

## Diff

3 lines changed in `home/commands/bd-import-github-issues.md` (Step 4):

- Step 4 prose expanded to explain the `$(cat …)` → `--body-file=` rationale.
- The bd create example now uses `--body-file=/tmp/bead-desc-<n>.md`.

## Closes

- `agentic-coding-config-85l` — this PR.

## Related

- `agentic-coding-config-b05` (closed) — research that surfaced this. Memory saved via `bd remember` so future sessions default to `--body-file` for any non-trivial `bd create`.

## Test plan

- [ ] CI passes (markdownlint already passes locally — verified before push)
- [ ] After merge: next time `/bd-import-github-issues` runs (e.g. via `/start-session`), confirm the bd create calls don't trigger multi-line re-prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
