### PR TITLE
feat(session): repo-level .agent-policy for Tier 2 opt-in (start + end)

### DIFF
--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -7,8 +7,8 @@ This command runs in two phases. Phase 1 is the tidy-up (mix of auto-actions and
 Every step in Phase 1 falls into one of three tiers — keep this in mind when adding or editing steps:
 
 - **Tier 1 — auto-act, no prompt**: safe, reversible, expected. Examples: `git fetch --prune`, `git pull --rebase`, `bd dolt push`, read-only surface listings.
-- **Tier 2 — auto-act behind one batched confirmation**: destructive but predictable, judgment is yes/no for the whole list. Examples: deleting merged branches, deleting squash-merged branches, pushing `main` if ahead.
-- **Tier 3 — surface only, user drives**: needs per-item judgment, or affects shared state in ways one y/n can't capture. Examples: open PRs awaiting merge, `bd in_progress` issues, stashes, user-started background processes.
+- **Tier 2 — auto-act behind one batched confirmation**: destructive but predictable, judgment is yes/no for the whole list. Examples: deleting merged branches, deleting squash-merged branches, pushing `main` if ahead. Per-repo opt-in to Tier 1 is available via `.agent-policy` (see below) for users who always say "yes" in a given repo.
+- **Tier 3 — surface only, user drives**: needs per-item judgment, or affects shared state in ways one y/n can't capture. Examples: open PRs awaiting merge, `bd in_progress` issues, stashes, user-started background processes. **Never** opt-in via `.agent-policy` — these require human judgment by design.
 
 When in doubt, downgrade a tier (Tier 1 → 2, or 2 → 3). Never upgrade silently.
 
@@ -22,7 +22,42 @@ git rev-parse --is-inside-work-tree
 
 If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `/end-session` requires a git-backed repo — nothing to tidy, stopping. ``) and stop. Do not run any further checks, do not proceed to Phase 2.
 
