### PR TITLE
feat(end-session): auto-close in_progress beads delivered this session

### DIFF
--- a/home/bin/end-session-gather-state
+++ b/home/bin/end-session-gather-state
@@ -94,6 +94,29 @@ run_sh open_prs '
 
 if [ -f .beads/metadata.json ]; then
     run_section bd_progress bd list --status=in_progress
+    # shellcheck disable=SC2016
+    run_sh bd_inprogress_delivered '
+        # For each in_progress bead, find any merged commit on main whose
+        # message contains "Closes <id>" or "Fixes <id>" (case-insensitive)
+        # — those signal the bead was delivered but never closed. Output:
+        #   <id>|<short-sha>|<subject>
+        # one per line. Empty output is fine (nothing to auto-close).
+        # Mirrors the same section in start-session-gather-state.
+        bd list --status=in_progress 2>/dev/null \
+            | grep -oE "[a-z][a-z0-9-]+-[a-z0-9]{3}" \
+            | sort -u \
+            | while read -r id; do
+                sha=$(git log main \
+                    --grep="closes\s*${id}" \
+                    --grep="fixes\s*${id}" \
+                    -i -1 --format="%H" 2>/dev/null)
+                if [ -n "$sha" ]; then
+                    short=$(git rev-parse --short "$sha" 2>/dev/null)
+                    subject=$(git log -1 --format="%s" "$sha" 2>/dev/null)
+                    echo "${id}|${short}|${subject}"
+                fi
+              done
+    '
 fi
 
 # shellcheck disable=SC2016
@@ -137,6 +160,6 @@ printf '===fetch (exit=%s)===\n' "$FETCH_EXIT"
 cat "$TMP/fetch.out"
 printf '\n'
 
-for s in local_state stashes worktrees merged_brs main_ci open_prs bd_progress stale_claude_files; do
+for s in local_state stashes worktrees merged_brs main_ci open_prs bd_progress bd_inprogress_delivered stale_claude_files; do
     [ -f "$TMP/$s.exit" ] && emit "$s"
 done

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -44,6 +44,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `main_ci` | 3 | Content `gh-unavailable` = silent skip. Non-zero with other content = real error. |
 | `open_prs` | 8 | Same skip convention as `main_ci`. |
 | `bd_progress` | 10 | Section absent if no beads workspace. All entries are `in_progress` by definition (that's the filter) — see step 10 for symbol-reading rules. |
+| `bd_inprogress_delivered` | 9.5 | Section absent if no beads workspace. Empty content = nothing to auto-close. Each line is `<id>\|<short-sha>\|<subject>` for an in_progress bead whose ID was referenced by a merged commit on `main` (`Closes <id>` / `Fixes <id>`). Mirrors `/start-session`'s section of the same name. |
 | `stale_claude_files` | 11 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
 Rules for interpreting exit codes:
@@ -135,9 +136,25 @@ Never auto-merge. List, link, move on.
 
 From gather section `stashes`. If non-empty, surface count + entries. Don't drop or apply anything.
 
+### 9.5. Auto-close delivered in_progress beads (Tier 1)
+
+From gather section `bd_inprogress_delivered` (absent if no beads workspace; empty if nothing matched). Each line is `<id>|<short-sha>|<subject>` — an `in_progress` bead whose ID was referenced by a merged commit on `main` with `Closes <id>` or `Fixes <id>` in the message.
+
+These are deliveries that landed in this session (or a recent prior one) but never had their bead closed. The PR was already reviewed and merged; closing the bead is bookkeeping, not a judgment call. Auto-close each one — no prompt:
+
+```sh
+bd close <id> --reason="Auto-closed by /end-session: shipped via <short-sha>"
+```
+
+Step 14 (`bd dolt push`) persists the closures. If the section is absent, empty, or nothing matched: skip silently. The Phase 1 summary shows a `Beads auto-closed (delivered)` line listing what was closed (omit when nothing was closed).
+
+This step duplicates `/start-session`'s step 5 logic so deliveries close at end-of-session rather than waiting for the next session start. Defense in depth: if the user shuts down without running `/start-session` next morning, the closure already lands. False-positive risk is low (a stray `Closes <bead-id>` in non-closing context); recovery is `bd reopen <id>`.
+
 ### 10. Beads in-progress check (Tier 3 — surface)
 
 From gather section `bd_progress` (absent if no beads workspace). The section is the output of `bd list --status=in_progress`, so **every entry is in_progress** — never report these as "blocked". Filter to issues claimed by the current user (assignee matches `git config user.email` or local username). Surface count + IDs/titles. User decides which to close — common forgetfulness pattern.
+
+**Note**: any beads auto-closed in step 9.5 won't appear here — they're already closed by the time this step runs. So this list is genuinely "still outstanding work", not "delivered but not bookkept".
 
 **Reading bd's symbols (don't conflate them):**
 
