### PR TITLE
feat(session): auto-close open beads delivered via Closes/Fixes trailers

### DIFF
--- a/home/bin/end-session-gather-state
+++ b/home/bin/end-session-gather-state
@@ -96,13 +96,15 @@ if [ -f .beads/metadata.json ]; then
     run_section bd_progress bd list --status=in_progress
     # shellcheck disable=SC2016
     run_sh bd_inprogress_delivered '
-        # For each in_progress bead, find any merged commit on main whose
-        # message contains "Closes <id>" or "Fixes <id>" (case-insensitive)
-        # — those signal the bead was delivered but never closed. Output:
+        # For each open OR in_progress bead, find any merged commit on main
+        # whose message contains "Closes <id>" or "Fixes <id>" (case-insensitive)
+        # — those signal the bead was delivered but never closed. Open is
+        # included to catch beads that shipped via a Closes-trailer commit
+        # but were never claimed (so they stayed open). Output:
         #   <id>|<short-sha>|<subject>
         # one per line. Empty output is fine (nothing to auto-close).
         # Mirrors the same section in start-session-gather-state.
-        bd list --status=in_progress 2>/dev/null \
+        bd list --status=in_progress,open 2>/dev/null \
             | grep -oE "[a-z][a-z0-9-]+-[a-z0-9]{3}" \
             | sort -u \
             | while read -r id; do

--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -231,12 +231,15 @@ if [ -f .beads/metadata.json ]; then
     '
     # shellcheck disable=SC2016
     run_sh bd_inprogress_delivered '
-        # For each in_progress bead, find any merged commit on $DEFAULT_BRANCH
-        # whose message contains "Closes <id>" or "Fixes <id>" (case-insensitive)
-        # — those signal the bead was delivered but never closed. Output:
+        # For each open OR in_progress bead, find any merged commit on
+        # $DEFAULT_BRANCH whose message contains "Closes <id>" or
+        # "Fixes <id>" (case-insensitive) — those signal the bead was
+        # delivered but never closed. Open is included to catch beads that
+        # shipped via a Closes-trailer commit but were never claimed (so
+        # they stayed open). Output:
         #   <id>|<short-sha>|<subject>
         # one per line. Empty output is fine (nothing to auto-close).
