### PR TITLE
perf(start-session): pre-summarise bd_ready, bd_in_progress, main_ci URL

### DIFF
--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -114,16 +114,23 @@ run_sh main_ci '
     # Parse to most-recent run per workflow on $DEFAULT_BRANCH.
     # Output:
     #   workflows=<N>
-    #   <name>=<conclusion-or-status>@<short-sha>
-    # On clean-and-green sessions this is 1-3 lines instead of a 10-element JSON dump.
+    #   <name>=<conclusion-or-status>@<short-sha>           (success / in_progress / queued)
+    #   <name>=<conclusion>@<short-sha> <url>                (failure / cancelled / timed_out)
+    # The URL on failing runs lets the brief link the failing job inline; on
+    # clean-and-green sessions this is still 1-3 lines instead of a JSON dump.
     gh run list --branch "$DEFAULT_BRANCH" --limit 20 \
-        --json status,conclusion,name,headSha,createdAt \
+        --json status,conclusion,name,headSha,createdAt,url \
       | jq -r '\''
           group_by(.name)
           | map(sort_by(.createdAt) | last)
           | sort_by(.name) as $w
           | "workflows=\($w | length)",
-            ($w[] | "\(.name)=\(.conclusion // .status)@\(.headSha[0:7])")
+            ($w[] | (
+                if (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")
+                then "\(.name)=\(.conclusion)@\(.headSha[0:7]) \(.url)"
+                else "\(.name)=\(.conclusion // .status)@\(.headSha[0:7])"
+                end
+            ))
         '\''
 '
 
@@ -159,8 +166,35 @@ run_sh gh_unmigrated '
 
 if [ -f .beads/metadata.json ]; then
     run_section bd_remote bd dolt remote list
-    run_section bd_ready bd ready
-    run_section bd_in_progress bd list --status=in_progress
+    # shellcheck disable=SC2016
+    run_sh bd_ready '
+        # Top-5 ready issues, pre-formatted for the brief. Strip the legend,
+        # totals, and tree icons; emit one pipe-separated row per issue:
+        #   <id>|P<n>|<title>
+        # Empty output = no ready work. /start-session uses these rows directly
+        # in the brief without further parsing.
+        bd ready --limit 5 2>/dev/null \
+          | awk '\''NF>=5 && $4 ~ /^P[0-9]/ {
+              id=$2; pri=$4;
+              $1=$2=$3=$4="";
+              sub(/^ +/, "", $0);
+              print id "|" pri "|" $0
+            }'\''
+    '
+    # shellcheck disable=SC2016
+    run_sh bd_in_progress '
+        # In-progress beads, pre-formatted for the brief. Same pipe-separated
+        # row shape as bd_ready:
+        #   <id>|P<n>|<title>
+        # No limit (usually 0-3 items). Empty output = nothing in flight.
+        bd list --status=in_progress 2>/dev/null \
+          | awk '\''NF>=5 && $4 ~ /^P[0-9]/ {
+              id=$2; pri=$4;
+              $1=$2=$3=$4="";
+              sub(/^ +/, "", $0);
+              print id "|" pri "|" $0
+            }'\''
+    '
     # shellcheck disable=SC2016
     run_sh bd_inprogress_delivered '
         # For each in_progress bead, find any merged commit on $DEFAULT_BRANCH

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -38,11 +38,11 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | --- | --- | --- |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 9 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
-| `main_ci` | 7 | Content `gh-unavailable` / `jq-unavailable` = silent skip. Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). Non-zero with other content = real error. |
+| `main_ci` | 7 | Content `gh-unavailable` / `jq-unavailable` = silent skip. Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
 | `gh_unmigrated` | 8 | Content `gh-unavailable` or `jq-unavailable` = silent skip. First line is `count=<N>`; remaining lines are `#<n> <title>` per unmigrated issue. |
 | `bd_remote` | 4 | Section absent if no beads workspace. Empty content = no remote configured (single-machine setup). |
-| `bd_ready` | 9 | Section absent if no beads workspace. Plain `bd ready` output — pick the top 5 entries for the brief. |
-| `bd_in_progress` | 9 | Section absent if no beads workspace. Mirrors `/end-session`'s `bd_progress` section. |
+| `bd_ready` | 9 | Section absent if no beads workspace. Empty content = no ready work. Otherwise up to 5 pipe-separated rows: `<id>\|P<n>\|<title>`. Already pre-summarised — use rows directly in the brief without further parsing. |
+| `bd_in_progress` | 9 | Section absent if no beads workspace. Empty content = nothing in flight. Otherwise pipe-separated rows: `<id>\|P<n>\|<title>` (no limit; usually 0-3). Same row shape as `bd_ready`. |
 | `bd_inprogress_delivered` | 5 | Section absent if no beads workspace. Empty content = nothing to auto-close. Each line is `<id>\|<short-sha>\|<subject>` for an in_progress bead whose ID was referenced by a merged commit on `<default>` (`Closes <id>` / `Fixes <id>`). |
 
 Rules for interpreting exit codes:
