### PR TITLE
feat(end-session): detect stale ~/.claude/ files vs chezmoi source

### DIFF
--- a/home/bin/end-session-gather-state
+++ b/home/bin/end-session-gather-state
@@ -97,6 +97,30 @@ if [ -f .beads/metadata.json ]; then
     run_section bd_preflight bd preflight
 fi
 
+# shellcheck disable=SC2016
+run_sh stale_claude_files '
+    # Detect files in ~/.claude/commands or ~/.claude/bin that chezmoi
+    # does not know about — typical drift after a slash command rename
+    # (chezmoi only adds/updates; never removes from target unless exact=true).
+    if ! command -v chezmoi >/dev/null 2>&1; then
+        echo "chezmoi-unavailable"
+        exit 1
+    fi
+    managed=$(mktemp)
+    actual=$(mktemp)
+    trap "rm -f $managed $actual" EXIT
+    chezmoi managed --include=files 2>/dev/null \
+      | grep -E "^\.claude/(commands|bin)/" \
+      | sort > "$managed"
+    for d in commands bin; do
+        [ -d "$HOME/.claude/$d" ] || continue
+        find "$HOME/.claude/$d" -mindepth 1 -maxdepth 1 -type f \
+          | sed "s|^$HOME/||"
+    done | sort > "$actual"
+    # Output: each line is a stale path under .claude/. Empty = nothing stale.
+    comm -23 "$actual" "$managed"
+'
+
 wait
 progress "all sections complete"
 
@@ -114,6 +138,6 @@ printf '===fetch (exit=%s)===\n' "$FETCH_EXIT"
 cat "$TMP/fetch.out"
 printf '\n'
 
-for s in local_state stashes worktrees merged_brs main_ci open_prs bd_progress bd_preflight; do
+for s in local_state stashes worktrees merged_brs main_ci open_prs bd_progress bd_preflight stale_claude_files; do
     [ -f "$TMP/$s.exit" ] && emit "$s"
 done

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -39,12 +39,13 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `fetch` | 2 (folded in) | Non-zero = network/auth issue — surface before proceeding. |
 | `local_state` | 1, 4 | Dirty tree + unpushed commits for step 4. |
 | `stashes` | 9 | Exit 0 even when empty. |
-| `worktrees` | 12 | Exit 0 even when empty. |
+| `worktrees` | 13 | Exit 0 even when empty. |
 | `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
 | `main_ci` | 3 | Content `gh-unavailable` = silent skip. Non-zero with other content = real error. |
 | `open_prs` | 8 | Same skip convention as `main_ci`. |
 | `bd_progress` | 10 | Section absent if no beads workspace. All entries are `in_progress` by definition (that's the filter) — see step 10 for symbol-reading rules. |
 | `bd_preflight` | 11 | Non-zero = preflight flagged something — surface its output. |
+| `stale_claude_files` | 12 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
 Rules for interpreting exit codes:
 
@@ -149,18 +150,37 @@ From gather section `bd_progress` (absent if no beads workspace). The section is
 
 From gather section `bd_preflight` (absent if no beads workspace). Surface output. Includes lint, stale, orphans checks — all read-only.
 
-### 12. Other worktrees (Tier 3 — surface)
+### 12. Stale Claude commands/bin files (Tier 1 — surface)
+
+From gather section `stale_claude_files` (silently skipped when `chezmoi` isn't on PATH).
+
+chezmoi only adds and updates target files; it never removes them when source files are renamed or deleted (unless the directory is configured `exact = true`, which has its own destructive risk for user-added files). Result: when a slash command is renamed in the source repo (e.g. `bd-migrate-embedded.md` → `bd-modernize.md`), the OLD file lingers at `~/.claude/commands/` on every machine that ever applied a version where it was present. Claude Code still sees the stale file and lists it as a slash command, so the drift compounds across versions.
+
+The gather computes `chezmoi managed` minus actual contents under `~/.claude/commands/` and `~/.claude/bin/`, and emits any extras (one path per line). Surface them with a one-line `rm` suggestion the user can paste:
+
+```text
+3 stale file(s) under ~/.claude/:
+  ~/.claude/commands/bd-migrate-embedded.md
+  ~/.claude/commands/old-thing.md
+  ~/.claude/bin/legacy-script
+
+Suggested: rm ~/.claude/commands/bd-migrate-embedded.md ~/.claude/commands/old-thing.md ~/.claude/bin/legacy-script
+```
+
+Don't `rm` automatically — the user might be testing an unstaged file, or these may belong to another tool. The check is "fast" (one `chezmoi managed` + two `find`s) so it runs unconditionally per session.
+
+### 13. Other worktrees (Tier 3 — surface)
 
 From gather section `worktrees`. If more than one entry, list non-primary worktrees with their branch. If any have uncommitted work, flag with `*`. Don't remove anything.
 
-### 13. Background processes
+### 14. Background processes
 
 Split by origin:
 
 - **Spawned by Claude in this session** (via `run_in_background`): list. Reap any that have completed (Tier 1 — auto). If still running and the task seems incomplete, surface before reaping.
 - **Started by the user / pre-existing**: surface only (Tier 3). Don't kill.
 
-### 14. Beads sync (Tier 1)
+### 15. Beads sync (Tier 1)
 
 If `.beads/metadata.json` exists:
 
@@ -170,7 +190,7 @@ bd dolt push
 
 If this fails, surface the error but don't block the phase — the user can retry manually.
 
-### 15. Phase 1 summary
+### 16. Phase 1 summary
 
 Print a concise summary. Each line says "none" loudly when clean, so noise scales with actual mess:
 
@@ -183,6 +203,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Stashes outstanding: `<count, or "none">`
 - Beads in_progress (yours): `<count, or "none">`
 - Beads preflight: `<pass/issues>`
+- Stale `~/.claude/` files: `<count, or "none" / "n/a (no chezmoi)">`
 - Other worktrees: `<count, or "none">`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`


