### PR TITLE
docs(claude): add PR-stacking rule, broaden CLI-flag verification to advice mode

### DIFF
--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -32,10 +32,11 @@
 - **Lint before pushing**: Always run the relevant linter/test suite locally before `git push`. Only push if everything passes — avoids CI round-trips
 - **Use native binaries over package runners**: When a linter/formatter is installed on PATH (`which <tool>`), invoke it directly (e.g. `markdownlint-cli2 "path"`) rather than wrapping it in `npx`/`pipx`/`uvx`. Wrappers introduce version drift from what CI and pre-commit use, are slower, and may trigger permission prompts
 - **Single-concern PRs**: Each PR should contain a single logical change. If multiple tasks are completed in a session, create separate PRs for each rather than bundling unrelated changes
+- **PR-stacking discipline**: only claim "stacked on" when the second branch literally has the first as parent (`git log --oneline first..second` shows just the second's commits). Branching both off `main` and writing "stacked on PR #N" in the body is misleading — reviewers can merge in any order, and the second PR's diff includes the first's changes. If they're truly independent, branch each from `main` and don't say stacked
 - **Batch reads before edits**: When modifying multiple files, read all target files first, then make all edits — avoids "file not read yet" errors on parallel Edit calls
 - **Always create a beads issue**: Even for quick single-file fixes, run `bd create` before starting work — maintains the audit trail and keeps the habit consistent
 
 ## Shell Scripts
 
 - **Target POSIX sh or ensure macOS/zsh compatibility**: Avoid bash-only builtins (`mapfile`, `readarray`, `declare -A`). Be aware that `$(( expr ))` returns exit code 1 when result is 0 (breaks `set -e`), and empty arrays behave differently in zsh with `set -u`
-- **Verify CLI flags before using them**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing — avoids round-trips from non-existent flags (e.g., `brew bundle --no-lock`)
+- **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your bash call or in the user's terminal after you suggest them


### PR DESCRIPTION
## Summary

Two tiny additions to `home/CLAUDE.md` Process Guidelines.

### 1. PR-stacking discipline (new bullet)

Only claim "stacked on" when the second branch literally has the first as parent. Branching both off `main` and writing "stacked on PR #N" in the PR body is misleading — reviewers can merge in any order, and the second PR's diff includes the first's changes.

This one earned its slot on the multi-recurrence test: cited in retros from 2026-05-02 (line 937) AND 2026-05-03 (line 974), both pupoot live-test sessions where the model claimed "stacked" without genuine parentage and caused merge confusion.

### 2. CLI-flag verification → also covers advice given to the user (fold-in)

Existing rule said "verify CLI flags before using them". Extended to also cover flags recommended in chat — `brew bundle --no-lock`-style hallucinations waste a round-trip whether they fire in Claude's bash call or in the user's terminal after Claude suggests them.

## What's NOT in this PR

- **Bead-before-code PreToolUse hook (item #2 from `agentic-coding-config-sej`)** was proposed and dropped after architectural pushback. Coupling bd-output-format parsing into the most-fundamental tool-use path (every Edit/Write fires the hook on every machine) was tighter coupling than the rule's "nudge" value warranted. Filing a separate bead to think about whether the global Claude Code config should be bd-aware at all, or whether bd integration should live in a per-project layer that beads itself ships.
- The other 7 items in `sej` were skipped per the recurring-pattern bar (single-citation, incident-shaped, time-conditional, or already-shipped elsewhere).

## Scope

Refs `agentic-coding-config-sej` — 1 of 3 user-selected items shipped here, 1 dropped per architectural concern (separate bead to follow), rest skipped per memory bar. Will close `sej` manually once the architectural bead is filed.

## Test plan

- [x] `markdownlint-cli2` clean
- [ ] Verify the rendered CLAUDE.md reads sensibly when the user views it (the "PR-stacking" bullet sits naturally after "Single-concern PRs")