-        bd list --status=in_progress 2>/dev/null \
+        bd list --status=in_progress,open 2>/dev/null \
             | grep -oE "[a-z][a-z0-9-]+-[a-z0-9]{3}" \
             | sort -u \
             | while read -r id; do

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -44,7 +44,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `main_ci` | 3 | Content `gh-unavailable` = silent skip. Non-zero with other content = real error. |
 | `open_prs` | 8 | Same skip convention as `main_ci`. |
 | `bd_progress` | 10 | Section absent if no beads workspace. All entries are `in_progress` by definition (that's the filter) — see step 10 for symbol-reading rules. |
-| `bd_inprogress_delivered` | 9.5 | Section absent if no beads workspace. Empty content = nothing to auto-close. Each line is `<id>\|<short-sha>\|<subject>` for an in_progress bead whose ID was referenced by a merged commit on `main` (`Closes <id>` / `Fixes <id>`). Mirrors `/start-session`'s section of the same name. |
+| `bd_inprogress_delivered` | 9.5 | Section absent if no beads workspace. Empty content = nothing to auto-close. Each line is `<id>\|<short-sha>\|<subject>` for an open or in_progress bead whose ID was referenced by a merged commit on `main` (`Closes <id>` / `Fixes <id>`). Open is included to catch beads that shipped via a `Closes`-trailer commit but were never claimed. Mirrors `/start-session`'s section of the same name. |
 | `stale_claude_files` | 11 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
 Rules for interpreting exit codes:
@@ -138,7 +138,7 @@ From gather section `stashes`. If non-empty, surface count + entries. Don't drop
 
 ### 9.5. Auto-close delivered in_progress beads (Tier 1)
 
-From gather section `bd_inprogress_delivered` (absent if no beads workspace; empty if nothing matched). Each line is `<id>|<short-sha>|<subject>` — an `in_progress` bead whose ID was referenced by a merged commit on `main` with `Closes <id>` or `Fixes <id>` in the message.
+From gather section `bd_inprogress_delivered` (absent if no beads workspace; empty if nothing matched). Each line is `<id>|<short-sha>|<subject>` — an open or in_progress bead whose ID was referenced by a merged commit on `main` with `Closes <id>` or `Fixes <id>` in the message. Open is included to catch beads that shipped via a `Closes`-trailer commit but were never claimed (so they stayed open instead of moving to in_progress).
 
 These are deliveries that landed in this session (or a recent prior one) but never had their bead closed. The PR was already reviewed and merged; closing the bead is bookkeeping, not a judgment call. Auto-close each one — no prompt:
 

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -44,7 +44,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `bd_remote` | 4 | Section absent if no beads workspace. Empty content = no remote configured (single-machine setup). |
 | `bd_ready` | 9 | Section absent if no beads workspace. Empty content = no ready work. Otherwise up to 5 pipe-separated rows: `<id>\|P<n>\|<title>`. Already pre-summarised — use rows directly in the brief without further parsing. |
 | `bd_in_progress` | 9 | Section absent if no beads workspace. Empty content = nothing in flight. Otherwise pipe-separated rows: `<id>\|P<n>\|<title>` (no limit; usually 0-3). Same row shape as `bd_ready`. |
-| `bd_inprogress_delivered` | 5 | Section absent if no beads workspace. Empty content = nothing to auto-close. Each line is `<id>\|<short-sha>\|<subject>` for an in_progress bead whose ID was referenced by a merged commit on `<default>` (`Closes <id>` / `Fixes <id>`). |
+| `bd_inprogress_delivered` | 5 | Section absent if no beads workspace. Empty content = nothing to auto-close. Each line is `<id>\|<short-sha>\|<subject>` for an open or in_progress bead whose ID was referenced by a merged commit on `<default>` (`Closes <id>` / `Fixes <id>`). Open is included to catch beads that shipped via a `Closes`-trailer commit but were never claimed. |
 
 Rules for interpreting exit codes:
 
@@ -96,7 +96,7 @@ If it fails (auth, network, or genuine conflict), halt the phase and surface the
 
 ### 5. Auto-close delivered in_progress beads (Tier 1)
 
-Read gather section `bd_inprogress_delivered` (absent if no beads workspace; empty if nothing matched). Each line is `<id>|<short-sha>|<subject>` — an `in_progress` bead whose ID was referenced by a merged commit on the default branch with `Closes <id>` or `Fixes <id>` in the message.
+Read gather section `bd_inprogress_delivered` (absent if no beads workspace; empty if nothing matched). Each line is `<id>|<short-sha>|<subject>` — an open or in_progress bead whose ID was referenced by a merged commit on the default branch with `Closes <id>` or `Fixes <id>` in the message. Open is included to catch beads that shipped via a `Closes`-trailer commit but were never claimed (so they stayed open instead of moving to in_progress).
 
 These are deliveries that never got their bead closed. The PR was already reviewed and merged; closing the bead is bookkeeping, not a judgment call. Auto-close each one — no prompt:
 


### PR DESCRIPTION
## Summary

- Extend `bd_inprogress_delivered` gather sections in both `/end-session` and `/start-session` to scan **open** beads in addition to `in_progress`.
- Beads that ship via a `Closes`-trailer commit but were never claimed (so they stayed `open`) are now auto-closed alongside `in_progress` ones.
- Doc updates in both command files explain the broadened criteria.

## Why

Hit on 2026-05-06: bead `agentic-coding-config-457` had `Closes agentic-coding-config-457` in commit `7e563aa`, but stayed `open` because the work was done with a direct edit (no `bd update --claim`). Auto-close skipped it; had to close manually.

The auto-close logic was already conservative on its match pattern (`Closes <id>` / `Fixes <id>` on a merged main commit). Broadening from `--status=in_progress` to `--status=in_progress,open` keeps that same conservatism but plugs the "forgot to claim" hole.

## Scope

This is sub-task 1 of 3 from `agentic-coding-config-0rk`:

- ✅ (2) drop `bd_preflight` from `/end-session` — already shipped in `0a4832d`
- ✅ (1) extend auto-close to scan `open` beads — **this PR**
- ⏳ (3) fast-path the brief when state is fully clean — separate PR to follow

## Test plan

- [x] Confirmed `bd list --status=in_progress,open` is supported syntax (per `bd list --help`)
- [x] Source `start-session-gather-state` emits `===bd_inprogress_delivered (exit=0)===` cleanly
- [x] Source `end-session-gather-state` emits the section cleanly
- [ ] Verify on next session start that an `open` bead with a `Closes` trailer in a merged commit gets auto-closed

## Risk

False-positive risk is unchanged: a stray `Closes <bead-id>` reference in a non-closing context still has the same near-zero collision risk. Recovery is `bd reopen <id>`. The audit already documents this trade-off in both step 9.5 (end-session) and step 5 (start-session).