### PR TITLE
docs(claude): direct ~/.claude edits forbidden; raise GH issue against a-c-c

### DIFF
--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -15,6 +15,12 @@
 - Before pushing follow-up commits to a PR branch, always check the PR is still open via `mcp__github__pull_request_read` (method: "get"). The user often reviews and merges PRs via the GitHub UI while work continues — if already merged, create a new branch and PR instead
 - When multiple related changes span different concerns, ask the user whether to use one branch or separate branches before committing
 
+## Agent Config (`~/.claude/` files)
+
+- **`~/.claude/` is chezmoi-managed from `pmgledhill102/agentic-coding-config`.** Do not edit these files directly — chezmoi will overwrite on the next apply and the change is lost. This includes `~/.claude/CLAUDE.md` itself, `~/.claude/settings.json`, slash commands under `~/.claude/commands/`, hooks, scripts under `~/.claude/bin/`, everything sourced from the `home/` directory of that repo.
+- **To request a change, open a GitHub issue against `pmgledhill102/agentic-coding-config`** (auto-approved via `gh issue create --repo pmgledhill102/*` — keep `--repo` as the first flag for the allow rule to match). Describe what should change and why; add acceptance criteria if useful. The user sweeps the GH-issue inbox into beads via `/bd-import-github-issues` at the start of a-c-c sessions and addresses tickets there, where the chezmoi source actually lives.
+- **Do not reach across repos to make the edit yourself.** Cross-repo file edits (e.g. `cd ~/dev/agentic-coding-config && edit home/...` from a session in another project) bypass the issue queue, skip the review/PR flow, and pollute the current session's context with unrelated work. Leave a message; don't reach across.
+
 ## Beads (bd)
 
 - **Prefer `bd-push-safe` over bare `bd dolt push`**: the shim at `~/.claude/bin/bd-push-safe` strips the cache hooks that `bd init` / `bd bootstrap` re-create from `init.templatedir`. On machines where dotfiles git-templates invoke the pre-commit framework, bare `bd dolt push` fails with `fatal: this operation must be run in a work tree`; `bd-push-safe` is a drop-in replacement that just works. Tracked upstream as `agentic-coding-config-o5w`; once that lands the shim becomes a no-op and can be removed.


### PR DESCRIPTION
## Summary

Adds a new section to `home/CLAUDE.md` (renders to `~/.claude/CLAUDE.md`, applies globally) telling agents:

1. `~/.claude/` is chezmoi-managed — do not edit those files directly (they'll be overwritten)
2. To request a change, open a GH issue against `pmgledhill102/agentic-coding-config` (already auto-approved)
3. Don't reach across repos to back-channel-edit the source

## Why

Today's audit traced "stranded" content in `~/.claude/CLAUDE.md` to an unmerged branch (`feat/process-rules-pr-stacking-cli-flags`) — chezmoi-applied while that branch was checked out, but main never caught up. Nothing was actually lost that time, but a related failure mode is real: an agent in `paul-context`/`dotfiles`/anywhere discovers something that should change in `~/.claude/` and either:

- **Edits the rendered file directly** → next chezmoi apply overwrites; change is silently lost
- **Reaches across repos to edit the source** → bypasses the issue queue, mixes contexts, no PR review

The user already designed a clean cross-repo message-box: GH issues against `agentic-coding-config`, swept into beads via `/bd-import-github-issues` at session start, addressed in a proper a-c-c session. But the convention was undocumented in the global instructions Claude actually reads.

## Refs

Closes `agentic-coding-config-pmo`

## Test plan

- [ ] Apply via chezmoi; confirm the new section renders into `~/.claude/CLAUDE.md`
- [ ] In a future session in any other repo, observe that when the agent identifies a desired Claude-config change, it raises a GH issue rather than editing `~/.claude/` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)