@@ -196,6 +213,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow name + run URL>>`
 - Open PRs needing action: `<count by category, or "none">`
 - Stashes outstanding: `<count, or "none">`
+- Beads auto-closed (delivered): `<list of ids, or "none">`
 - Beads in_progress (yours): `<count, or "none">`
 - Stale `~/.claude/` files: `<count, or "none" / "n/a (no chezmoi)">`
 - Other worktrees: `<count, or "none">`


### PR DESCRIPTION
## Summary

Mirrors `/start-session` step 5 into `/end-session`: detect in_progress beads whose IDs appear in `Closes <id>` / `Fixes <id>` trailers on merged `main` commits, and auto-close them.

- `home/bin/end-session-gather-state`: new `bd_inprogress_delivered` section emitting `<id>|<short-sha>|<subject>` per delivered bead. Logic mirrors `start-session-gather-state`'s same-name section.
- `home/commands/end-session.md`: new **Step 9.5** (Tier 1) auto-closes each delivered bead via `bd close --reason=...`. Step 14's existing `bd dolt push` persists the closures — no separate push needed. Step 10's "beads in_progress" note now states that auto-closed entries no longer appear, so the list shows genuinely outstanding work. Phase 1 summary adds a `Beads auto-closed (delivered)` line.

## Why

Defense in depth. `/start-session` step 5 only runs the next morning. If the user shuts down without re-opening Claude Code (or starts in a different repo), in_progress beads that were delivered in the just-merged session linger as stale `in_progress` until something sweeps them. Closing them at the end of the same session is the symmetric fix.

A side effect (asked for by the bead's "distinguish delivered from outstanding" sub-item): step 10's `bd_progress` list now genuinely is "still outstanding work" — the delivered ones have been closed already in 9.5, so no manual filtering is needed.

Partial close on `agentic-coding-config-n8l` (sub-item: `/end-session` auto-close beads with `Closes`-trailer; line 1103, and the closely-related Step 10 distinguish-delivered-from-outstanding sub-item; line 973). Earlier n8l sub-items shipped in PR #22 (squash-merged `gh` fallback) and PR #24 (`/start-session` gather-tighten).

## Test plan

- [x] `bash -n` + `shellcheck` clean (verified locally — exit 0).
- [x] `markdownlint-cli2 home/commands/end-session.md` clean (0 errors).
- [x] Smoke-run gather: `bd_inprogress_delivered` correctly emits `agentic-coding-config-6hb|9aaabb0|feat(retrospective): journal-draft inbox/promote pattern (no cross-repo git ops)` (matches the in-flight in_progress bead and its delivering commit).
- [ ] Manual end-to-end: run `/end-session` against a state with at least one in_progress bead whose ID was referenced by a merged commit on `main`; verify the bead is auto-closed and the summary line lists it.
- [ ] Negative case: in_progress bead with no matching commit on main is left untouched and shows up in step 10 as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