+## Repo-level policy (`.agent-policy`)
+
+**Optional.** A POSIX shell `KEY=VALUE` file at the repo root that opts specific Tier 2 prompts into Tier 1 (auto-run, no prompt) on a per-repo basis. The file is shared with `/start-session` (which has its own keys); each command consults the keys it cares about. Defaults (file absent or key unset) preserve every prompt — adding the file never makes any repo behave more aggressively than before.
+
+**Supported keys (this command):**
+
+| Key | When `=true` | Affects |
+| --- | --- | --- |
+| `AUTO_DELETE_MERGED_BRANCHES` | Auto-delete Batch A (`-d`, fully merged into `origin/main`) — no prompt | Step 6 Batch A |
+| `AUTO_DELETE_SQUASH_MERGED_BRANCHES` | Auto-delete Batch B (`-D`, squash-merged with the safety net check) — no prompt | Step 6 Batch B |
+| `AUTO_PUSH_MAIN_IF_AHEAD` | Auto-push `main` when local is ahead of `origin/main` — no prompt | Step 7 |
+
+Any value other than `true` is treated as unset. Unknown keys (including `/start-session`'s own keys when read by this command) are ignored silently.
+
+**Trust model:** the file is sourced as POSIX shell, so a hostile commit could place arbitrary commands in it. Treat `.agent-policy` the same as `.envrc` / `.editorconfig` — only commit it on repos you control, and only opt into automation you actually want.
+
+**Note on the two delete keys:** Batch A and Batch B are separate keys deliberately. Batch A uses `-d` and only succeeds for branches with reachable upstream history — fully safe. Batch B uses `-D` (force) and relies on a safety net (empty diff vs `main` OR a merged PR via `gh`) to identify squash-merged work. Some users will trust Batch A but want to keep Batch B prompted.
+
+**Example `.agent-policy`:**
+
+```sh
+# .agent-policy — opt-in automation for /end-session in this repo
+AUTO_DELETE_MERGED_BRANCHES=true
+AUTO_PUSH_MAIN_IF_AHEAD=true
+# Leave AUTO_DELETE_SQUASH_MERGED_BRANCHES unset to keep the Batch B prompt.
+```
+
 ## Phase 1 — Tidy-up
+
+If `.agent-policy` exists at the repo root, source it once before proceeding:
+
+```sh
+[ -f .agent-policy ] && . ./.agent-policy
+```
+
+This loads any opt-in keys consulted by Tier 2 steps. The file is optional; if absent, every Tier 2 step prompts as today.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
@@ -117,7 +152,7 @@ git pull --rebase origin main
 
 If the rebase fails (conflicts, divergent history), stop and surface the error — don't attempt `--abort` or destructive recovery without asking.
 
-### 6. Prune obsolete local branches (Tier 2 — two batches, each prompted once)
+### 6. Prune obsolete local branches (Tier 2 — two batches, each prompted once; per-batch policy opt-in)
 
 Two batches. Present each list, ask **one** y/n per batch, then act on the whole list. Never iterate per-branch.
 
@@ -134,20 +169,25 @@ Take the list from gather section `merged_brs`.
 For each batch:
 
 - If empty, say so and move on.
-- Otherwise present the full list and ask once: "delete all of these? (y/n)".
-- On `y`: `-d` for Batch A, `-D` for Batch B.
+- Otherwise present the full list. Then **either**:
+  - **If the corresponding `.agent-policy` key is `true`** (`AUTO_DELETE_MERGED_BRANCHES` for Batch A, `AUTO_DELETE_SQUASH_MERGED_BRANCHES` for Batch B): skip the prompt and delete directly. Add a `Policy:` line to the Phase 1 summary noting the auto-delete fired with the deleted branch count.
+  - **Otherwise (default)**: ask once: "delete all of these? (y/n)".
+- On `y` (or policy fire): `-d` for Batch A, `-D` for Batch B.
 
-If a `[gone]` branch has a non-empty diff vs `main` AND no merged PR is found via `gh`, surface it by name ("`feat/x` — upstream gone but diffs against `main` and no merged PR found, left alone") so the user can decide manually. Don't roll it into Batch B.
+If a `[gone]` branch has a non-empty diff vs `main` AND no merged PR is found via `gh`, surface it by name ("`feat/x` — upstream gone but diffs against `main` and no merged PR found, left alone") so the user can decide manually. Don't roll it into Batch B — the safety net protects the auto-delete path too.
 
 For remote-tracking refs, `git fetch --prune` in step 2 already handled stale `origin/*` refs. Don't delete anything on the remote itself.
 
-### 7. Push main if ahead (Tier 2)
+### 7. Push main if ahead (Tier 2 — prompt, or Tier 1 with policy opt-in)
 
 ```sh
 git log origin/main..HEAD --oneline
 ```
 
-If main is ahead of origin/main (shouldn't normally happen, but catches the case where commits landed locally), ask before pushing.
+If main is ahead of origin/main (shouldn't normally happen, but catches the case where commits landed locally):
+
+- **If `AUTO_PUSH_MAIN_IF_AHEAD=true` (from `.agent-policy`)**: push directly without prompting. Add a `Policy:` line to the Phase 1 summary noting the push fired and the commit count.
+- **Otherwise (default)**: ask before pushing.
 
 ### 8. Open PRs needing your action (Tier 3 — surface only)
 
@@ -251,6 +291,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
 - Beads pushed: `<yes/no/n/a>`
+- Policy: `<list of .agent-policy keys that fired this session, e.g. "AUTO_DELETE_MERGED_BRANCHES → 3 deleted">` — omit the line entirely when no keys fired or the file is absent. Don't list keys that were set but had nothing to do (e.g. `AUTO_DELETE_MERGED_BRANCHES=true` with no merged branches).
 - Anything skipped/surfaced: `<list>`
 
 ## Phase 2 — Retrospective
@@ -271,8 +312,9 @@ On `n`: stop. The session is tidied; the user can run `/retrospective` later if 
 
 ## Guardrails
 
-- **`-D` (force delete) is allowed only for Batch B of step 6** — branches that are `[upstream: gone]` AND have an empty `git diff` against `main`. Everywhere else: always `-d`. If `-d` refuses, that's signal — surface it, don't override.
+- **`-D` (force delete) is allowed only for Batch B of step 6** — branches that are `[upstream: gone]` AND have an empty `git diff` against `main` (or a merged PR via `gh`). Everywhere else: always `-d`. If `-d` refuses, that's signal — surface it, don't override. The Batch B safety net protects the `AUTO_DELETE_SQUASH_MERGED_BRANCHES` opt-in path identically — auto-delete only acts on entries that already passed the safety check.
 - **Never `git push --force` or `git reset --hard`.** Those aren't session-tidy operations; if they're needed, the user should drive them.
 - **Never auto-merge PRs, auto-close issues, or auto-drop stashes.** Per-item judgment lives with the user (Tier 3).
-- **Ask before every Tier 2 destructive action** (branch deletes, force-pushing). One y/n per batch is fine — don't ask per-branch if a single list is presented.
+- **Ask before every Tier 2 destructive action by default** (branch deletes, force-pushing). One y/n per batch is fine — don't ask per-branch if a single list is presented. The `.agent-policy` keys (`AUTO_DELETE_MERGED_BRANCHES`, `AUTO_DELETE_SQUASH_MERGED_BRANCHES`, `AUTO_PUSH_MAIN_IF_AHEAD`) are the only sanctioned way to skip the prompt, and they're per-repo opt-in.
 - **Don't modify settings, config, or unrelated files.** This command's scope is git, GitHub, beads, and process state only.
+- **`.agent-policy` only promotes Tier 2 → Tier 1 for the keys it explicitly governs.** Tier 3 surfaces (user judgment) cannot be opted in. Unknown keys are ignored silently.

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -7,8 +7,8 @@ This command runs in a single phase. It mirrors `/end-session`'s shape — paral
 Every step falls into one of three tiers — keep this in mind when adding or editing steps:
 
 - **Tier 1 — auto-act, no prompt**: safe, reversible, expected. Examples: `git fetch --prune`, `git pull --rebase` on the default branch, `bd dolt pull`, read-only surface listings.
-- **Tier 2 — auto-act behind one batched confirmation**: predictable but should be a conscious choice. Example: chaining into `/bd-import-github-issues` when unmigrated GitHub issues exist.
-- **Tier 3 — surface only, user drives**: needs per-item judgment. Examples: a feature branch trailing `main`, in-progress beads left mid-flight from the last session, red `main` CI.
+- **Tier 2 — auto-act behind one batched confirmation**: predictable but should be a conscious choice. Example: chaining into `/bd-import-github-issues` when unmigrated GitHub issues exist. Per-repo opt-in to Tier 1 is available via `.agent-policy` (see below) for users who always say "yes" in a given repo.
+- **Tier 3 — surface only, user drives**: needs per-item judgment. Examples: a feature branch trailing `main`, in-progress beads left mid-flight from the last session, red `main` CI. **Never** opt-in via `.agent-policy` — these require human judgment by design.
 
 When in doubt, downgrade a tier (Tier 1 → 2, or 2 → 3). Never upgrade silently.
 
@@ -22,7 +22,38 @@ git rev-parse --is-inside-work-tree
 
 If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `/start-session` requires a git-backed repo — nothing to sync, stopping. ``) and stop.
 
+## Repo-level policy (`.agent-policy`)
+
+**Optional.** A POSIX shell `KEY=VALUE` file at the repo root that opts specific Tier 2 prompts into Tier 1 (auto-run, no prompt) on a per-repo basis. Defaults (file absent or key unset) preserve the prompt — adding the file never makes any repo behave more aggressively than before.
+
+**Supported keys:**
+
+| Key | When `=true` | Affects |
+| --- | --- | --- |
+| `AUTOMATE_GITHUB_IMPORT` | Auto-run `/bd-import-github-issues` when `count > 0` — no prompt | Step 8 |
+| `AUTOMATE_JOURNAL_PROMOTE` | Auto-run `/promote-journal-inbox` when filesystem `_incoming/` count >= 1 — no prompt | Step 8.5 |
+
+Any value other than `true` is treated as unset. Unknown keys are ignored silently (forward-compatibility).
+
+**Trust model:** the file is sourced as POSIX shell, so a hostile commit could place arbitrary commands in it. Treat `.agent-policy` the same as `.envrc` / `.editorconfig` — only commit it on repos you control, and only opt into automation you actually want. The file lives at the repo root (not under `.claude/`, which is reserved for the harness's own config).
+
+**Example `.agent-policy`:**
+
+```sh
+# .agent-policy — opt-in automation for /start-session in this repo
+AUTOMATE_GITHUB_IMPORT=true
+AUTOMATE_JOURNAL_PROMOTE=true
+```
+
 ## Phase 1 — Sync
+
+If `.agent-policy` exists at the repo root, source it once before proceeding:
+
+```sh
+[ -f .agent-policy ] && . ./.agent-policy
+```
+
+This loads any opt-in keys consulted by Tier 2 steps. The file is optional; if absent, every Tier 2 step prompts as today.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
@@ -133,20 +164,23 @@ From gather section `recent_main_commits`. The first line is `count=<N>` — com
 
 This is informational only — no action prompts. The section adds a few lines on busy days and zero on quiet ones.
 
-### 8. Unmigrated GitHub Issues (Tier 2 — prompt)
+### 8. Unmigrated GitHub Issues (Tier 2 — prompt, or Tier 1 with policy opt-in)
 
 From gather section `gh_unmigrated`. The first line is `count=<N>`; remaining lines are `#<number> <title>` per unmigrated issue.
 
 - **`gh-unavailable` / `jq-unavailable` / no remote**: skip silently.
 - **`count=0`**: silent.
-- **`count > 0`**: print the count and (up to) the first 5 titles, then prompt:
+- **`count > 0`**: print the count and (up to) the first 5 titles, then:
 
-  > `<N>` open GitHub issue(s) haven't been imported into beads yet. Run `/bd-import-github-issues` now? (y/n)
+  - **If `AUTOMATE_GITHUB_IMPORT=true` (from `.agent-policy`)**: skip the prompt and invoke `/bd-import-github-issues` directly. Add a `Policy:` line to the session brief noting that the import fired automatically.
+  - **Otherwise (default)**: prompt:
 
-  - **yes** → invoke `/bd-import-github-issues` directly. That command does its own `bd dolt pull` (Step 0) and `bd dolt push` (Step 8); a second pull right after step 4 is a clean no-op, and the push at the end is what we want anyway.
-  - **no / empty / cancel** → carry on. Surface the count in the session brief under "Needs attention" so it's visible at a glance.
+    > `<N>` open GitHub issue(s) haven't been imported into beads yet. Run `/bd-import-github-issues` now? (y/n)
 
-### 8.5. Paul-context inbox surface (Tier 2 — prompt, paul-context only)
+    - **yes** → invoke `/bd-import-github-issues` directly. That command does its own `bd dolt pull` (Step 0) and `bd dolt push` (Step 8); a second pull right after step 4 is a clean no-op, and the push at the end is what we want anyway.
+    - **no / empty / cancel** → carry on. Surface the count in the session brief under "Needs attention" so it's visible at a glance.
+
+### 8.5. Paul-context inbox surface (Tier 2 — prompt, paul-context only; Tier 1 with policy opt-in)
 
 **Only fires when the current working tree is `paul-context`** (`basename "$(git rev-parse --show-toplevel)" = "paul-context"`). Otherwise skip silently. This is a runtime filesystem check, not part of the gather output — `/start-session` runs in many repos and a generic gather section would always be empty for the rest.
 
@@ -157,12 +191,15 @@ ls -1 _incoming/ 2>/dev/null
 Filter the listing to entries matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+\.md$` (excludes `README.md` and any non-conforming files). Count the matches.
 
 - **0 matches**: skip silently.
-- **>= 1 match**: print the count and (up to first 5) filenames, then prompt:
+- **>= 1 match**: print the count and (up to first 5) filenames, then:
 
-  > `<N>` journal draft(s) pending in `_incoming/`. Run `/promote-journal-inbox` now? (y/n)
+  - **If `AUTOMATE_JOURNAL_PROMOTE=true` (from `.agent-policy`)**: skip the prompt and invoke `/promote-journal-inbox` directly. Add a `Policy:` line to the session brief noting that the promote fired automatically.
+  - **Otherwise (default)**: prompt:
 
-  - **yes** → invoke `/promote-journal-inbox` directly. That command's pre-flight verifies cwd, then drains both filesystem `_incoming/` and `journal-draft`-labeled Issues from `pmgledhill102/paul-context`, commits each draft separately, single-pushes, and closes the drained Issues. Carry the result into the session brief.
-  - **no / empty / cancel** → carry on. Surface the count in the session brief under "Needs attention" so it's visible at a glance.
+    > `<N>` journal draft(s) pending in `_incoming/`. Run `/promote-journal-inbox` now? (y/n)
+
+    - **yes** → invoke `/promote-journal-inbox` directly. That command's pre-flight verifies cwd, then drains both filesystem `_incoming/` and `journal-draft`-labeled Issues from `pmgledhill102/paul-context`, commits each draft separately, single-pushes, and closes the drained Issues. Carry the result into the session brief.
+    - **no / empty / cancel** → carry on. Surface the count in the session brief under "Needs attention" so it's visible at a glance.
 
 Note: this surface only counts the **filesystem** half of the inbox. The Issue-side half (sandbox-fallback drafts) isn't enumerated here — surfacing it would require an extra `gh issue list --label journal-draft` call, and the filesystem count is the dominant signal because the local machine is where the user lives. `/promote-journal-inbox` itself drains both inboxes when invoked, so user action is consistent regardless of which path filed the draft.
 
@@ -177,6 +214,10 @@ Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
 Dolt:     <pulled / up-to-date / no remote / FAILED>
 CI:       <green / N failing / N in-progress / n/a>
+
+Policy:                                             (omit when no policy keys fired)
+  AUTOMATE_GITHUB_IMPORT=true → imported <N> issue(s)
+  AUTOMATE_JOURNAL_PROMOTE=true → promoted <N> draft(s)
 
 Auto-closed (delivered):                            (omit when none)
   <id>  via <short-sha>  <commit subject>
@@ -208,6 +249,7 @@ Rules:
 - "In progress" is sourced from gather section `bd_in_progress`. Same `<id>|P<n>|<title>` row shape; no cap (usually 0–3 items). Note: any beads auto-closed in Step 5 won't appear here — they're already closed by the time the brief renders.
 - "Auto-closed (delivered)" is sourced from the IDs Step 5 closed. Omit the entire section when Step 5 closed nothing.
 - "Recent merges" is sourced from gather section `recent_main_commits`. Omit the entire section when `count=0`.
+- "Policy" lists each `.agent-policy` key that fired this session (i.e. promoted a Tier 2 prompt to Tier 1 auto-action). Omit the entire section when no keys fired or the file is absent. Don't list keys that were set but had nothing to do (e.g. `AUTOMATE_GITHUB_IMPORT=true` when `count=0`) — only list actual fires.
 - If the repo has no beads workspace, drop both Beads sections silently (the brief still shows git/CI/GH lines).
 - Truncate any title to ~78 columns to keep rows on one line.
 
@@ -217,5 +259,6 @@ Rules:
 - **Never auto-rebase a feature branch** onto an advanced default branch. Surface the gap and stop. The user picks the strategy.
 - **Never switch branches except when the upstream is gone and the tree is clean.** That single case (PR merged + branch auto-deleted on remote, no local uncommitted work) is auto-handled per Step 3. Otherwise, `/start-session` reports state on whatever branch the user is on.
 - **`bd dolt pull` failures halt the phase.** Don't attempt auto-resolve, don't fall back to JSONL, don't rebuild the DB. Surface and stop.
-- **Don't push anything except the auto-close result in Step 5.** Pushes generally belong to `/end-session` (for git/`main`) and `/bd-import-github-issues` (for beads after import). The single carve-out is Step 5's `bd dolt push` after auto-closing delivered in_progress beads — that push is what makes the auto-close cross-machine durable. `/start-session` is otherwise read-mostly.
+- **Don't push anything except the auto-close result in Step 5.** Pushes generally belong to `/end-session` (for git/`main`) and `/bd-import-github-issues` (for beads after import). The single carve-out is Step 5's `bd dolt push` after auto-closing delivered in_progress beads — that push is what makes the auto-close cross-machine durable. `/start-session` is otherwise read-mostly. (Note: if `AUTOMATE_GITHUB_IMPORT=true` fires, `/bd-import-github-issues` runs its own push — that's the import command's contract, not a new carve-out.)
 - **Don't modify settings, config, or unrelated files.** Scope is git, beads, and GitHub-issue surface only.
+- **`.agent-policy` only promotes Tier 2 → Tier 1 for the keys it explicitly governs.** Tier 3 surfaces (user judgment) cannot be opted in. Unknown keys are ignored silently.

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -30,8 +30,8 @@ If the exit code is non-zero (or stdout is not `true`), print a single-line warn
 
 | Key | When `=true` | Affects |
 | --- | --- | --- |
-| `AUTOMATE_GITHUB_IMPORT` | Auto-run `/bd-import-github-issues` when `count > 0` — no prompt | Step 8 |
-| `AUTOMATE_JOURNAL_PROMOTE` | Auto-run `/promote-journal-inbox` when filesystem `_incoming/` count >= 1 — no prompt | Step 8.5 |
+| `AUTO_GITHUB_IMPORT` | Auto-run `/bd-import-github-issues` when `count > 0` — no prompt | Step 8 |
+| `AUTO_JOURNAL_PROMOTE` | Auto-run `/promote-journal-inbox` when filesystem `_incoming/` count >= 1 — no prompt | Step 8.5 |
 
 Any value other than `true` is treated as unset. Unknown keys are ignored silently (forward-compatibility).
 
@@ -41,8 +41,8 @@ Any value other than `true` is treated as unset. Unknown keys are ignored silent
 
 ```sh
 # .agent-policy — opt-in automation for /start-session in this repo
-AUTOMATE_GITHUB_IMPORT=true
-AUTOMATE_JOURNAL_PROMOTE=true
+AUTO_GITHUB_IMPORT=true
+AUTO_JOURNAL_PROMOTE=true
 ```
 
 ## Phase 1 — Sync
@@ -172,7 +172,7 @@ From gather section `gh_unmigrated`. The first line is `count=<N>`; remaining li
 - **`count=0`**: silent.
 - **`count > 0`**: print the count and (up to) the first 5 titles, then:
 
-  - **If `AUTOMATE_GITHUB_IMPORT=true` (from `.agent-policy`)**: skip the prompt and invoke `/bd-import-github-issues` directly. Add a `Policy:` line to the session brief noting that the import fired automatically.
+  - **If `AUTO_GITHUB_IMPORT=true` (from `.agent-policy`)**: skip the prompt and invoke `/bd-import-github-issues` directly. Add a `Policy:` line to the session brief noting that the import fired automatically.
   - **Otherwise (default)**: prompt:
 
     > `<N>` open GitHub issue(s) haven't been imported into beads yet. Run `/bd-import-github-issues` now? (y/n)
@@ -193,7 +193,7 @@ Filter the listing to entries matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+\.
 - **0 matches**: skip silently.
 - **>= 1 match**: print the count and (up to first 5) filenames, then:
 
-  - **If `AUTOMATE_JOURNAL_PROMOTE=true` (from `.agent-policy`)**: skip the prompt and invoke `/promote-journal-inbox` directly. Add a `Policy:` line to the session brief noting that the promote fired automatically.
+  - **If `AUTO_JOURNAL_PROMOTE=true` (from `.agent-policy`)**: skip the prompt and invoke `/promote-journal-inbox` directly. Add a `Policy:` line to the session brief noting that the promote fired automatically.
   - **Otherwise (default)**: prompt:
 
     > `<N>` journal draft(s) pending in `_incoming/`. Run `/promote-journal-inbox` now? (y/n)
@@ -216,8 +216,8 @@ Dolt:     <pulled / up-to-date / no remote / FAILED>
 CI:       <green / N failing / N in-progress / n/a>
 
 Policy:                                             (omit when no policy keys fired)
-  AUTOMATE_GITHUB_IMPORT=true → imported <N> issue(s)
-  AUTOMATE_JOURNAL_PROMOTE=true → promoted <N> draft(s)
+  AUTO_GITHUB_IMPORT=true → imported <N> issue(s)
+  AUTO_JOURNAL_PROMOTE=true → promoted <N> draft(s)
 
 Auto-closed (delivered):                            (omit when none)
   <id>  via <short-sha>  <commit subject>
@@ -249,7 +249,7 @@ Rules:
 - "In progress" is sourced from gather section `bd_in_progress`. Same `<id>|P<n>|<title>` row shape; no cap (usually 0–3 items). Note: any beads auto-closed in Step 5 won't appear here — they're already closed by the time the brief renders.
 - "Auto-closed (delivered)" is sourced from the IDs Step 5 closed. Omit the entire section when Step 5 closed nothing.
 - "Recent merges" is sourced from gather section `recent_main_commits`. Omit the entire section when `count=0`.
-- "Policy" lists each `.agent-policy` key that fired this session (i.e. promoted a Tier 2 prompt to Tier 1 auto-action). Omit the entire section when no keys fired or the file is absent. Don't list keys that were set but had nothing to do (e.g. `AUTOMATE_GITHUB_IMPORT=true` when `count=0`) — only list actual fires.
+- "Policy" lists each `.agent-policy` key that fired this session (i.e. promoted a Tier 2 prompt to Tier 1 auto-action). Omit the entire section when no keys fired or the file is absent. Don't list keys that were set but had nothing to do (e.g. `AUTO_GITHUB_IMPORT=true` when `count=0`) — only list actual fires.
 - If the repo has no beads workspace, drop both Beads sections silently (the brief still shows git/CI/GH lines).
 - Truncate any title to ~78 columns to keep rows on one line.
 
@@ -259,6 +259,6 @@ Rules:
 - **Never auto-rebase a feature branch** onto an advanced default branch. Surface the gap and stop. The user picks the strategy.
 - **Never switch branches except when the upstream is gone and the tree is clean.** That single case (PR merged + branch auto-deleted on remote, no local uncommitted work) is auto-handled per Step 3. Otherwise, `/start-session` reports state on whatever branch the user is on.
 - **`bd dolt pull` failures halt the phase.** Don't attempt auto-resolve, don't fall back to JSONL, don't rebuild the DB. Surface and stop.
-- **Don't push anything except the auto-close result in Step 5.** Pushes generally belong to `/end-session` (for git/`main`) and `/bd-import-github-issues` (for beads after import). The single carve-out is Step 5's `bd dolt push` after auto-closing delivered in_progress beads — that push is what makes the auto-close cross-machine durable. `/start-session` is otherwise read-mostly. (Note: if `AUTOMATE_GITHUB_IMPORT=true` fires, `/bd-import-github-issues` runs its own push — that's the import command's contract, not a new carve-out.)
+- **Don't push anything except the auto-close result in Step 5.** Pushes generally belong to `/end-session` (for git/`main`) and `/bd-import-github-issues` (for beads after import). The single carve-out is Step 5's `bd dolt push` after auto-closing delivered in_progress beads — that push is what makes the auto-close cross-machine durable. `/start-session` is otherwise read-mostly. (Note: if `AUTO_GITHUB_IMPORT=true` fires, `/bd-import-github-issues` runs its own push — that's the import command's contract, not a new carve-out.)
 - **Don't modify settings, config, or unrelated files.** Scope is git, beads, and GitHub-issue surface only.
 - **`.agent-policy` only promotes Tier 2 → Tier 1 for the keys it explicitly governs.** Tier 3 surfaces (user judgment) cannot be opted in. Unknown keys are ignored silently.


### PR DESCRIPTION
## Summary

Add an optional `.agent-policy` file at the repo root that opts specific Tier 2 prompts in **both** `/start-session` and `/end-session` into Tier 1 (auto-run, no prompt) on a per-repo basis. Defaults preserve every prompt — adding the file **never makes a repo behave more aggressively than before**.

## Why

Today both session commands have several Tier 2 prompts:

- `/start-session` Step 8 — "N open GitHub issues haven't been imported into beads yet. Run `/bd-import-github-issues`?"
- `/start-session` Step 8.5 — "N journal draft(s) pending. Run `/promote-journal-inbox`?" (paul-context only)
- `/end-session` Step 6 Batch A — "delete N merged branches?"
- `/end-session` Step 6 Batch B — "delete N squash-merged branches?"
- `/end-session` Step 7 — "push main? It's ahead by N commits."

For repos where the answer is always "yes" (e.g. "everything goes through beads here", or "I always clean merged branches"), the prompts are friction. `.agent-policy` lets a repo opt those into Tier 1 without changing global behaviour.

## Design

- **Format**: POSIX shell `KEY=VALUE` at the repo root. `[ -f .agent-policy ] && . ./.agent-policy` — no parser, no extra dependency.
- **Shared file, per-command keys**: each command's doc lists only the keys it consumes; unknown keys (including the other command's keys when read by the first) are ignored silently.
- **Five keys at v1**:

  | Key | Command | Step | Effect when `=true` |
  |---|---|---|---|
  | `AUTO_GITHUB_IMPORT` | `/start-session` | 8 | Skip prompt, auto-run `/bd-import-github-issues` when count > 0 |
  | `AUTO_JOURNAL_PROMOTE` | `/start-session` | 8.5 | Skip prompt, auto-run `/promote-journal-inbox` when filesystem `_incoming/` count >= 1 |
  | `AUTO_DELETE_MERGED_BRANCHES` | `/end-session` | 6 Batch A | Skip prompt, `-d` delete the listed merged branches |
  | `AUTO_DELETE_SQUASH_MERGED_BRANCHES` | `/end-session` | 6 Batch B | Skip prompt, `-D` delete the squash-merged branches (existing safety net still applies) |
  | `AUTO_PUSH_MAIN_IF_AHEAD` | `/end-session` | 7 | Skip prompt, push main when ahead of origin/main |

- **Trust model**: file is sourced as shell, treat it like `.envrc` / `.editorconfig` — only commit on repos you control. Documented inline in both command docs.
- **Brief / summary**: a `Policy:` line lists keys that actually fired (omitted entirely when none, and "set but inert" doesn't count).
- **Batch A vs Batch B kept as separate keys**: `-D` (force delete) is more sensitive even with the safety net (`[upstream: gone]` + (empty diff vs main OR merged PR via `gh`)). Some users will trust `-d` auto-delete but want to keep the `-D` prompt.
- **Guardrail**: `.agent-policy` only promotes Tier 2 → Tier 1 for the keys it explicitly governs. Tier 3 surfaces (user judgment) cannot be opted in. Unknown keys ignored silently for forward-compatibility.

## What's not in this PR

- No `.agent-policy` file is committed to this repo (it has no Tier 2 prompts that would benefit today on this machine).
- No code changes — this is purely doc-driven; the LLM reads the policy section and follows.
- No new gather sections — the policy is read inline at the steps that consume it.

## Test plan

- [x] `markdownlint-cli2` clean on both changed files
- [ ] In a repo with `.agent-policy` containing `AUTO_GITHUB_IMPORT=true`: next `/start-session` with unmigrated issues auto-runs the import without prompting
- [ ] In a repo with `AUTO_DELETE_MERGED_BRANCHES=true`: next `/end-session` with merged branches deletes them without prompting; without the key, prompts as today
- [ ] Brief / summary shows `Policy:` line only when a key actually fired (not when set-but-inert)
- [ ] Batch B safety net still rejects `[gone]` branches with non-empty diff and no merged PR even when `AUTO_DELETE_SQUASH_MERGED_BRANCHES=true`

## Scope

Closes `agentic-coding-config-320`. Single feature spanning two commands; same `.agent-policy` file consumed by both.