### PR TITLE
feat(end-session): fast-path the brief when state is fully clean

### DIFF
--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -54,6 +54,37 @@ Rules for interpreting exit codes:
 - `exit != 0` with content equal to `gh-unavailable`: silent skip (step 3 / step 8 degrade gracefully).
 - `exit != 0` with other content: real error — surface it before continuing Phase 1.
 
+### 1.5. Fast-path when state is fully clean (Tier 1 — narration optimisation)
+
+When the gather output shows nothing actionable, skip the per-step narration entirely and jump straight to step 14 (beads push) and step 15 (summary). This keeps a typical short-session `/end-session` to ~12 lines of output instead of ~24 (one redundant "Step N — none" line per step).
+
+Apply when **all** of the following hold (single-pass check over already-collected gather output — no extra calls):
+
+- `local_state.status` is empty (clean working tree)
+- `local_state.unpushed` is empty (no unpushed commits — covers steps 4 and 7)
+- `merged_brs` is empty
+- `stashes` is empty
+- `bd_progress` is empty (no in_progress beads)
+- `bd_inprogress_delivered` is empty (nothing to auto-close)
+- `open_prs` is empty (or content is `gh-unavailable`)
+- `main_ci` has no `failure` / `cancelled` / `timed_out` line (an `in_progress` workflow is allowed — summary still surfaces it)
+- `stale_claude_files` is empty (or content is `chezmoi-unavailable`)
+- `worktrees` has exactly one entry (just the primary)
+
+If the predicate holds:
+
+1. **Still run step 14** (`bd dolt push`) if `.beads/metadata.json` exists — that's an unconditional action, not narration.
+2. Emit step 15's summary directly. Every actionable line says "none"; static lines (main rebased, beads pushed) reflect the already-clean state.
+3. Do **not** narrate steps 2–13 individually. No "Step 4 — pass", no "Step 6 — nothing to prune", no per-step status lines. The summary IS the output.
+4. Phase 2's retrospective prompt still fires as today.
+
+If **any** predicate fails, run every step as before — a messy session's narration is unchanged.
+
+**Caveats** (deliberately accepted to keep the predicate single-pass):
+
+- The fast-path skips step 6 Batch B's squash-merged branch check (`~/.claude/bin/end-session-squash-merged`). A `[upstream: gone]` branch with no upstream PR can linger one extra session before being detected — slow-decay, picked up next non-fast-path run.
+- Background processes (step 13) aren't in the predicate. Claude tracks them from session state, not gather; if any are running, surface them in the summary regardless of fast-path.
+
 ### 2. Fetch and prune remote-tracking refs
 
 Folded into step 1's gather. The `fetch` section contains the output. If its exit code is non-zero, stop and surface before proceeding.
@@ -204,7 +235,7 @@ If this fails, surface the error but don't block the phase — the user can retr
 
 ### 15. Phase 1 summary
 
-Print a concise summary. Each line says "none" loudly when clean, so noise scales with actual mess:
+Print a concise summary. Each line says "none" loudly when clean, so noise scales with actual mess. (Step 1.5's fast-path also lands here directly when the predicate holds — same format, all "none" lines.)
 
 - Branches pruned (merged): `<list or "none">`
 - Branches pruned (squash-merged): `<list or "none">`


### PR DESCRIPTION
## Summary

- Add a **step 1.5 fast-path** to `/end-session`: when gather shows nothing actionable, skip the per-step narration entirely and jump straight to step 14 (beads push) and step 15 (summary).
- Predicate is a single-pass check over already-collected gather output — **no extra calls**.
- A messy session is unchanged — every step still surfaces what it found.

## Why

A short clean session today produces ~24 lines of mostly-redundant narration ("Step 4 — pass", "Step 6 — none to prune", "Step 9 — none", …) before the summary. The summary at step 15 already conveys the clean state in one block. The narration is pure noise when nothing's happening.

This change keeps a typical short-session `/end-session` to ~12 lines (the summary block) instead of ~24. Doc-only — no code change required since the gather script already supplies all the predicates.

## Predicate

Fast-path triggers when **all** of:

- `local_state.status` empty (clean tree)
- `local_state.unpushed` empty (covers steps 4 and 7)
- `merged_brs` empty
- `stashes` empty
- `bd_progress` empty
- `bd_inprogress_delivered` empty
- `open_prs` empty (or `gh-unavailable`)
- `main_ci` has no `failure` / `cancelled` / `timed_out` line (in_progress allowed)
- `stale_claude_files` empty (or `chezmoi-unavailable`)
- `worktrees` count == 1

If any predicate fails: full narration as before.

## Caveats (deliberately accepted)

- Skips step 6 Batch B's squash-merged branch check. A `[upstream: gone]` branch can linger one extra session before being detected — slow-decay, no real harm.
- Background processes (step 13) aren't in the predicate. Claude tracks them from session state, not gather; if any are running, summary surfaces them regardless of fast-path.

## Scope

Sub-task 3 of `agentic-coding-config-0rk`. Closes the parent bead — sub-task 1 shipped in #29, sub-task 2 shipped in `0a4832d`.

## Test plan

- [x] `markdownlint-cli2` clean on the changed file
- [ ] Next clean `/end-session` run emits ~12-line summary (human verification)
- [ ] Next non-clean `/end-session` run shows full narration (human verification)