### PR TITLE
fix(bd-modernize): document 'no common ancestor' Dolt failure + recovery

### DIFF
--- a/home/commands/bd-modernize.md
+++ b/home/commands/bd-modernize.md
@@ -229,6 +229,20 @@ If the push fails with a credential-prompt error, that's the Dolt v1.81.10 bug �
 
 If the push fails with `fatal: this operation must be run in a work tree`, Step 5c didn't catch all the cache hooks — re-run the `find … -name hooks -exec rm -rf` in 5c, then retry.
 
+If the push fails with `Error 1105: unknown push error; no common ancestor`, the local Dolt DB just created by `bd init --from-jsonl` (Step 4b) has a fresh `repository_id` with no shared history with the remote's existing `refs/dolt/data`. This happens whenever the remote was already seeded — typical for any project that's been on the modern target for a while and is now being re-modernised. Recovery (worked on `agentic-coding-config` 2026-05-04):
+
+```sh
+rm -rf .beads/embeddeddolt .beads/dolt    # discard local DB; .beads/issues.jsonl is untouched
+bd bootstrap                               # re-clone from remote (data-identical, just different history)
+```
+
+Then **two follow-ups** before retrying push:
+
+1. **Identity mismatch.** `bd bootstrap` clones the database with the remote's canonical `_project_id` but does **not** update `.beads/metadata.json` — bd will refuse all reads/writes with `workspace identity mismatch detected`. Edit `.beads/metadata.json` `project_id` to match the value bd shows in the error message (it prints both: the metadata.json one and the database `_project_id`). The database value is the canonical one.
+2. **Cache hooks re-created.** `bd bootstrap` re-creates the `.beads/embeddeddolt/.../.dolt/git-remote-cache/<hash>/repo.git/hooks/` directory that Step 5c removed earlier in the run. Re-run Step 5c's `find .beads/embeddeddolt -type d -name hooks -exec rm -rf {} +` before retrying push, otherwise it'll fail with the work-tree error covered above.
+
+Then `bd dolt push` is a clean no-op (local now matches remote). The skill could in principle pre-flight-detect this case (remote has populated `refs/dolt/data` → prefer `bd bootstrap` over `bd init --from-jsonl` at Step 4b); not implemented today.
+
 ### 5e. Disable JSONL auto-staging
 
 Append (or set) `export.git-add: false` in `.beads/config.yaml`. Leave `export.auto: true` (default) so the file stays fresh on disk for IDE visibility — it just never gets staged.


### PR DESCRIPTION
## Summary

Adds a third `Step 5d` failure mode that surfaced when re-modernising this repo on 2026-05-04. When the remote already has populated `refs/dolt/data` (typical for any project that's been on the modern target for a while), `bd init --from-jsonl` (Step 4b) creates a local DB with a fresh `repository_id` and no shared ancestor. Push then refuses with `Error 1105: unknown push error; no common ancestor`.

The skill currently only covers two Step 5d failure modes (credential-prompt bug + cache-hooks work-tree error). This PR adds the third with a tested recovery procedure.

## Recovery procedure (verified working)

```sh
rm -rf .beads/embeddeddolt .beads/dolt    # discard local DB; .beads/issues.jsonl untouched
bd bootstrap                               # re-clone from remote
```

Then **two follow-ups** before retrying push:

1. **Identity mismatch.** `bd bootstrap` clones with the canonical `_project_id` but doesn't update `.beads/metadata.json` — bd refuses all reads/writes with `workspace identity mismatch detected`. Edit `metadata.json` to match the database `_project_id` (bd prints both in the error).
2. **Cache hooks re-created.** `bd bootstrap` re-installs `.beads/embeddeddolt/.../.dolt/git-remote-cache/<hash>/repo.git/hooks/` (templated from `~/.git-templates`). Re-run Step 5c's `find … -name hooks -exec rm -rf {} +`, otherwise the next push fails with the work-tree error.

## Closes

- `agentic-coding-config-p1x`

## Notes

- Doc-only change. No skill behavior change for the happy path.
- A future enhancement (out of scope for this PR) could pre-flight-detect the case at Step 4b — if remote already has populated `refs/dolt/data`, prefer `bd bootstrap` over `bd init --from-jsonl` and skip the failure entirely. Worth filing as a separate bead if the friction recurs.

## Test plan

- [ ] CI passes (markdownlint already passes locally)
- [ ] On next re-modernise of any repo with a seeded remote, the failure mode + recovery match the documented procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
