### PR TITLE
feat(bd): add bd-push-safe shim that strips cache hooks before push

### DIFF
--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -15,6 +15,10 @@
 - Before pushing follow-up commits to a PR branch, always check the PR is still open via `mcp__github__pull_request_read` (method: "get"). The user often reviews and merges PRs via the GitHub UI while work continues — if already merged, create a new branch and PR instead
 - When multiple related changes span different concerns, ask the user whether to use one branch or separate branches before committing
 
+## Beads (bd)
+
+- **Prefer `bd-push-safe` over bare `bd dolt push`**: the shim at `~/.claude/bin/bd-push-safe` strips the cache hooks that `bd init` / `bd bootstrap` re-create from `init.templatedir`. On machines where dotfiles git-templates invoke the pre-commit framework, bare `bd dolt push` fails with `fatal: this operation must be run in a work tree`; `bd-push-safe` is a drop-in replacement that just works. Tracked upstream as `agentic-coding-config-o5w`; once that lands the shim becomes a no-op and can be removed.
+
 ## Commit & PR Style
 
 - Use multiple `-m` flags for multi-paragraph commit messages: `git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`

--- a/home/bin/bd-push-safe
+++ b/home/bin/bd-push-safe
@@ -1,0 +1,16 @@
+#!/bin/sh
+# bd-push-safe — wrap `bd dolt push` with the cache-hooks workaround.
+#
+# Background: `bd init` and `bd bootstrap` re-create
+# .beads/embeddeddolt/<db>/.dolt/git-remote-cache/<hash>/repo.git/hooks/
+# from `git init`'s template. If the user's dotfiles configure
+# `init.templatedir` to invoke the pre-commit framework, those cache hooks
+# fire on the next `bd dolt push`, run `git diff` in a non-worktree context,
+# and the push fails with `fatal: this operation must be run in a work tree`.
+#
+# Recovery is mechanical: strip the cache hooks first, then push. This shim
+# encapsulates that. Once agentic-coding-config-o5w lands upstream, this
+# shim becomes a no-op and can be removed.
+
+find .beads/embeddeddolt -type d -name hooks -exec rm -rf {} + 2>/dev/null
+exec bd dolt push "$@"


### PR DESCRIPTION
## Summary

- New `home/bin/bd-push-safe` (3-line POSIX-sh shim): strips `.beads/embeddeddolt/<db>/.dolt/git-remote-cache/<hash>/repo.git/hooks/` before `exec bd dolt push "$@"`.
- `home/CLAUDE.md` documents the shim under a new **Beads (bd)** section, marking it as the preferred push command and noting the upstream tracking issue.

## Why

`bd init` and `bd bootstrap` re-create the cache hooks dir from `init.templatedir` (or the system default). When dotfiles git-templates invoke the pre-commit framework, those cache hooks fire on the next `bd dolt push`, run `git diff` in a non-worktree context, and the push fails with `fatal: this operation must be run in a work tree`.

Hit ~5 times in the 2026-05-04 session. Recovery is mechanical (one `find` + retry), which is the strongest signal it should be wrapped, not memorised. The persistent memory captures the rule for cases where the shim isn't on PATH; this PR adds the convenience layer.

Once `agentic-coding-config-o5w` lands upstream and is in a released `bd` version, this shim becomes a no-op and can be deleted.

## Test plan

- [ ] `shellcheck home/bin/bd-push-safe` passes (verified locally — clean)
- [ ] `markdownlint-cli2 home/CLAUDE.md` passes (verified locally — 0 errors)
- [ ] `chmod +x` set (verified — `mode 100755`)
- [ ] After `chezmoi apply`, `bd-push-safe` on a repo with cache hooks succeeds where bare `bd dolt push` would fail
- [ ] On a repo with no cache hooks, `bd-push-safe` is a clean no-op + push (the `find` exits silently)

Closes agentic-coding-config-f5i