@@ -115,9 +115,9 @@ False-positive risk is low: a stray `Closes <bead-id>` reference in a non-closin
 
 ### 7. `main` CI status (Tier 1 — surface)
 
-From gather section `main_ci`. The script has already deduplicated to one most-recent run per workflow on `<default>` and emitted compact lines: `<workflow-name>=<conclusion-or-status>@<short-sha>`.
+From gather section `main_ci`. The script has already deduplicated to one most-recent run per workflow on `<default>` and emitted compact lines: `<workflow-name>=<conclusion-or-status>@<short-sha>`. Failing runs include the URL on the same line: `<workflow-name>=<conclusion>@<short-sha> <url>`.
 
-- **Any line where `<conclusion-or-status>` is `failure` / `cancelled` / `timed_out`**: flag in the session brief with workflow name + short-sha. A red default branch is the loudest "not clean" signal — call it out before the user starts new work.
+- **Any line where `<conclusion-or-status>` is `failure` / `cancelled` / `timed_out`**: flag in the session brief with workflow name + short-sha + run URL (the URL is on the same line — surface it inline so the user can click straight through). A red default branch is the loudest "not clean" signal — call it out before the user starts new work.
 - **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
 - **All `success`**: silent (the brief reports "green").
 
@@ -190,8 +190,8 @@ Needs attention:
 Rules:
 
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
-- "Ready to pick up next" is sourced from gather section `bd_ready`. Take the first 5 rows of `bd ready`'s output. `bd ready` already filters to issues whose blockers are all closed and sorts sensibly — preserve its order.
-- "In progress" is sourced from gather section `bd_in_progress`. No cap (usually 0–3 items). Note: any beads auto-closed in Step 5 won't appear here — they're already closed by the time the brief renders.
+- "Ready to pick up next" is sourced from gather section `bd_ready`. Each row is already pipe-separated `<id>|P<n>|<title>` and pre-truncated to 5 — split on `|` and emit. `bd ready` already filters to issues whose blockers are all closed and sorts sensibly; preserve the gather order.
+- "In progress" is sourced from gather section `bd_in_progress`. Same `<id>|P<n>|<title>` row shape; no cap (usually 0–3 items). Note: any beads auto-closed in Step 5 won't appear here — they're already closed by the time the brief renders.
 - "Auto-closed (delivered)" is sourced from the IDs Step 5 closed. Omit the entire section when Step 5 closed nothing.
 - If the repo has no beads workspace, drop both Beads sections silently (the brief still shows git/CI/GH lines).
 - Truncate any title to ~78 columns to keep rows on one line.


### PR DESCRIPTION
## Summary

Three more compactions to `home/bin/start-session-gather-state`, on top of the earlier `main_ci` / `fetch` / `bd_preflight` pass:

1. **`bd_ready`** — pre-parsed to up to 5 pipe-separated rows: `<id>|P<n>|<title>`. Drops the legend, totals, separator, and tree icons. `/start-session` can split on `|` and emit straight to the brief.
2. **`bd_in_progress`** — same `<id>|P<n>|<title>` shape; no limit (typically 0-3 rows). Identical consumer code path.
3. **`main_ci`** — `failure` / `cancelled` / `timed_out` lines now end with the run URL (`<workflow>=<conclusion>@<short-sha> <url>`), so `/start-session` Step 7 can surface the failing job link inline. Successful and in-progress lines unchanged.

`home/commands/start-session.md` updated to match: section table notes the new shapes; Step 7 surfaces the URL; Step 9 brief rules document the pipe-separated row format.

## Why

n8l (line 1107) — the gather script's raw `bd ready` and `bd list --status=in_progress` outputs included tree icons, a separator line, totals, and a 5-line legend per section, all of which the brief discards. Pre-summarising in the gather instead of in the consumer cuts model-visible context per `/start-session` invocation. The `main_ci` URL inclusion solves the n8l `/end-session` Step 3 sibling problem at the start-session site (failing CI URL surfaced inline instead of requiring a second tool call).

Partial close on `agentic-coding-config-n8l` — sub-item: `/start-session` gather-script tightening. Other n8l sub-items remain open.

## Test plan

- [x] `bash -n` + `shellcheck` clean (verified locally — exit 0).
- [x] `markdownlint-cli2 home/commands/start-session.md` clean (0 errors).
- [x] Smoke-run gather script in this repo: `bd_ready` emits 5 pipe-rows, `bd_in_progress` emits 1 pipe-row, `main_ci` emits `workflows=1` + `CI=success@<sha>` (no URL on the success path, as designed).
- [ ] Manual end-to-end: next `/start-session` run renders the brief from the new shapes without further parsing changes.
- [ ] Validate failure-path `main_ci` output the next time a workflow fails on main (URL should appear after the short-sha on the failing line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
