### PR TITLE
feat(retrospective): journal-draft inbox/promote pattern (no cross-repo git ops)

### DIFF
--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -137,14 +137,21 @@ run_sh gh_unmigrated '
         echo "jq-unavailable"
         exit 1
     fi
-    # gh issue list excludes PRs by default. The marker `Migrated to beads `
-    # is the idempotency anchor written by /bd-import-github-issues.
+    # gh issue list excludes PRs by default. Filter out:
+    #   - issues whose body has the marker "Migrated to beads " (idempotency
+    #     anchor written by /bd-import-github-issues),
+    #   - issues labeled "journal-draft" (sandbox-fallback drafts for the
+    #     paul-context inbox/promote pattern; drained by /promote-journal-inbox,
+    #     not /bd-import-github-issues).
     # Bind the filtered list to $u so we can both count and iterate it.
     # The '\'' sequence closes/reopens the outer single quote so jq can
     # take a single-quoted filter argument.
-    gh issue list --state open --limit 100 --json number,title,body \
+    gh issue list --state open --limit 100 --json number,title,body,labels \
       | jq -r '\''
-          map(select((.body // "") | test("Migrated to beads ") | not)) as $u
+          map(select(
+              ((.body // "") | test("Migrated to beads ") | not)
+              and ([(.labels // [])[].name] | index("journal-draft") | not)
+          )) as $u
           | "count=\($u | length)",
             ($u[] | "#\(.number) \(.title)")
         '\''

--- a/home/commands/bd-import-github-issues.md
+++ b/home/commands/bd-import-github-issues.md
@@ -74,11 +74,12 @@ From the `mcp__github__list_issues` response, apply these filters in order:
 - **Filter by author allowlist (apply first)**: any item whose `user.login` is not in the allowlist above — exclude. **Do not surface filtered-out items' titles or bodies** in any subsequent output; keeping their content out of the model's context is the point of the filter. Track the count only.
 - **Filter out PRs**: any item where the `pull_request` field is non-null is a PR — exclude.
 - **Filter out already-migrated**: any item whose `body` matches the regex `Migrated to beads [a-z0-9-]+` — exclude. This is the idempotency check; re-runs skip these.
+- **Filter out journal drafts**: any item carrying the `journal-draft` label — exclude. These are journal entry drafts filed by the `retrospective` skill's sandbox fallback, drained by `/promote-journal-inbox`, not this skill. Importing them as beads would mis-categorise narrative content as actionable work. (See `paul-context/decisions/2026-05-05-journal-inbox-promotion.md`.)
 - **For each remaining issue**, capture: `number`, `title`, `body` (may be null/empty), `labels` (array of `{name}`), `assignees`, `created_at`, `html_url`.
 - **Decode HTML entities** in titles and bodies before further processing. The GitHub API returns `&#39;` for apostrophe, `&#34;` for double-quote, `&amp;` for ampersand, etc. Pass them verbatim to `bd create` and your bead title ends up as literal `Need a &#39;dotup&#39;...` Decode at minimum: `&#39;` → `'`, `&#34;` → `"`, `&amp;` → `&`, `&lt;` → `<`, `&gt;` → `>`. A more complete decoder is fine but not required for the common cases.
 - **Normalise mojibake in bodies**. Windows tool outputs (winget, MSBuild) often dump runs of unicode block characters (U+2588, U+2592) for progress bars; these get re-encoded as ASCII garbage like `ÔûêÔûêÔûêÔûÆ` somewhere along the API path. Strip runs of these specific mojibake patterns and add a one-line note to the bead description (`progress-bar mojibake stripped during import; see source URL for original`). Don't strip anything else — preserve all real content verbatim.
 
-When announcing the candidate list to the user (Step 3), include a one-line summary of any filter activity, e.g. `(2 issues from non-allowlisted authors skipped; 1 PR skipped; 0 already migrated)`. If the filtered candidate list is empty, report which filters consumed the input (`"5 issues filtered out — 4 by author allowlist, 1 already migrated; nothing to import"`) and stop.
+When announcing the candidate list to the user (Step 3), include a one-line summary of any filter activity, e.g. `(2 issues from non-allowlisted authors skipped; 1 PR skipped; 0 already migrated; 1 journal draft skipped)`. If the filtered candidate list is empty, report which filters consumed the input (`"5 issues filtered out — 4 by author allowlist, 1 journal draft; nothing to import"`) and stop.
 
 ### Step 2: Infer beads type and priority from labels
 
@@ -217,7 +218,7 @@ Report a summary to the user:
 - N beads created (with their IDs and titles)
 - N GitHub issues closed (or skipped if Step 5 was "skip")
 - N issues filtered by author allowlist (count only — IDs and titles stay out of context)
-- N issues skipped as already-migrated, N PRs skipped
+- N issues skipped as already-migrated, N PRs skipped, N `journal-draft` Issues skipped
 - Any failures (issues whose close didn't go through, etc.)
 
 ### Step 8: Push imported beads to remote

--- a/home/commands/promote-journal-inbox.md
+++ b/home/commands/promote-journal-inbox.md
@@ -1,0 +1,138 @@
+Drain the journal-draft inbox for `paul-context`: move filesystem drafts from `~/dev/paul-context/_incoming/` to `journal/`, drain GitHub Issues labeled `journal-draft` from `pmgledhill102/paul-context` into `journal/`, commit each, push once, then close the drained Issues with back-links. Run from `~/dev/paul-context/` (the slash command lives in `agentic-coding-config` per the slash-commands-in-dotfiles convention; the work happens in `paul-context`).
+
+See `paul-context/decisions/2026-05-05-journal-inbox-promotion.md` for the design rationale.
+
+## Pre-flight
+
+This command **must run inside the `paul-context` working tree.** It commits to that repo; running elsewhere would write into the wrong place. Run the bare commands below and branch on their exit codes — don't paste compound `||` / `&&` forms, which won't match any single allow rule.
+
+```sh
+git rev-parse --is-inside-work-tree
+basename "$(git rev-parse --show-toplevel)"
+```
+
+If the first command's exit code is non-zero (or stdout is not `true`), abort with `/promote-journal-inbox requires a git-backed repo, stopping.` and stop.
+
+If `basename` doesn't match `paul-context`, abort with `/promote-journal-inbox must run from ~/dev/paul-context/, not <where>` and stop.
+
+If the working tree is dirty (`git status --porcelain` non-empty), surface the dirty paths and ask the user to commit/stash before promotion. Don't bundle unrelated changes into journal commits.
+
+## Phase 1 — Filesystem inbox drain
+
+### 1. Enumerate `_incoming/`
+
+```sh
+ls _incoming/ 2>/dev/null
+```
+
+Filter to filenames matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+\.md$` and exclude `README.md` (tracked separately). Capture the matching list.
+
+If empty, surface `(no filesystem drafts pending)` and skip to Phase 2.
+
+### 2. For each draft, in deterministic order
+
+For each `<filename>` in the sorted list:
+
+1. **Conflict check**: if `journal/<filename>` already exists, skip. Append to the conflict-list as `<filename> — already in journal/, left in _incoming/`. Continue with the next draft.
+2. `git mv _incoming/<filename> journal/<filename>` — preserves the filename exactly.
+3. Stage with `git add journal/<filename>` (already staged by `git mv`, but explicit is safer for the followup commit).
+4. Derive the commit message slug: strip the leading `<YYYY-MM-DD>-` from `<filename>` and the trailing `.md`. The remainder is `<source-repo-slug>-<topic-slug>`.
+5. Commit each draft separately:
+
+   ```sh
+   git commit -m "journal: <YYYY-MM-DD> <source-repo-slug>-<topic-slug>"
+   ```
+
+   Per-draft commits keep the audit trail clean and let any single entry be reverted without touching others.
+
+## Phase 2 — Issue inbox drain
+
+### 1. Find labeled Issues
+
+```sh
+gh issue list --repo pmgledhill102/paul-context \
+    --label journal-draft --state open --limit 100 \
+    --json number,title,body,createdAt
+```
+
+If the `gh` CLI is unavailable, fall back to `mcp__github__list_issues` with `labels=["journal-draft"]` and `state=OPEN`.
+
+If empty, skip to Phase 3.
+
+### 2. For each Issue
+
+For each Issue, in `createdAt` order (oldest first):
+
+1. **Strip prefix**: the title shape is `journal: <YYYY-MM-DD>-<source-repo-slug>-<topic-slug>` (no `.md`). Strip the literal `journal:` prefix (with trailing space). The remainder + `.md` is `<filename>`.
+2. **Validate filename**: must match `^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+\.md$`. If not, skip with `Issue #N — title doesn't match journal-draft shape, left open` in the conflict-list. Don't try to coerce.
+3. **Conflict check**: if `journal/<filename>` already exists, skip with `Issue #N — journal/<filename> already exists, left open` in the conflict-list. Don't close.
+4. **Write body**: write the Issue body **verbatim** to `journal/<filename>`. The body IS the journal markdown — no transformation, no front-matter strip. Use the `Write` tool.
+5. **Stage**: `git add journal/<filename>`.
+6. **Commit**: `git commit -m "journal: <YYYY-MM-DD> <source-repo-slug>-<topic-slug>"` — date from `<filename>` (already correct), slug from filename per Phase 1.
+7. **Capture** Issue `#N` for the close step in Phase 4.
+
+Don't close any Issues yet. Closing happens **after** the push so a failed push doesn't strand drained drafts.
+
+## Phase 3 — Push
+
+If nothing was committed (Phase 1 + Phase 2 both produced zero new commits):
+
+- Surface `(nothing to push)` and skip to Phase 4.
+
+Otherwise:
+
+```sh
+git push origin main
+```
+
+If push fails (rejected, network, hook):
+
+- Surface the error verbatim.
+- **Do not** close any Issues. Drafts stay committed locally; the next run will see `journal/<filename>` already exists for those entries and skip them as conflicts (until the user manually resolves by `git push`-ing). The Issues remain open as the source of truth.
+- Stop. Don't proceed to Phase 4's close step.
+
+If push succeeds, proceed to Phase 4.
+
+## Phase 4 — Close drained Issues
+
+For each Issue captured in Phase 2:
+
+1. Add a back-link comment via `mcp__github__add_issue_comment`:
+
+   ```text
+   Promoted to paul-context/journal/<filename> (commit <short-sha>). Closing.
+   ```
+
+   (Capture the commit sha from `git rev-parse HEAD~<N+offset>` or by walking the recent log — straightforward when each draft is its own commit.)
+
+2. Close the Issue via `mcp__github__issue_write` with `method=update`, `state=closed`, `state_reason=completed`.
+
+If a comment or close fails, surface the failure and continue with the rest. The bead has already been promoted (the journal entry is live on `main`), so a missed close is a recoverable bookkeeping issue — re-running `/promote-journal-inbox` will re-enumerate the still-open Issues, find the journal entries already exist, surface them as conflicts, and the user can close manually.
+
+## Phase 5 — Summary
+
+Print a tight wrap-up:
+
+```text
+/promote-journal-inbox complete.
+
+  Filesystem drafts drained: <N>
+  Issue drafts drained:      <N>
+  Conflicts (skipped):       <N>
+<for each conflict>:
+    - <filename or Issue ref> — <reason>
+
+  Pushed: <yes/no/n/a>
+  Closed Issues: <count> — <list of #N or "(none)">
+```
+
+Surface the conflict list explicitly so it's obvious what didn't move and why.
+
+## Guardrails
+
+- **Never overwrite** an existing `journal/<file>.md`. Skip + surface. Manual resolution lives with the user.
+- **Per-draft commits**, single batched push. Each entry is its own commit — clean audit trail, easy revert. The single push at end keeps remote round-trips down and makes the close-Issues precondition simple.
+- **Close-Issues happens AFTER push.** If push fails, drafts stay committed locally but upstream Issues remain open — the next run handles the recovery cleanly via the conflict path.
+- **No retries on network failures.** Surface and stop. The user drives the retry.
+- **No body transformation on Issue drafts.** What the Issue body says is what lands in `journal/`. Don't try to fix typos, normalise headings, or strip metadata — that's manual editing, not promotion.
+- **Don't `cd` away from `paul-context`** during the run. Every git operation should target the same working tree the pre-flight validated.

--- a/home/commands/retrospective.md
+++ b/home/commands/retrospective.md
@@ -1,4 +1,4 @@
-Run a retrospective on this session: write a per-session journal entry to `paul-context/journal/`, route actionable findings into beads (current repo) or GitHub Issues (cross-repo), and capture durable lessons as memories. Do **not** append to `~/.claude/retros.md` — that file is retired (see `paul-context/decisions/2026-05-03-beads-per-repo-issues-as-inbox.md`).
+Run a retrospective on this session: draft a per-session journal entry into `paul-context/_incoming/` (or as a `journal-draft`-labeled Issue against `pmgledhill102/paul-context` when the local clone isn't available), route actionable findings into beads (current repo) or GitHub Issues (cross-repo), and capture durable lessons as memories. Do **not** append to `~/.claude/retros.md` — that file is retired (see `paul-context/decisions/2026-05-03-beads-per-repo-issues-as-inbox.md`). Do **not** commit or push to `paul-context` from this skill — promotion lives in `/promote-journal-inbox`, run from `~/dev/paul-context/` (see `paul-context/decisions/2026-05-05-journal-inbox-promotion.md`).
 
 ## Steps
 
@@ -73,7 +73,7 @@ For each finding, decide what kind of artifact it should produce:
 
 | Kind | When to use | How to produce |
 | --- | --- | --- |
-| **Journal entry** | Always (unless the session was uneventful — then skip and stop). Captures the narrative thread, Continue items, and Observations that don't fit into actionable artifacts | `Write` to `~/dev/paul-context/journal/<YYYY-MM-DD>-<short-slug>.md`. Then `git -C ~/dev/paul-context add + commit + push origin main`. Tight format: H1 title, project/duration metadata, Continue / Stop / Created / Observations sections, ~30-50 lines |
+| **Journal entry** | Always (unless the session was uneventful — then skip and stop). Captures the narrative thread, Continue items, and Observations that don't fit into actionable artifacts | Draft via the inbox/promote pattern. **Filesystem path** (preferred when `~/dev/paul-context/_incoming/` is writeable): `Write` to `~/dev/paul-context/_incoming/<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md` — **no git ops against `paul-context`**. **GitHub Issue fallback** (sandbox / remote VM / no local clone): `gh issue create --repo pmgledhill102/paul-context --label journal-draft --title="journal: <filename-without-.md>" --body-file=/tmp/<filename>`. Tight format: H1 title, project/duration metadata, Continue / Stop / Created / Observations sections, ~30-50 lines. Promoted into `paul-context/journal/` later by `/promote-journal-inbox` |
 | **Same-repo bead** | Action whose subject is the **current cwd's repo** | `bd create --title=... --type=<task/bug/feature> --priority=N` (priority 0-4; P2 is "do this soon", P3 is "next time we touch this", P4 is "backlog"). **Body MUST include**: "From retro: paul-context/journal/<file>.md" |
 | **Cross-repo Issue** | Action whose subject is a *different* personal repo from cwd | `gh issue create --repo pmgledhill102/<target> --title=... --body=...` — picked up by `/start-session` there via `/bd-import-github-issues`. **Body MUST include** the journal cross-reference. **DO NOT** `cd` to the target repo and run `bd create` there, even if you have it cloned locally — see "No cd-shortcut" below |
 | **paul-context Issue** | Cross-cutting or no-clear-home findings | `gh issue create --repo pmgledhill102/paul-context --title=... --body=...`. **Body MUST include** the journal cross-reference |
@@ -126,11 +126,22 @@ Wait for explicit confirmation. Don't proceed on ambiguous input.
 **Order matters**: write the journal **first** so subsequent beads/issues can reference its path. Then create everything else.
 
 1. **journal** (always first):
-   - `Write` `~/dev/paul-context/journal/<YYYY-MM-DD>-<slug>.md` with the format under "Journal entry format" below.
-   - `git -C ~/dev/paul-context add journal/<file>.md`
-   - `git -C ~/dev/paul-context commit -m "journal: <YYYY-MM-DD> <slug>"` (paul-context has no branch protection — direct commit to main is the convention)
-   - `git -C ~/dev/paul-context push origin main`
-   - Capture the relative path `paul-context/journal/<file>.md` for cross-references.
+   - **Derive the filename.** `<source-repo-slug>` = sanitised basename of `git remote get-url origin` from the current cwd (lowercase, `[a-z0-9-]+`). If no git remote, use `basename "$PWD"`. `<topic-slug>` = kebab-cased session summary, ≤5 words. `<filename>` = `<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md`.
+   - **Resolve same-project same-day collisions** at write-time: if the target already exists, append `-2`, `-3`, … before `.md` until unique. Filesystem path checks `~/dev/paul-context/_incoming/<filename>`; Issue path checks for an open Issue with the same title (rare in practice — same project, same day, same topic — but the suffix prevents silent merge of two distinct retros).
+   - **Pick the inbox path:**
+     - **Filesystem inbox** (preferred): if `[ -d ~/dev/paul-context/_incoming ] && [ -w ~/dev/paul-context/_incoming ]`, `Write` the journal markdown to `~/dev/paul-context/_incoming/<filename>`. **No git operations against `paul-context`.**
+     - **GitHub Issue fallback** (sandbox / remote VM / no local clone): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Write(/tmp/**)` is auto-allowed), then file as a labeled Issue:
+
+       ```sh
+       gh issue create --repo pmgledhill102/paul-context \
+           --label journal-draft \
+           --title "journal: <filename-without-.md>" \
+           --body-file /tmp/<filename>
+       ```
+
+       The `journal-draft` label and the `journal:` (with trailing space) title prefix are how `/promote-journal-inbox` finds the draft. Promotion infers the eventual filename by stripping `journal:` (with trailing space) from the Issue title and appending `.md`, so the filename is stable from draft → committed.
+     - **Both unreachable** (rare — offline AND no local clone): print the full draft to the session log with clear `===BEGIN JOURNAL===` / `===END JOURNAL===` delimiters and stop. Don't silently discard content. Tell the user to save it manually.
+   - Capture `paul-context/journal/<filename>` (the eventual post-promotion path) for cross-references in subsequent beads/issues. The path is stable across both inbox paths because both preserve `<filename>` exactly.
 2. **memory**: Write the memory file with proper frontmatter (`name`, `description`, `type` of `user|feedback|project|reference`), then Edit `MEMORY.md` to add a one-line index entry. Follow the conventions in the parent CLAUDE.md auto-memory section.
 3. **bead** (same-repo): `bd create --title="..." --description="..." --type=... --priority=...` — run from the **current cwd**. Description **MUST** include `From retro: paul-context/journal/<file>.md` near the top. Capture the new ID for the summary.
 4. **issue** (cross-repo): `gh issue create --repo pmgledhill102/<repo> --title="..." --body="..."` — DO NOT `cd` into the target repo for `bd create` (see step 3a). Body **MUST** include `From retro: paul-context/journal/<file>.md`. Capture the URL.
@@ -177,7 +188,7 @@ Print a compact wrap-up:
 ```text
 Retrospective complete.
 
-  Journal:                    paul-context/journal/2026-05-03-foo.md (pushed)
+  Journal:                    paul-context/journal/2026-05-03-agentic-coding-config-foo.md (drafted to _incoming/; pending /promote-journal-inbox)
   Beads created (here):       3 — paul-context-abc, paul-context-def, paul-context-ghi
   Issues raised cross-repo:   2 — github.com/.../issues/14, github.com/.../issues/15
   Memories saved:             1 — feedback_xyz.md
@@ -202,13 +213,13 @@ Next /start-session in the cross-repo'd repos will sweep the new Issues into bea
 
 ## What changed from the previous versions
 
-This command used to append a markdown entry to `~/.claude/retros.md` (the original flow), then was rewritten to output beads/Issues only without any journal (rev 1 of the new flow), then revised to include a per-session journal in `paul-context` (current). A later revision (2026-05-06) added the **Shell-friction patterns** dimension to Section 2 so each retro proactively surfaces command-shape friction (`$(cat …)`, heredocs, inline JSON) and proposes verified file-flag alternatives. The final shape:
+This command used to append a markdown entry to `~/.claude/retros.md` (the original flow), then was rewritten to output beads/Issues only without any journal (rev 1 of the new flow), then revised to include a per-session journal in `paul-context` (current). A later revision (2026-05-06) added the **Shell-friction patterns** dimension to Section 2 so each retro proactively surfaces command-shape friction (`$(cat …)`, heredocs, inline JSON) and proposes verified file-flag alternatives. A subsequent revision (2026-05-06) replaced the direct-write-to-`journal/` flow with an **inbox/promote** pattern: drafts land in `paul-context/_incoming/` (or as a `journal-draft`-labeled Issue when the local clone isn't available), and `/promote-journal-inbox` (run from `~/dev/paul-context/`) drains both inboxes into `journal/`. Filename convention gained a `<source-repo-slug>` prefix so cross-project drafts can't clobber each other. The skill no longer performs git operations against `paul-context` from arbitrary projects — see `paul-context/decisions/2026-05-05-journal-inbox-promotion.md` for the rationale. The final shape:
 
-- **Sandbox-agent reachable**: beads + GitHub Issues are network-reachable, and `paul-context/journal/` is a private git repo accessible via `gh` from anywhere.
+- **Sandbox-agent reachable**: beads + GitHub Issues are network-reachable, and journal drafts fall back to a `journal-draft`-labeled Issue against `paul-context` when the local `_incoming/` directory isn't present. Sandbox runs surface as Issues; local runs surface as filesystem drafts; promotion is invisible to the eventual journal entry.
 - **Per-entry, not single-master**: each retro produces a dated, slugged file in `paul-context/journal/`. The original `retros.md` decayed because it was one file containing everything. Per-entry files survive long-term scrolling.
 - **Privacy gives candour**: `paul-context` is private, so retros can be honest ("got stuck", "almost shipped a broken design") without self-censorship that public agentic-coding-config would force.
 - **Different layers**: agentic-coding-config is *what I configure*; the journal is *how I reflected on using it*. Reflections live with personal context, not tool config.
 - **Cross-repo actions land in the right tracker**: an action surfaced during a `dotfiles` retro that affects `agentic-coding-config` becomes an Issue/bead *there*, with a backlink to the journal entry in `paul-context`.
-- **paul-context has no branch protection**: direct commit + push to `main`. No PR overhead per retro.
+- **paul-context has no branch protection**: `/promote-journal-inbox` commits + pushes to `main` directly. No PR overhead per retro.
 
 See `paul-context/decisions/2026-05-03-beads-per-repo-issues-as-inbox.md` for the work-tracking architecture, and `paul-context/decisions/2026-05-03-personal-infra-public-private-split.md` for the wider three-repo layout this fits into.

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -136,6 +136,26 @@ From gather section `gh_unmigrated`. The first line is `count=<N>`; remaining li
   - **yes** → invoke `/bd-import-github-issues` directly. That command does its own `bd dolt pull` (Step 0) and `bd dolt push` (Step 8); a second pull right after step 4 is a clean no-op, and the push at the end is what we want anyway.
   - **no / empty / cancel** → carry on. Surface the count in the session brief under "Needs attention" so it's visible at a glance.
 
+### 8.5. Paul-context inbox surface (Tier 2 — prompt, paul-context only)
+
+**Only fires when the current working tree is `paul-context`** (`basename "$(git rev-parse --show-toplevel)" = "paul-context"`). Otherwise skip silently. This is a runtime filesystem check, not part of the gather output — `/start-session` runs in many repos and a generic gather section would always be empty for the rest.
+
+```sh
+ls -1 _incoming/ 2>/dev/null
+```
+
+Filter the listing to entries matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+\.md$` (excludes `README.md` and any non-conforming files). Count the matches.
+
+- **0 matches**: skip silently.
+- **>= 1 match**: print the count and (up to first 5) filenames, then prompt:
+
+  > `<N>` journal draft(s) pending in `_incoming/`. Run `/promote-journal-inbox` now? (y/n)
+
+  - **yes** → invoke `/promote-journal-inbox` directly. That command's pre-flight verifies cwd, then drains both filesystem `_incoming/` and `journal-draft`-labeled Issues from `pmgledhill102/paul-context`, commits each draft separately, single-pushes, and closes the drained Issues. Carry the result into the session brief.
+  - **no / empty / cancel** → carry on. Surface the count in the session brief under "Needs attention" so it's visible at a glance.
+
+Note: this surface only counts the **filesystem** half of the inbox. The Issue-side half (sandbox-fallback drafts) isn't enumerated here — surfacing it would require an extra `gh issue list --label journal-draft` call, and the filesystem count is the dominant signal because the local machine is where the user lives. `/promote-journal-inbox` itself drains both inboxes when invoked, so user action is consistent regardless of which path filed the draft.
+
 ### 9. Session brief (Tier 1 — final summary)
 
 Always print, even when everything is clean. This is the user-facing payoff — one screenful, scannable, no surprises. Format:
@@ -160,6 +180,7 @@ Ready to pick up next:
 
 Needs attention:
   • <unmigrated GH issues: N>      (omit when 0 / n/a)
+  • <pending journal drafts: N>    (omit when 0 / not paul-context)
   • <main CI red on workflow X>    (omit when green)
   • <feature branch behind main by N>          (omit when on default, even, or auto-switched)
   • <branch upstream gone but tree dirty>      (omit unless that case fires)

--- a/home/settings.json
+++ b/home/settings.json
@@ -306,7 +306,8 @@
       "mcp__google-developer-knowledge__search_documents",
       "Read(~/.claude/retros.md)",
       "Read(~/.claude/settings.json)",
-      "Write(/tmp/**)"
+      "Write(/tmp/**)",
+      "Write(~/dev/paul-context/_incoming/**)"
     ]
   },
   "hooks": {

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -569,6 +569,18 @@ that otherwise discourages the structured-body pattern.
   `--body-file` or `$(cat ...)`. Restrict scope further to
   `Write(/tmp/claude-*)` (with a naming-convention discipline) if the
   broad rule ever feels uncomfortable.
+- `Write(~/dev/paul-context/_incoming/**)` — journal-draft inbox for
+  the cross-repo retrospective skill. Drafts land here and are later
+  promoted into `paul-context/journal/` by `/promote-journal-inbox`
+  (run from `~/dev/paul-context/`). The directory is `.gitignored` in
+  the `paul-context` repo, so anything written here is local-only
+  until promotion — content can't pollute `paul-context`'s git
+  history regardless of what gets written. This single user-level
+  rule replaces what would otherwise be N per-project
+  `Write(~/dev/paul-context/journal/**)` grants plus git-on-paul-context
+  permissions in every project that runs `/end-session`. See
+  `paul-context/decisions/2026-05-05-journal-inbox-promotion.md` for
+  the full rationale.
 
 ## Never allow
 


### PR DESCRIPTION
## Summary

PR 2 of 2 — the agentic-coding-config side of the inbox/promote pattern landed in pmgledhill102/paul-context#3. Removes cross-repo git ops from the `retrospective` skill, adds a `/promote-journal-inbox` command, surfaces pending drafts in `/start-session` (paul-context only), filters `journal-draft` Issues from import flows, and grants a single user-level write rule.

The skill now writes drafts to `~/dev/paul-context/_incoming/` when the local clone is available, or files a `journal-draft`-labeled GitHub Issue when it isn't (sandbox / remote VM). `/promote-journal-inbox` drains both inboxes into `journal/`, commits each draft separately, single-pushes, then closes the drained Issues.

## Files

- **`home/commands/retrospective.md`** — flip Step 6.1. New filename convention `YYYY-MM-DD-<source-repo-slug>-<topic-slug>.md`. Filesystem path preferred; GitHub Issue fallback when `_incoming/` isn't writeable; both-unreachable case prints draft to session log instead of silently discarding. Table row, summary line, and "What changed" log all updated. **No git operations against `paul-context` from this skill anymore.**
- **`home/commands/promote-journal-inbox.md`** — new slash command. Pre-flight verifies cwd is `paul-context` and the working tree is clean. Phase 1 drains filesystem `_incoming/` via `git mv` + per-draft commits. Phase 2 drains `journal-draft`-labeled Issues into `journal/` (body verbatim, no transformation), with per-Issue commits. Phase 3 single-push. Phase 4 closes drained Issues with back-link comments. Conflicts skip + surface, never overwrite.
- **`home/commands/start-session.md`** — new Step 8.5 (paul-context only): count pending `_incoming/` drafts, prompt to run `/promote-journal-inbox` (Tier 2). New `pending journal drafts: N` line in the brief's "Needs attention" section.
- **`home/commands/bd-import-github-issues.md`** — filter `journal-draft`-labeled Issues out of import candidates. Without this, sandbox-fallback drafts would get mis-imported as beads.
- **`home/bin/start-session-gather-state`** — same filter for `gh_unmigrated`'s jq query, so `journal-draft` Issues don't inflate the unmigrated count or trigger the import prompt.
- **`home/settings.json`** + **`home/settings.json.md`** — add `Write(~/dev/paul-context/_incoming/**)` (single user-level rule) with rationale.

## Sandbox / no-local-clone path

The fallback design from PR pmgledhill102/paul-context#3:

```sh
gh issue create --repo pmgledhill102/paul-context \
    --label journal-draft \
    --title "journal: <YYYY-MM-DD>-<source-repo-slug>-<topic-slug>" \
    --body-file /tmp/<filename>
```

Title shape is the bare filename (without `.md`). `/promote-journal-inbox` strips `journal:` (with trailing space) and appends `.md` to recover the filename; the Issue body is written verbatim to `journal/<filename>`.

Auth surface: `Bash(gh issue create --repo pmgledhill102/*)` is already auto-approved at the user level (landed in PR #19), so no new permissions for the fallback path.

## Why filter `journal-draft` from import flows in this PR

Once the sandbox fallback is live, `journal-draft` Issues will appear at `pmgledhill102/paul-context`. If `/start-session` runs in `paul-context` afterward without this filter, the gather counts them as "unmigrated" and prompts the user to run `/bd-import-github-issues` — which would then try to import the journal content as a bead. That mis-categorises narrative content as actionable work and pollutes the bead workspace. Filtering at both surfaces (gather + import) is defence-in-depth.

## Test plan

- [x] `markdownlint-cli2` passes on all 5 changed/new markdown files (verified locally — 0 errors)
- [x] `shellcheck home/bin/start-session-gather-state` passes (verified locally — clean)
- [x] `jq empty home/settings.json` passes (verified locally — valid JSON)
- [x] jq filter for `journal-draft` exclusion: smoke-tested with 5 fixture issues (normal / journal-draft-labeled / migrated-marker / other-label / both); only `normal` and `other-label` survive (verified locally)
- [ ] After `chezmoi apply`, run `/end-session` in any project → `retrospective` writes to `~/dev/paul-context/_incoming/` without prompting (no `Write(~/dev/paul-context/journal/**)` prompt; no `git -C ~/dev/paul-context …` prompt)
- [ ] After `chezmoi apply`, run `/start-session` in `~/dev/paul-context` with one or more drafts in `_incoming/` → surfaces the count + offers `/promote-journal-inbox`
- [ ] Run `/promote-journal-inbox` from `~/dev/paul-context/` with both filesystem and Issue inboxes populated → both drain, single push, Issues close with back-links
- [ ] Conflict path: pre-create a `journal/<filename>` matching a draft, run promotion → draft stays in `_incoming/`, summary surfaces the conflict
- [ ] Sandbox simulation: temporarily rename `~/dev/paul-context` and run `/end-session` → skill files Issue with `journal-draft` label instead of writing filesystem
- [ ] Verify `/start-session` in `paul-context` with a `journal-draft` Issue does NOT count it as unmigrated and does NOT prompt for `/bd-import-github-issues` on it

Closes agentic-coding-config-6hb
Refs pmgledhill102/paul-context#3