### PR TITLE
feat(allowlist): auto-approve gh issue create + Write(/tmp/**)

### DIFF
--- a/home/settings.json
+++ b/home/settings.json
@@ -127,6 +127,7 @@
       "Bash(gcloud sql instances list *)",
       "Bash(gcloud storage cat *)",
       "Bash(gcloud storage ls *)",
+      "Bash(gh issue create --repo pmgledhill102/*)",
       "Bash(gh issue list *)",
       "Bash(gh issue view *)",
       "Bash(gh pr checks *)",
@@ -304,7 +305,8 @@
       "mcp__google-developer-knowledge__get_documents",
       "mcp__google-developer-knowledge__search_documents",
       "Read(~/.claude/retros.md)",
-      "Read(~/.claude/settings.json)"
+      "Read(~/.claude/settings.json)",
+      "Write(/tmp/**)"
     ]
   },
   "hooks": {

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -199,6 +199,7 @@ manually (see Never Allow). Closing PRs/issues and `gh api` (which can
 POST/DELETE) require prompting. These entries will be retired once the
 GitHub MCP server is validated — see GitHub MCP section below.
 
+- `Bash(gh issue create --repo pmgledhill102/*)` — narrower than `gh issue create *`. Restricts auto-approval to issues filed against the user's own repos. **Caveat**: Claude Code's Bash matcher is literal-prefix, so `--repo pmgledhill102/<name>` must be the **first flag** after `gh issue create` for the rule to match. Putting `--title` or `--body-file` first will fall back to manual approval. Symmetric `gh issue comment/edit/close --repo pmgledhill102/*` rules are deliberately deferred — they share the same shape and can be added when the friction surfaces.
 - `Bash(gh issue list *)`
 - `Bash(gh issue view *)`
 - `Bash(gh pr checks *)`
@@ -548,6 +549,26 @@ run. Write/Edit access remains gated.
 
 - `Read(~/.claude/retros.md)`
 - `Read(~/.claude/settings.json)`
+
+### Write permissions (scratch space)
+
+`/tmp` on macOS is per-user, ephemeral, and the standard scratch space —
+nothing durable or shared lives there. The blast radius of allowing
+`Write` is "Claude can scribble in scratch space," which is exactly
+what scratch space is for.
+
+User-level CLAUDE.md forbids heredocs (`cat <<'EOF'`) and ANSI-C
+quoting in bash commands, so any multi-line content for `gh issue
+create --body-file`, `bd create --body-file=...`, etc. has to flow
+through a temp file. Auto-approving `Write(/tmp/**)` removes the
+double-prompt friction (one for the command, one for the temp file)
+that otherwise discourages the structured-body pattern.
+
+- `Write(/tmp/**)` — scratch space for staging long, structured content
+  (issue bodies, bead descriptions, etc.) before passing to a CLI via
+  `--body-file` or `$(cat ...)`. Restrict scope further to
+  `Write(/tmp/claude-*)` (with a naming-convention discipline) if the
+  broad rule ever feels uncomfortable.
 
 ## Never allow
 


### PR DESCRIPTION
## Summary

- Add `Bash(gh issue create --repo pmgledhill102/*)` to `permissions.allow` — restricts auto-approval to issues filed against the user's own repos.
- Add `Write(/tmp/**)` to `permissions.allow` — scratch space for staging multi-line content for `--body-file` / `$(cat ...)` flows.
- `home/settings.json.md` documents both rules, including the gh-issue-create flag-ordering caveat and the rationale for `/tmp/**` over `/tmp/claude-*`.

## Why

Surfaced 2026-05-03 during retros consolidation: filing 7 issues each prompted **twice** — once for the `gh issue create` shape, once for `Write(/tmp/<scratch>.md)` to stage the body. Cumulative friction is high enough that it discourages the structured-body pattern in favour of cramming everything into shell-quoted `--body=...` strings.

Both rules together unblock the same workflow. Adding only one leaves half the friction in place.

## Why not `mcp__github__issue_write` instead?

`mcp__github__issue_write` is **wider, not narrower** — Claude Code's MCP allowlist is name-based with no per-repo filtering, so allowing it would auto-approve writes to any GitHub repo Claude has access to. The Bash wildcard with `--repo pmgledhill102/*` is more precise and matches the user's stated guardrail ("manual approval for any non-personal repo").

## Decisions deliberately deferred

- **Symmetric `gh issue comment/edit/close --repo pmgledhill102/*` rules** — same shape, can land later when the friction surfaces. Single-concern PR.
- **Tighter `Write(/tmp/claude-*)` variant** — broader `Write(/tmp/**)` chosen for now; the companion doc notes the option to narrow.

## Test plan

- [ ] `markdownlint-cli2 home/settings.json.md` passes (verified locally — 0 errors)
- [ ] `jq empty home/settings.json` passes (verified locally — valid JSON)
- [ ] After `chezmoi apply`, `gh issue create --repo pmgledhill102/<any-repo> --body-file /tmp/test.md` runs end-to-end without prompts
- [ ] After `chezmoi apply`, `gh issue create --repo someother/foo --body-file /tmp/test.md` still prompts on the first call (mismatched owner)

Closes agentic-coding-config-i3r