### PR TITLE
feat(bd-modernize): pre-flight detect bare .beads/ and .claude/ blanket-ignore

### DIFF
--- a/home/commands/bd-modernize.md
+++ b/home/commands/bd-modernize.md
@@ -38,12 +38,14 @@ echo "===git status==="; git status --porcelain
 echo "===origin url==="; git remote get-url origin
 echo "===running dolt-server pid==="; [ -f .beads/dolt-server.pid ] && cat .beads/dolt-server.pid || echo "(none)"
 echo "===init.templatedir==="; td=$(git config --get init.templatedir); echo "templatedir=$td"; [ -n "$td" ] && ls "${td/#~/$HOME}/hooks/" 2>/dev/null | head -5
+echo "===root .gitignore blanket patterns==="; for pattern in .beads .claude; do grep -nE "^/?${pattern}/?\$" .gitignore 2>/dev/null && echo "WARN: bare ${pattern}/ pattern in .gitignore — would silently block 'git add ${pattern}/...' in Step 6"; done; true
 ```
 
 Interpret the results:
 
 - **`bd version` < 1.0**: stop, tell the user to upgrade (e.g. `brew upgrade beads`).
 - **`origin url` not on `github.com`**: Dolt git-remote feature won't work. Surface this; offer to skip the remote / push steps or stop entirely.
+- **Bare `.beads/` or `.claude/` blanket pattern detected** in root `.gitignore` (the WARN line above): STOP. The pattern silently blocks Step 6's `git add` — the commit goes through reporting nothing changed, the project stays on legacy state, and the failure is invisible (`paul-gledhill-dev` lost ~5 min to this exact trap). Show the offending line, propose replacing it with a JSONL-only ignore for `.beads/` (`.beads/issues.jsonl`) or removing it entirely for `.claude/`, and ask the user to fix `.gitignore` and re-run. Don't auto-edit — the bare pattern may have been added by another tool and removing it has wider implications.
 - **Compute `IS_LEGACY`** = `(.beads/metadata.json missing) OR (dolt_mode != "embedded") OR (.beads/dolt/ exists)`. This signal drives `.beads/config.yaml` preservation in Step 1 (legacy = wipe; modern = preserve).
 - **Compute `AT_TARGET`** = `dolt_mode == "embedded"` AND `bd dolt remote list` has a `git+...` or `https://github.com/...` remote matching origin AND JSONL tracked check returned exit 1 (untracked).
 - **If `AT_TARGET`**: skip to Step 6 (verification). Reports "already aligned" and exits in <30s. Done.
@@ -255,16 +257,14 @@ Use the `Edit` tool to append. If scripting it, ensure the file ends in a newlin
 
 ### 5f. Add `.beads/issues.jsonl` to project `.gitignore`
 
-Two parts — both against the **project root** `.gitignore` (not `.beads/.gitignore`, which `bd init` may regenerate):
+Pre-flight already verified the project root `.gitignore` has no bare `.beads/` or `.claude/` blanket pattern (those are stop conditions there — this step assumes they're absent).
 
-1. **Detect a bare `.beads/` pattern first.** If the file already has a line matching `.beads/?` or `/.beads/?` (no further path component), that pattern silently blocks `git add .beads/` and Step 6's commit fails with no obviously relevant error (`paul-gledhill-dev` lost ~5 min to this). Surface the offending line, propose replacing it with the JSONL-only pattern below, and ask the user whether to remove it. **Don't auto-remove** — the bare pattern may have been added by another tool and removing it has wider implications.
+Append the JSONL-only ignore to the **project root** `.gitignore` (not `.beads/.gitignore`, which `bd init` may regenerate). Idempotent — skip if already present:
 
-2. **Append the JSONL-only ignore** (idempotent — skip if already present):
-
-   ```gitignore
-   # Beads exports — source of truth is Dolt + refs/dolt/data on origin.
-   .beads/issues.jsonl
-   ```
+```gitignore
+# Beads exports — source of truth is Dolt + refs/dolt/data on origin.
+.beads/issues.jsonl
+```
 
 ### 5g. Untrack the JSONL (only if currently tracked)
 


### PR DESCRIPTION
## Summary

Move the bare blanket-pattern detection in root `.gitignore` from **Step 5f** (post-nuke) to **pre-flight** (pre-nuke), and extend it to cover `.claude/` as well as `.beads/`.

- Pre-flight gains one new `for pattern in .beads .claude; …` line that greps for bare blanket patterns (`.beads`, `.beads/`, `/.beads`, `/.beads/`, etc).
- "Interpret the results" gains a new STOP condition: detected → fail loudly, ask the user to fix the bare pattern (replace with JSONL-only for `.beads/`, or remove for `.claude/`) and re-run.
- Step 5f loses its inline detection (now redundant) and keeps only the JSONL-append responsibility.

## Why

A bare `.beads/` or `.claude/` blanket pattern silently swallows Step 6's `git add` — the commit reports nothing changed, the project stays on legacy state, and the failure is invisible. `paul-gledhill-dev` lost ~5 min to the `.beads/` variant. The `.claude/` variant has the identical shape: Step 5a's `git add .claude/settings.json` no-ops with no error if `.gitignore` has a bare `.claude/` pattern. Catching this **before** the nuke-and-pave runs gives the user the chance to fix `.gitignore` while the project is still in a known-good state, rather than discovering it after the destructive Step 3.

Detection is regex-narrow (`^/?<pattern>/?$`) so it doesn't false-trigger on `.beads/issues.jsonl`, `.claude/*`, or commented lines (verified locally with a fixture covering all four cases). Auto-edit is **not** offered — the bare pattern may have been added by another tool with wider implications.

Partial close on `agentic-coding-config-n8l` — sub-items: `/bd-modernize` Step 5f bare-`.beads/` pre-flight detect+remove (n8l line 80) and Step 5f bare-`.claude/` blanket-ignore detect (n8l line 22).

## Test plan

- [x] `markdownlint-cli2 home/commands/bd-modernize.md` clean (0 errors).
- [x] Regex test against fixture covering: `.beads/`, `/.beads`, `.claude` (all should trigger); `.beads/issues.jsonl`, `.claude/*`, `# .beads/...` (none should trigger). Verified locally.
- [ ] Manual end-to-end: run `/bd-modernize` against a project with `.beads/` bare in `.gitignore`; pre-flight stops with the STOP condition and the user is prompted to fix `.gitignore` before re-running.
- [ ] Negative case: project with `.beads/issues.jsonl` (correct JSONL-only ignore) and no `.claude/` blanket — pre-flight passes silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
