### PR TITLE
feat(claude-config): pre-approve bd-push-safe and fix bare-name advice

### DIFF
--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -17,7 +17,7 @@
 
 ## Beads (bd)
 
-- **Prefer `bd-push-safe` over bare `bd dolt push`**: the shim at `~/.claude/bin/bd-push-safe` strips the cache hooks that `bd init` / `bd bootstrap` re-create from `init.templatedir`. On machines where dotfiles git-templates invoke the pre-commit framework, bare `bd dolt push` fails with `fatal: this operation must be run in a work tree`; `bd-push-safe` is a drop-in replacement that just works. Tracked upstream as `agentic-coding-config-o5w`; once that lands the shim becomes a no-op and can be removed.
+- **Prefer `~/.claude/bin/bd-push-safe` over bare `bd dolt push`**: the shim at `~/.claude/bin/bd-push-safe` strips the cache hooks that `bd init` / `bd bootstrap` re-create from `init.templatedir`. On machines where dotfiles git-templates invoke the pre-commit framework, bare `bd dolt push` fails with `fatal: this operation must be run in a work tree`; `~/.claude/bin/bd-push-safe` is a drop-in replacement that just works. **Always use the absolute path** — `~/.claude/bin/` is not on `PATH` on every machine, so bare `bd-push-safe` will trigger a permission prompt and then fail with "command not found". Tracked upstream as `agentic-coding-config-o5w`; once that lands the shim becomes a no-op and can be removed.
 
 ## Commit & PR Style
 

--- a/home/settings.json
+++ b/home/settings.json
@@ -39,6 +39,8 @@
       "Bash(diff *)",
       "Bash(dig *)",
       "Bash(dolt *)",
+      "Bash(~/.claude/bin/bd-push-safe)",
+      "Bash(~/.claude/bin/bd-push-safe *)",
       "Bash(~/.claude/bin/end-session-*)",
       "Bash(~/.claude/bin/start-session-*)",
       "Bash(/Applications/draw.io.app/Contents/MacOS/draw.io *)",

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -11,6 +11,22 @@ changing permission rules, update both files together.
 - `Bash(bd *)`
 - `Bash(beads *)`
 
+The `bd-push-safe` shim at `~/.claude/bin/bd-push-safe` is a drop-in
+replacement for `bd dolt push` that strips the cache hooks `bd init` /
+`bd bootstrap` re-create from `init.templatedir`. On machines whose
+dotfiles git-templates invoke the pre-commit framework, bare
+`bd dolt push` fails with `fatal: this operation must be run in a work
+tree`; the shim makes it just work. Tracked upstream as
+`agentic-coding-config-o5w`; once that lands the shim becomes a no-op
+and these rules can be removed. `~/.claude/bin/` is **not** currently
+on `PATH`, so only the absolute-path form is auto-approved — if the
+bare-name form is ever needed, add `Bash(bd-push-safe)` /
+`Bash(bd-push-safe *)` then. The companion entries live in the
+`~/.claude/bin/` cluster alongside the session-lifecycle scripts.
+
+- `Bash(~/.claude/bin/bd-push-safe)`
+- `Bash(~/.claude/bin/bd-push-safe *)`
+
 ### BigQuery (read-only metadata)
 
 `bq query` is **not** auto-approved — its `--use_legacy_sql=false` flag


### PR DESCRIPTION
## Summary

Two coupled changes that together stop the recurring permission-prompt-then-fail loop for the `bd-push-safe` shim:

1. **Add global allow rules** for `~/.claude/bin/bd-push-safe` (exact + with args) so Claude can invoke it without prompting. Mirrors the `go mod tidy` / `go mod tidy *` exact+wildcard precedent.
2. **Update `home/CLAUDE.md`** to refer to the shim by its absolute path, with an explicit note that `~/.claude/bin/` is **not** on `PATH` on every machine. The previous wording told Claude to invoke bare `bd-push-safe`, which prompted, was approved, then failed at the shell with "command not found" — wasting the approval and falling back to the broken bare `bd dolt push` the shim was meant to avoid.

## Why one PR

Single root concern: "make `bd-push-safe` just work without prompts." Splitting these would leave one half ineffective — if only the allow rule lands, Claude still tries bare `bd-push-safe` per global advice and the rule never matches; if only the advice fix lands, the absolute-path form still needs first-time approval.

## Refs

Closes `agentic-coding-config-gba` (allow rule)
Closes `agentic-coding-config-dci` (advice fix)

## Test plan

- [ ] Apply via chezmoi (or wait for the user's next apply); confirm `~/.claude/settings.json` and `~/.claude/CLAUDE.md` reflect the new content
- [ ] In a fresh session, observe that `~/.claude/bin/bd-push-safe` runs without a permission prompt
- [ ] Confirm `bd dolt push` no longer trips the `init.templatedir` cache-hooks issue when the shim is used per the updated guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)