### PR DESCRIPTION
## Summary

Adds a stale-files check to `/end-session` that surfaces any files under `~/.claude/commands/` or `~/.claude/bin/` that are present on disk but not tracked by chezmoi — typically left over from a slash command rename or a removed bin script.

## Why

chezmoi only **adds** and **updates** target files; it never removes them when source files are renamed or deleted (unless the directory is configured `exact = true`, which has its own destructive risk for user-added files). Result: a slash command renamed in the source repo (e.g. `bd-migrate-embedded.md` → `bd-modernize.md`) leaves the OLD file at `~/.claude/commands/` on every machine that ever applied a version where it was present, until manually removed. Claude Code still lists those files as available slash commands — drift accumulates silently across versions.

The bead's concrete example was `~/.claude/commands/bd-migrate-embedded.md`, which was lingering after the rename to `bd-modernize`. (Already cleaned up on the local machine, but the class of issue stands.)

## What changed

### `home/bin/end-session-gather-state`

New `stale_claude_files` section that runs in parallel with the existing gather:

```sh
chezmoi managed --include=files \
  | grep -E '^\.claude/(commands|bin)/' \
  | sort > $managed
{ for d in commands bin; do
    [ -d "$HOME/.claude/$d" ] || continue
    find "$HOME/.claude/$d" -mindepth 1 -maxdepth 1 -type f \
      | sed "s|^$HOME/||"
  done } | sort > $actual
comm -23 $actual $managed
```

- Empty body (exit=0) ⇒ nothing stale.
- Body with `chezmoi-unavailable` (exit=1) ⇒ silent skip (consistent with `gh-unavailable` pattern elsewhere).
- Body with paths ⇒ each line is a stale file under `.claude/`.

### `home/commands/end-session.md`

- New **Step 12: Stale Claude commands/bin files (Tier 1 — surface)**. Surfaces extras with a paste-ready `rm` suggestion. Doesn't auto-delete — the file might be a user test, or belong to another tool.
- Steps 12–15 renumbered to 13–16 (Other worktrees, Background processes, Beads sync, Phase 1 summary).
- Section table gets a new `stale_claude_files` row; `worktrees` row's "Drives step(s)" updated 12→13.
- Phase 1 summary gains a `Stale ~/.claude/ files` line.

## Closes

- `agentic-coding-config-85q`

## Test plan

- [ ] CI passes (markdownlint + shellcheck both green locally)
- [ ] On a machine with chezmoi: run `/end-session` and confirm the stale-files section surfaces correctly when there are extras (test by `touch ~/.claude/commands/test-stale.md`, run `/end-session`, expect the file to appear; then `rm`)
- [ ] On a machine without chezmoi: confirm silent skip (`stale_claude_files` body = `chezmoi-unavailable`, no surface in summary)
- [ ] Confirm renumbered steps still flow correctly (no stale "Step 13" / "Step 14" cross-references — verified locally with grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
