### PR TITLE
fix(bd-import-github-issues): collision-proof temp-file paths via per-run token

### DIFF
--- a/home/commands/bd-import-github-issues.md
+++ b/home/commands/bd-import-github-issues.md
@@ -138,8 +138,16 @@ Proceed with the above mapping?
 
 **Don't pass descriptions inline.** GitHub bodies routinely contain quotes, apostrophes, code fences, multi-line shell output — escaping all that into a single `--description="..."` argument is brittle and breaks differently each time. `$(cat …)` substitution is a partial fix but can still trip Claude Code's harness re-prompt heuristic by surfacing multi-line content in the rendered command. Use `bd create --body-file=PATH` instead — bd reads the description directly from the file and the command line stays a single static line that matches the `Bash(bd *)` glob rule cleanly.
 
-1. For each confirmed candidate, write the full description to a temp file using the `Write` tool: `/tmp/bead-desc-<gh_number>.md`. The file content is plain text, no shell-escaping needed.
-2. Then run `bd create` with `--body-file=/tmp/bead-desc-<gh_number>.md` — no shell substitution involved.
+**Capture a per-run token first** so temp-file paths can't collide with prior runs (the `Write` tool refuses to clobber a path it hasn't read in this session — even if the file's content is stale from a previous import in another project that happened to share GitHub issue numbers):
+
+```sh
+RUN_TS=$(date +%s)
+```
+
+Use `RUN_TS` as a prefix on every temp-file path. Re-runs in the same boot session — and runs across different projects with overlapping GH issue numbers — are then collision-free by construction.
+
+1. For each confirmed candidate, write the full description to a temp file using the `Write` tool: `/tmp/bead-import-<RUN_TS>-<gh_number>.md`. The file content is plain text, no shell-escaping needed.
+2. Then run `bd create` with `--body-file=/tmp/bead-import-<RUN_TS>-<gh_number>.md` — no shell substitution involved.
 
 Description file template:
 
@@ -157,7 +165,7 @@ Then for each confirmed candidate, in order:
 ```sh
 bd create \
   --title="<decoded gh title>" \
-  --body-file=/tmp/bead-desc-<n>.md \
+  --body-file=/tmp/bead-import-<RUN_TS>-<n>.md \
   --type=<inferred or overridden> \
   --priority=<inferred or overridden>
 ```
@@ -170,7 +178,7 @@ Notes:
 
 - Don't try to preserve GitHub labels as bd labels — beads doesn't have a labels concept the same way. The label names are already captured indirectly via type/priority inference; the original list is in the GitHub issue's history (still accessible after closing).
 - Don't try to map GitHub assignees — for solo-dev usage they're always you; for multi-user teams the mapping needs more thought and is out of scope for v1.
-- The `/tmp/bead-desc-<n>.md` files are leftover after the run. Harmless; they're cleared on next reboot. If you want them gone immediately, `rm /tmp/bead-desc-*.md` at the end.
+- The `/tmp/bead-import-<RUN_TS>-<n>.md` files are leftover after the run. Harmless; they're cleared on next reboot. If you want them gone immediately, `rm /tmp/bead-import-${RUN_TS}-*.md` at the end (or just `rm /tmp/bead-import-*.md` to sweep all prior runs too — the `<RUN_TS>` prefix keeps each run's files easy to scope).
 
 ### Step 5: Confirmation B — close the GitHub issues?
 


### PR DESCRIPTION
## Summary

Make `/bd-import-github-issues` Step 4 use collision-proof temp-file paths by capturing a per-run epoch token (`RUN_TS=$(date +%s)`) and prefixing every `/tmp/bead-*` path with it.

## Why

The `Write` tool refuses to clobber paths it hasn't read in the current session — even if the file's content is now stale from a prior run. The current scheme `/tmp/bead-desc-<gh_number>.md` is deterministic, so re-runs across projects with overlapping GitHub issue numbers (or back-to-back runs in one boot session) collide:

```
File has not been read yet. Read it first before writing to it.
```

Observed live on 2026-05-07 — two paul-context imports in one session collided on `/tmp/bead-desc-1.md`. Worked around manually with a different prefix; this PR makes the fix permanent.

## What changes

In `home/commands/bd-import-github-issues.md` Step 4:

- Capture `RUN_TS=$(date +%s)` once at the start of step 4
- Path scheme: `/tmp/bead-import-<RUN_TS>-<gh_number>.md` (was `/tmp/bead-desc-<gh_number>.md`)
- Cleanup notes updated: per-run scoped (`rm /tmp/bead-import-${RUN_TS}-*.md`) or sweep-all (`rm /tmp/bead-import-*.md`)

12 line diff, doc-only.

## Why this approach

- **Single shared epoch per run** (not per-issue) keeps cleanup easy: one prefix groups all of a run's files
- **No mkdir** required — flat path, just `Write` directly
- **Filename rename** (`bead-desc-` → `bead-import-`) makes the prefix command-specific so it can't collide with ad-hoc `/tmp/bead-desc-*.md` files used by other contexts (e.g. when the model writes a one-off `bd create --body-file` description elsewhere)

## Scope

Closes `agentic-coding-config-blq`. Single-concern fix.

## Test plan

- [x] `markdownlint-cli2` clean
- [ ] Run `/bd-import-github-issues` twice in succession against repos with overlapping GH issue numbers — second run should succeed without "File has not been read yet" errors