### PR TITLE
fix(promote-journal-inbox): use plain mv instead of git mv for ignored sources

### DIFF
--- a/home/commands/promote-journal-inbox.md
+++ b/home/commands/promote-journal-inbox.md
@@ -34,8 +34,8 @@ If empty, surface `(no filesystem drafts pending)` and skip to Phase 2.
 For each `<filename>` in the sorted list:
 
 1. **Conflict check**: if `journal/<filename>` already exists, skip. Append to the conflict-list as `<filename> — already in journal/, left in _incoming/`. Continue with the next draft.
-2. `git mv _incoming/<filename> journal/<filename>` — preserves the filename exactly.
-3. Stage with `git add journal/<filename>` (already staged by `git mv`, but explicit is safer for the followup commit).
+2. `mv _incoming/<filename> journal/<filename>` — preserves the filename exactly. Plain `mv` (not `git mv`) because `_incoming/*.md` is gitignored at the repo level — `git mv` refuses to move untracked sources with `fatal: not under version control`. The destination lives under `journal/` (tracked), so step 3 picks it up cleanly.
+3. Stage with `git add journal/<filename>`.
 4. Derive the commit message slug: strip the leading `<YYYY-MM-DD>-` from `<filename>` and the trailing `.md`. The remainder is `<source-repo-slug>-<topic-slug>`.
 5. Commit each draft separately:
 


### PR DESCRIPTION
## Summary

Replace `git mv` with plain `mv` in `/promote-journal-inbox` Phase 1 step 2.

## Why

`_incoming/*.md` is gitignored at the repo level (the inbox is by-design staging-only — drafts live there until they're promoted). `git mv` refuses to move untracked sources with:

```
fatal: not under version control, source=_incoming/<filename>, destination=journal/<filename>
```

So the skill's prescribed `git mv` line aborts the whole flow.

Observed live on 2026-05-07: `/retrospective` produced a draft, the follow-up `/promote-journal-inbox` died on the first `git mv`. Worked around manually with `mv` + `git add` — that's also the right permanent fix.

## What changes

Step 2 wording, step 3 wording (drops the now-obsolete "already staged by `git mv`" parenthetical). Two-line diff.

## Why this works

The destination lives under `journal/` (tracked). Plain `mv` doesn't care about source tracked-status; the existing step 3 `git add journal/<filename>` stages the destination cleanly. As a bonus, this is also robust to the rare case where `_incoming/<file>` was force-added historically — `mv` works either way, and `git add` only cares about the destination.

## Scope

Closes `agentic-coding-config-8in`. Single-concern fix.

## Test plan

- [x] `markdownlint-cli2` clean
- [ ] Run `/promote-journal-inbox` against a draft in `_incoming/` (gitignored) and verify the move + commit succeed