### PR TITLE
feat(bd-import-github-issues): add author allowlist filter

### DIFF
--- a/home/commands/bd-import-github-issues.md
+++ b/home/commands/bd-import-github-issues.md
@@ -11,6 +11,7 @@ Run at the start of a session when the GitHub Issues tab on this repo has accumu
 - **No bidirectional sync.** Changes in beads are not pushed back to GitHub. The migrated GitHub issues are closed and inert.
 - **No automatic / scheduled execution.** Always invoke explicitly.
 - **No PR migration.** GitHub's `list_issues` returns PRs as well as issues — those are filtered out and left alone.
+- **No imports from external authors.** Step 1's first filter excludes Issues from anyone not in the allowlist — content from non-allowlisted authors never enters beads or the model's context. Edit Step 1's allowlist to add identities (e.g. sandbox-bot accounts).
 - **No hard delete by default.** GitHub's API doesn't allow non-admins to delete issues; even admins lose the audit trail. Default is close-with-comment-and-link, which gives the same effect for a solo workflow with a recoverable record.
 
 ## Operational notes
@@ -58,15 +59,26 @@ This step is Tier 1 — pull is reversible, the only failure modes (auth, networ
 
 ### Step 1: Build the candidate list
 
-From the `mcp__github__list_issues` response:
+#### Author allowlist (edit this list to add identities)
 
+```text
+pmgledhill102
+```
+
+Issues from authors **not** in this list are excluded entirely — they stay open on GitHub but never enter beads, and their titles/bodies are never surfaced in the candidate table. This is a hard guardrail against external Issue spam: even on public repos with Issues enabled, content from non-allowlisted authors can't reach the bead database or the model's context. Add known sandbox-bot identities here as they're commissioned.
+
+#### Filters
+
+From the `mcp__github__list_issues` response, apply these filters in order:
+
+- **Filter by author allowlist (apply first)**: any item whose `user.login` is not in the allowlist above — exclude. **Do not surface filtered-out items' titles or bodies** in any subsequent output; keeping their content out of the model's context is the point of the filter. Track the count only.
 - **Filter out PRs**: any item where the `pull_request` field is non-null is a PR — exclude.
 - **Filter out already-migrated**: any item whose `body` matches the regex `Migrated to beads [a-z0-9-]+` — exclude. This is the idempotency check; re-runs skip these.
 - **For each remaining issue**, capture: `number`, `title`, `body` (may be null/empty), `labels` (array of `{name}`), `assignees`, `created_at`, `html_url`.
 - **Decode HTML entities** in titles and bodies before further processing. The GitHub API returns `&#39;` for apostrophe, `&#34;` for double-quote, `&amp;` for ampersand, etc. Pass them verbatim to `bd create` and your bead title ends up as literal `Need a &#39;dotup&#39;...` Decode at minimum: `&#39;` → `'`, `&#34;` → `"`, `&amp;` → `&`, `&lt;` → `<`, `&gt;` → `>`. A more complete decoder is fine but not required for the common cases.
 - **Normalise mojibake in bodies**. Windows tool outputs (winget, MSBuild) often dump runs of unicode block characters (U+2588, U+2592) for progress bars; these get re-encoded as ASCII garbage like `ÔûêÔûêÔûêÔûÆ` somewhere along the API path. Strip runs of these specific mojibake patterns and add a one-line note to the bead description (`progress-bar mojibake stripped during import; see source URL for original`). Don't strip anything else — preserve all real content verbatim.
 
-If after filtering the candidate list is empty, report "all open issues already migrated or are PRs" and stop.
+When announcing the candidate list to the user (Step 3), include a one-line summary of any filter activity, e.g. `(2 issues from non-allowlisted authors skipped; 1 PR skipped; 0 already migrated)`. If the filtered candidate list is empty, report which filters consumed the input (`"5 issues filtered out — 4 by author allowlist, 1 already migrated; nothing to import"`) and stop.
 
 ### Step 2: Infer beads type and priority from labels
 
@@ -204,6 +216,8 @@ Report a summary to the user:
 
 - N beads created (with their IDs and titles)
 - N GitHub issues closed (or skipped if Step 5 was "skip")
+- N issues filtered by author allowlist (count only — IDs and titles stay out of context)
+- N issues skipped as already-migrated, N PRs skipped
 - Any failures (issues whose close didn't go through, etc.)
 
 ### Step 8: Push imported beads to remote


### PR DESCRIPTION
## Summary

Adds an author-allowlist filter as Step 1's **first** guardrail in `/bd-import-github-issues`. Issues from anyone not in the allowlist (initial value: `pmgledhill102`) are excluded entirely — their titles and bodies never reach the model's context, and they never enter beads.

## Why

This is the security-process workstream's highest-priority guardrail. It makes external Issue spam **operationally inert** even on public repos with Issues left enabled, which is the soft-measure that justifies the no-lockdown decision in `paul-context/decisions/2026-05-03-defer-issues-pr-lockdown.md`. Without it, an external troll could populate every `/start-session` import with junk content that the model would have to read.

The filter is "filter, not flag" — content from non-allowlisted authors is discarded silently rather than shown for review. Surfacing the title/body would defeat the point.

## What changed

`home/commands/bd-import-github-issues.md`:

- New `## Step 1 / Author allowlist` callout — the editable list. Initial value `pmgledhill102`. Structure is ready for sandbox-bot identities (decision pending in `paul-context-4k8`).
- New "Filter by author allowlist (apply first)" filter rule, ordered before the PR / already-migrated filters. Track only the count; never surface filtered-out content.
- New "What it doesn't do" entry: `No imports from external authors`.
- Step 3 / Step 7 reporting now includes filter-activity counts so filter behaviour is visible to the user (e.g. `"2 issues from non-allowlisted authors skipped"`).

## Closes

- `agentic-coding-config-kgb`

## Caveats / test plan

- [ ] CI passes (markdownlint already passes locally)
- [ ] **End-to-end verification requires a non-`pmgledhill102` Issue** to confirm the filter actually drops it. Easiest way: create a test Issue on this repo from a second GitHub account (or via a PAT for a sandbox identity), then run `/bd-import-github-issues` and confirm the filter count surfaces and the bead never sees the content. The bead-acceptance criterion includes this test, but it can't be done end-to-end from a Claude Code session — flagging for manual verification.
- [ ] Future expansion: when `paul-context-4k8` settles on sandbox-bot identities, append them to the allowlist in Step 1.

## Related

- Earlier in the chain: `agentic-coding-config-b05` (research) → `agentic-coding-config-85l` / PR #12 (the `--body-file=` cleanup) → this. Both improve the import skill, but on different axes (security vs ergonomics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
