### PR TITLE
Adopt GitHub Issues for work tracking + deterministic beads migration script

### DIFF
--- a/adrs/0013-github-issues-for-work-tracking.md
+++ b/adrs/0013-github-issues-for-work-tracking.md
@@ -1,0 +1,73 @@
+# ADR-0013: GitHub Issues replaces beads for work tracking
+
+- **Status**: Accepted (2026-07-14)
+- **Date**: 2026-07-14
+- **Tags**: workflow, tooling, issue-tracking
+
+## Context
+
+Beads (`bd`) has been the issue tracker across repos since January 2026.
+It works, but its weight is disproportionate for solo hobby projects:
+a ~45 MB binary, an embedded Dolt database per repo, schema migrations
+that require a "designated migrator" machine, git hooks that conflict
+with the pre-commit framework (the `bd-push-safe` shim exists solely to
+work around this), and sync failures that block work — during the
+research session itself, `bd create` refused to run pending four
+unreconciled schema migrations. Beads' sweet spot is fleets of parallel
+agents (Gas Town); ours is one human plus one agent.
+
+Research (2026-07-13, tracked in issue
+[#49](https://github.com/pmgledhill102/agentic-coding-config/issues/49))
+compared GitHub Issues, Backlog.md, Linear, beads_rust, and git-bug
+against the actual requirements: repo-scoped tracking with history,
+Epic→Feature→Task hierarchy, dependencies, priorities, multi-machine
+sync, and agent ergonomics. Key findings:
+
+- GitHub shipped the previously missing pieces: sub-issues (GA Apr 2025,
+  8 levels deep), native blocked-by/blocking dependencies (GA Aug 2025),
+  and first-class `gh` CLI flags for both (v2.94.0, Jun 2026). All were
+  verified working on this personal account's repos.
+- The rumoured responsiveness problems do not bite a solo dev with one
+  agent. Measured API latency is 0.26–0.57 s per call; rate limits only
+  affect bulk migrations and tight polling loops. The one real hazard is
+  the eventually consistent **search** API — mitigated by using
+  strongly consistent direct reads (`gh issue list`, `GET` by number).
+- The industry converged on issue trackers as the agent task queue:
+  issues are now assignable to Copilot, Claude, and Codex on github.com,
+  so this choice compounds rather than dead-ends.
+- Claude Code has no built-in persistent tracker; its documented pattern
+  is an external tracker via MCP — which is already connected.
+
+## Decision
+
+Adopt GitHub Issues as the work tracker for all personal repos,
+replacing beads. Conventions live in
+[docs/github-issues-workflow.md](../docs/github-issues-workflow.md);
+per-repo migration follows
+[docs/beads-migration-runbook.md](../docs/beads-migration-runbook.md)
+using the deterministic `home/bin/bd-migrate-to-github` script.
+
+Summary of the conventions:
+
+- Hierarchy via **sub-issues**: epic → feature → task.
+- Priority via labels **P0–P4** (issue types and Priority fields are
+  org-only; labels are the personal-account mechanism).
+- Type via labels (`type: epic|feature|task|bug`).
+- Dependencies via native **blocked-by** relationships.
+- Agents use `gh issue list` / direct reads, never `gh search issues`,
+  for anything time-sensitive.
+
+## Consequences
+
+- The beads integration in this repo (bd `prime` hooks, `bd-*` commands,
+  `bd-push-safe`, permission allowlist entries, `.beads/` workspaces)
+  retires once migration is proven — tracked as follow-up work under
+  issue #49, deliberately separate from this decision.
+- Work tracking now requires network access. Accepted: offline operation
+  was explicitly not a requirement.
+- Ticket data lives in GitHub rather than in-repo. History is preserved
+  via the issue timeline (stronger than beads' history) but is no longer
+  cloned with the repo.
+- `bd remember` memories are not carried to GitHub Issues; the migration
+  script exports them to a markdown file for manual triage into
+  CLAUDE.md or auto-memory.

--- a/docs/beads-migration-runbook.md
+++ b/docs/beads-migration-runbook.md
@@ -1,0 +1,91 @@
+# Beads → GitHub Issues migration runbook
+
+Per-repo procedure for migrating a beads (`bd`) database to GitHub
+Issues using `home/bin/bd-migrate-to-github` (deployed to
+`~/.claude/bin/` via chezmoi). One repo at a time; each repo is
+independent.
+
+## What the script guarantees
+
+- **Deterministic**: issues are created in `(created_at, id)` order, so
+  the same export always produces the same numbering.
+- **Idempotent / resumable**: every completed step is recorded in
+  `.beads/github-migration-state.json` immediately. Interrupt it, hit a
+  rate limit, lose the network — re-running skips completed work and
+  continues. It never re-creates an issue it has already created.
+- **Rate-limit aware**: mutating calls are paced (default 2 s apart)
+  and retried with exponential backoff + jitter, honouring
+  `Retry-After` on 403/429/5xx.
+- **Eventual-consistency aware**: it never touches the search API.
+  Verification uses direct GETs by issue number (strongly consistent);
+  linking freshly created issues retries briefly on 404.
+- **Dry-run by default**: without `--apply` it prints the full plan and
+  writes nothing.
+
+What it migrates: title, description, notes, open/closed state,
+priority (P0–P4 labels), type (`type: *` labels), a `beads-import`
+label, hierarchy (`parent-child` → sub-issues), dependencies (`blocks`
+→ blocked-by), supersedes edges (cross-reference comment), and a
+provenance footer with the original bd id and timestamps. `bd remember`
+memories are written to `.beads/memories-export.md` for manual triage —
+they do not become issues.
+
+What it does not migrate: comment threads (beads comments are rare in
+these repos; check `comment_count` in the export before migrating a
+repo where they matter), assignees, and in-progress status
+(`in_progress` issues arrive as open — re-claim by assigning yourself).
+
+## Procedure
+
+```bash
+cd <repo>
+
+# 1. Preflight
+gh auth status                      # authenticated, repo scope
+bd export --all -o .beads/migration-export.jsonl   # works read-only even
+                                    # when schema migrations block writes
+
+# 2. Dry run — review the full plan
+~/.claude/bin/bd-migrate-to-github --export .beads/migration-export.jsonl
+
+# 3. Apply (paced; ~2s per write — a 40-issue repo takes ~3-4 minutes)
+~/.claude/bin/bd-migrate-to-github --export .beads/migration-export.jsonl --apply
+
+# 4. If it fails partway: fix the cause and re-run the same command.
+#    The state file resumes exactly where it stopped.
+```
+
+The run ends with a verification pass (direct reads: state, labels,
+sub-issue links, blocked-by links) and exits non-zero listing any
+mismatches. Nothing is deleted on failure — re-run to converge.
+
+## Post-migration checklist (per repo)
+
+1. Triage `.beads/memories-export.md` into the repo's CLAUDE.md or
+   auto-memory, then delete it.
+2. Remove the beads workspace and its git hooks: `rm -rf .beads/`
+   (keep `migration-export.jsonl` and the state file somewhere first if
+   you want an audit copy — e.g. attach them to the migration PR).
+3. Strip the `BEADS INTEGRATION` blocks from `CLAUDE.md` / `AGENTS.md`
+   and replace with a pointer to
+   [docs/github-issues-workflow.md](github-issues-workflow.md)
+   conventions.
+4. Spot-check in the UI: one epic shows its sub-issue tree; one blocked
+   issue shows the blocked icon.
+
+## Rollback
+
+The beads database is untouched by migration (the script only reads the
+export). Until `.beads/` is deleted in step 2 of the checklist, rolling
+back means closing the created GitHub issues (they all carry the
+`beads-import` label: `gh issue list --label beads-import`) and
+carrying on with bd.
+
+## Global cleanup (once all repos are migrated)
+
+Tracked as follow-up work under
+[#49](https://github.com/pmgledhill102/agentic-coding-config/issues/49):
+retire the `bd prime` hooks, `bd-*` commands, `bd-push-safe`, and the
+`bd`/`beads`/`dolt` permission allowlist entries from `home/`; update
+`/start-session`, `/end-session`, `/retrospective`, and `/repo-review`
+to target GitHub Issues.

--- a/docs/github-issues-workflow.md
+++ b/docs/github-issues-workflow.md
@@ -1,0 +1,79 @@
+# GitHub Issues workflow
+
+How work is tracked in personal repos, replacing beads
+(see [ADR-0013](../adrs/0013-github-issues-for-work-tracking.md)).
+
+## Structure
+
+| Concept | Mechanism | Notes |
+| --- | --- | --- |
+| Epic → Feature → Task | Sub-issues (`--parent`) | Nests up to 8 levels; 100 children per parent |
+| Type | Labels `type: epic\|feature\|task\|bug` | Issue *types* are org-only; labels work everywhere |
+| Priority | Labels `P0`–`P4` | P0 critical … P2 medium … P4 backlog (beads scale) |
+| Dependencies | Native blocked-by (`--blocked-by`) | Max 50 per relationship type; blocked icon in lists |
+| History | Issue timeline | Automatic; includes label/state/relationship events |
+
+## Everyday commands
+
+```bash
+# Epic
+gh issue create --title "Epic: overhaul auth" --label "type: epic,P1" --body "..."
+
+# Feature under the epic (issue 12), task under the feature (issue 15)
+gh issue create --title "Feature: passkey login" --parent 12 --label "type: feature,P2" --body "..."
+gh issue create --title "Add WebAuthn ceremony" --parent 15 --label "type: task,P2" --body "..."
+
+# Dependencies
+gh issue create --title "Wire session storage" --blocked-by 14 --body "..."
+gh issue edit 17 --add-blocked-by 16
+
+# Ready work: open and not directly blocked
+gh issue list --search "is:open -is:blocked" --json number,title,labels
+
+# My active work
+gh issue list --assignee @me --state open
+```
+
+Prefer the GitHub MCP tools (`issue_write`, `sub_issue_write`,
+`issue_read`, `list_issues`) when the MCP server is connected; the `gh`
+commands above are the fallback and the cloud-sandbox option.
+
+## Rules for agents
+
+- **Never use the search API for anything time-sensitive.** `gh search
+  issues` and `/search/issues` are eventually consistent — a
+  just-created issue can be invisible for seconds to minutes. Use
+  `gh issue list` or direct reads (`gh issue view <n>`), which are
+  strongly consistent. Deduplicate against `gh issue list --state all`,
+  not search.
+- **Create an issue before starting work** (same habit as `bd create`),
+  and close it when the work merges: `gh issue close <n> --comment
+  "Shipped in #<pr>"`. Reference the issue from the PR body (`Closes
+  #<n>`) so closure is automatic on merge.
+- **"Ready" is approximate.** `-is:blocked` filters direct blocks only;
+  there is no transitive ready-work query. For a solo backlog this is
+  fine — check the blocked icon before claiming work.
+- **Keep issues small and specific.** Agent-dispatch data
+  (dotnet/runtime, 878 PRs) shows 1–50-line changes succeed at 76–80%
+  vs 64% at 100+ lines. State expected vs actual behaviour and
+  acceptance criteria in the body — the issue is the prompt.
+- **Batch politely.** When creating many issues in a loop, pace writes
+  (~2 s apart). Secondary rate limits allow at most 80 content-creating
+  requests/min, and bursts trigger 403s.
+
+## Label bootstrap
+
+New repos need the label set once (idempotent):
+
+```bash
+for l in "P0:b60205" "P1:d93f0b" "P2:fbca04" "P3:0e8a16" "P4:c5def5"; do
+  gh label create "${l%%:*}" --color "${l##*:}" --force
+done
+for t in epic feature task bug; do
+  gh label create "type: $t" --color 1d76db --force
+done
+```
+
+`/setup-repo` is the natural home for this — tracked in
+[#49](https://github.com/pmgledhill102/agentic-coding-config/issues/49)
+follow-ups.

--- a/home/bin/bd-migrate-to-github
+++ b/home/bin/bd-migrate-to-github
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""Migrate a beads (bd) database to GitHub Issues, deterministically.
+
+Reads a `bd export --all` JSONL file and recreates the issues in a GitHub
+repository, preserving:
+
+  - hierarchy   : beads `parent-child` dependencies -> GitHub sub-issues
+  - dependencies: beads `blocks` dependencies       -> GitHub "blocked by"
+  - supersedes  : beads `supersedes` dependencies   -> cross-reference comment
+  - priority    : beads 0-4                         -> labels P0-P4
+  - type        : beads issue_type                  -> labels `type: <t>`
+  - status      : open/closed (+ provenance footer with original timestamps)
+  - memories    : `bd remember` records             -> markdown file for triage
+
+Design constraints (see docs/beads-migration-runbook.md):
+
+  - Deterministic: issues are created in (created_at, id) order, so repeated
+    runs against the same export produce the same numbering.
+  - Idempotent: every completed step is recorded in a state file immediately;
+    re-runs skip completed work. Safe to interrupt and resume.
+  - Rate-limit aware: mutating calls are paced (default 2s apart, ~30/min,
+    well under GitHub's 80 content-creating requests/min secondary limit) and
+    retried with exponential backoff + jitter, honoring Retry-After.
+  - Eventual-consistency aware: never uses the search API. Verification uses
+    direct GETs by issue number (strongly consistent). Linking of freshly
+    created issues retries briefly on 404.
+  - Dry-run by default: pass --apply to write anything.
+
+Requires: python3 (stdlib only) and an authenticated `gh` CLI for the token.
+"""
+
+import argparse
+import json
+import os
+import random
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_ROOT = "https://api.github.com"
+API_VERSION = "2022-11-28"
+
+PRIORITY_LABELS = {
+    0: ("P0", "b60205", "Critical"),
+    1: ("P1", "d93f0b", "High"),
+    2: ("P2", "fbca04", "Medium"),
+    3: ("P3", "0e8a16", "Low"),
+    4: ("P4", "c5def5", "Backlog"),
+}
+TYPE_LABEL_COLOR = "1d76db"
+IMPORT_LABEL = ("beads-import", "ededed", "Migrated from beads")
+
+RETRYABLE_STATUSES = {403, 429, 500, 502, 503, 504}
+LINK_NOT_FOUND_RETRIES = 5  # 404s right after creation: consistency guard
+
+
+class ApiError(Exception):
+    def __init__(self, status, body, url):
+        super().__init__(f"HTTP {status} for {url}: {body[:300]}")
+        self.status = status
+
+
+class GitHub:
+    """Minimal GitHub REST client with pacing, retries and backoff."""
+
+    def __init__(self, token, repo, write_interval, max_retries):
+        self.token = token
+        self.repo = repo
+        self.write_interval = write_interval
+        self.max_retries = max_retries
+        self._last_write = 0.0
+
+    def _request(self, method, path, payload):
+        url = f"{API_ROOT}/repos/{self.repo}{path}"
+        data = json.dumps(payload).encode() if payload is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", f"Bearer {self.token}")
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("X-GitHub-Api-Version", API_VERSION)
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = resp.read().decode()
+                return resp.status, dict(resp.headers), body
+        except urllib.error.HTTPError as e:
+            return e.code, dict(e.headers or {}), e.read().decode()
+
+    def call(self, method, path, payload=None, not_found_retries=0):
+        """Perform a request with pacing (writes) and retry/backoff."""
+        mutating = method in ("POST", "PATCH", "PUT", "DELETE")
+        attempt = 0
+        nf_attempt = 0
+        while True:
+            if mutating:
+                wait = self._last_write + self.write_interval - time.monotonic()
+                if wait > 0:
+                    time.sleep(wait)
+            status, headers, body = self._request(method, path, payload)
+            if mutating:
+                self._last_write = time.monotonic()
+            if status < 300:
+                return json.loads(body) if body.strip() else {}
+            if status == 404 and nf_attempt < not_found_retries:
+                nf_attempt += 1
+                delay = min(2.0 * (2 ** (nf_attempt - 1)), 30.0)
+                log(f"  404 (may be consistency lag), retry {nf_attempt}/"
+                    f"{not_found_retries} in {delay:.0f}s: {path}")
+                time.sleep(delay)
+                continue
+            if status in RETRYABLE_STATUSES and attempt < self.max_retries:
+                attempt += 1
+                delay = min(2.0 * (2 ** (attempt - 1)), 60.0)
+                delay *= random.uniform(0.75, 1.25)
+                retry_after = headers.get("Retry-After") or headers.get("retry-after")
+                if retry_after:
+                    try:
+                        delay = max(delay, float(retry_after))
+                    except ValueError:
+                        pass
+                log(f"  HTTP {status}, retry {attempt}/{self.max_retries} "
+                    f"in {delay:.0f}s: {method} {path}")
+                time.sleep(delay)
+                continue
+            raise ApiError(status, body, path)
+
+    def paginate(self, path):
+        results = []
+        page = 1
+        while True:
+            sep = "&" if "?" in path else "?"
+            batch = self.call("GET", f"{path}{sep}per_page=100&page={page}")
+            results.extend(batch)
+            if len(batch) < 100:
+                return results
+            page += 1
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def gh_output(args):
+    try:
+        return subprocess.run(
+            ["gh"] + args, capture_output=True, text=True, check=True
+        ).stdout.strip()
+    except FileNotFoundError:
+        die("gh CLI not found on PATH; it is required for authentication")
+    except subprocess.CalledProcessError as e:
+        die(f"gh {' '.join(args)} failed: {e.stderr.strip()}")
+
+
+def load_export(path):
+    issues, memories = [], []
+    with open(path, encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as e:
+                die(f"{path}:{line_no}: invalid JSON ({e})")
+            kind = row.get("_type")
+            if kind == "issue":
+                if not row.get("id") or not row.get("title"):
+                    die(f"{path}:{line_no}: issue record missing id/title")
+                issues.append(row)
+            elif kind == "memory":
+                memories.append(row)
+    issues.sort(key=lambda r: (r.get("created_at") or "", r["id"]))
+    return issues, memories
+
+
+def load_state(path):
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    return {"issues": {}, "links": {}, "closed": {}, "commented": {}}
+
+
+def save_state(path, state):
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+    os.replace(tmp, path)
+
+
+def wanted_labels(issue):
+    labels = [IMPORT_LABEL[0]]
+    if issue.get("priority") in PRIORITY_LABELS:
+        labels.append(PRIORITY_LABELS[issue["priority"]][0])
+    if issue.get("issue_type"):
+        labels.append(f"type: {issue['issue_type']}")
+    return labels
+
+
+def issue_body(issue):
+    parts = []
+    if issue.get("description"):
+        parts.append(issue["description"].rstrip())
+    if issue.get("notes"):
+        parts.append("## Notes\n\n" + issue["notes"].rstrip())
+    prov = [f"Migrated from beads `{issue['id']}`"]
+    if issue.get("created_at"):
+        prov.append(f"created {issue['created_at']}")
+    if issue.get("closed_at"):
+        prov.append(f"closed {issue['closed_at']}")
+    if issue.get("close_reason"):
+        prov.append(f"close reason: {issue['close_reason']}")
+    parts.append("---\n" + ", ".join(prov) + ".")
+    return "\n\n".join(parts)
+
+
+def collect_edges(issues):
+    """Return (parent_child, blocks, supersedes) as (issue_id, other_id) pairs.
+
+    beads edge semantics: {issue_id: X, depends_on_id: Y} means X depends on Y.
+      parent-child: Y is X's parent.
+      blocks:       X is blocked by Y.
+      supersedes:   X is superseded by Y (old depends on new).
+    """
+    ids = {i["id"] for i in issues}
+    parent_child, blocks, supersedes, dangling = [], [], [], []
+    for issue in issues:
+        for dep in issue.get("dependencies") or []:
+            pair = (dep["issue_id"], dep["depends_on_id"])
+            if pair[0] not in ids or pair[1] not in ids:
+                dangling.append((dep.get("type"), pair))
+                continue
+            if dep.get("type") == "parent-child":
+                parent_child.append(pair)
+            elif dep.get("type") == "blocks":
+                blocks.append(pair)
+            elif dep.get("type") == "supersedes":
+                supersedes.append(pair)
+    return sorted(set(parent_child)), sorted(set(blocks)), \
+        sorted(set(supersedes)), dangling
+
+
+def write_memories(memories, path, dry_run):
+    if not memories:
+        return
+    lines = ["# Memories exported from beads", ""]
+    for m in sorted(memories, key=lambda m: m.get("key") or ""):
+        lines.append(f"## {m.get('key', '(no key)')}")
+        lines.append("")
+        lines.append(m.get("value", "").rstrip())
+        lines.append("")
+    if dry_run:
+        log(f"[dry-run] would write {len(memories)} memories to {path}")
+        return
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    log(f"wrote {len(memories)} memories to {path}")
+
+
+def ensure_labels(gh, needed, dry_run):
+    existing = {l["name"] for l in gh.paginate("/labels")}
+    catalogue = {IMPORT_LABEL[0]: IMPORT_LABEL}
+    for name, color, desc in PRIORITY_LABELS.values():
+        catalogue[name] = (name, color, desc)
+    for name in sorted(needed):
+        if name in existing:
+            continue
+        _, color, desc = catalogue.get(
+            name, (name, TYPE_LABEL_COLOR, "Issue type (migrated from beads)"))
+        if dry_run:
+            log(f"[dry-run] would create label {name}")
+            continue
+        gh.call("POST", "/labels",
+                {"name": name, "color": color, "description": desc})
+        log(f"created label {name}")
+
+
+def verify(gh, issues, state, parent_child, blocks):
+    failures = []
+    for issue in issues:
+        rec = state["issues"].get(issue["id"])
+        if not rec:
+            failures.append(f"{issue['id']}: never created")
+            continue
+        live = gh.call("GET", f"/issues/{rec['number']}")
+        expect_state = "closed" if issue.get("status") == "closed" else "open"
+        if live.get("state") != expect_state:
+            failures.append(f"{issue['id']}: #{rec['number']} state "
+                            f"{live.get('state')} != {expect_state}")
+        live_labels = {l["name"] for l in live.get("labels", [])}
+        missing = set(wanted_labels(issue)) - live_labels
+        if missing:
+            failures.append(
+                f"{issue['id']}: #{rec['number']} missing labels {missing}")
+    by_parent = {}
+    for child, parent in parent_child:
+        by_parent.setdefault(parent, set()).add(child)
+    for parent, children in sorted(by_parent.items()):
+        p = state["issues"].get(parent)
+        subs = {s["number"]
+                for s in gh.paginate(f"/issues/{p['number']}/sub_issues")}
+        for child in children:
+            c = state["issues"].get(child)
+            if not c or c["number"] not in subs:
+                failures.append(f"sub-issue link missing: {child} under {parent}")
+    for blocked, blocker in blocks:
+        b = state["issues"].get(blocked)
+        blockers = {x["number"] for x in gh.paginate(
+            f"/issues/{b['number']}/dependencies/blocked_by")}
+        if state["issues"].get(blocker, {}).get("number") not in blockers:
+            failures.append(f"blocked-by link missing: {blocked} <- {blocker}")
+    return failures
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Migrate a beads export to GitHub Issues (dry-run by "
+                    "default; pass --apply to write).")
+    ap.add_argument("--repo", help="owner/name (default: current repo via gh)")
+    ap.add_argument("--export", dest="export_path",
+                    help="bd export JSONL (default: run `bd export --all`)")
+    ap.add_argument("--state", default=".beads/github-migration-state.json",
+                    help="state file for idempotent resume")
+    ap.add_argument("--memories-out", default=".beads/memories-export.md",
+                    help="where to write exported bd memories")
+    ap.add_argument("--write-interval", type=float, default=2.0,
+                    help="minimum seconds between mutating API calls")
+    ap.add_argument("--max-retries", type=int, default=5)
+    ap.add_argument("--apply", action="store_true",
+                    help="actually create issues (otherwise dry-run)")
+    ap.add_argument("--skip-verify", action="store_true",
+                    help="skip the post-migration verification pass")
+    args = ap.parse_args()
+    dry_run = not args.apply
+
+    repo = args.repo or gh_output(
+        ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+    if "/" not in repo:
+        die(f"could not resolve repository (got {repo!r}); pass --repo")
+
+    export_path = args.export_path
+    if not export_path:
+        export_path = os.path.join(".beads", "migration-export.jsonl")
+        log(f"exporting beads database to {export_path}")
+        gh_dir = os.path.dirname(export_path)
+        if gh_dir and not os.path.isdir(gh_dir):
+            die("no .beads/ directory here; run from the repo root or pass "
+                "--export")
+        result = subprocess.run(
+            ["bd", "export", "--all", "-o", export_path],
+            capture_output=True, text=True)
+        if result.returncode != 0 or not os.path.exists(export_path):
+            die(f"bd export failed: {result.stderr.strip()[:300]}")
+
+    issues, memories = load_export(export_path)
+    parent_child, blocks, supersedes, dangling = collect_edges(issues)
+    log(f"repo={repo} issues={len(issues)} memories={len(memories)} "
+        f"parent-child={len(parent_child)} blocks={len(blocks)} "
+        f"supersedes={len(supersedes)}"
+        + (" (DRY RUN)" if dry_run else ""))
+    for kind, pair in dangling:
+        log(f"warning: skipping dangling {kind} edge {pair[0]} -> {pair[1]}")
+
+    state = load_state(args.state)
+    token = None if dry_run else gh_output(["auth", "token"])
+    gh = None if dry_run else GitHub(
+        token, repo, args.write_interval, args.max_retries)
+
+    write_memories(memories, args.memories_out, dry_run)
+
+    needed_labels = set()
+    for issue in issues:
+        needed_labels.update(wanted_labels(issue))
+    if dry_run:
+        log(f"[dry-run] labels needed: {sorted(needed_labels)}")
+    else:
+        ensure_labels(gh, needed_labels, dry_run)
+
+    # Phase 1: create issues in deterministic order.
+    for issue in issues:
+        if issue["id"] in state["issues"]:
+            continue
+        labels = wanted_labels(issue)
+        if dry_run:
+            log(f"[dry-run] create: {issue['id']} \"{issue['title']}\" "
+                f"labels={labels} status={issue.get('status')}")
+            continue
+        created = gh.call("POST", "/issues", {
+            "title": issue["title"],
+            "body": issue_body(issue),
+            "labels": labels,
+        })
+        state["issues"][issue["id"]] = {
+            "number": created["number"], "id": created["id"]}
+        save_state(args.state, state)
+        log(f"created #{created['number']} <- {issue['id']} "
+            f"\"{issue['title']}\"")
+
+    # Phase 2: hierarchy (child depends_on parent -> sub-issue of parent).
+    for child, parent in parent_child:
+        key = f"sub:{child}"
+        if state["links"].get(key):
+            continue
+        if dry_run:
+            log(f"[dry-run] sub-issue: {child} under {parent}")
+            continue
+        c, p = state["issues"][child], state["issues"][parent]
+        gh.call("POST", f"/issues/{p['number']}/sub_issues",
+                {"sub_issue_id": c["id"]},
+                not_found_retries=LINK_NOT_FOUND_RETRIES)
+        state["links"][key] = True
+        save_state(args.state, state)
+        log(f"linked #{c['number']} as sub-issue of #{p['number']}")
+
+    # Phase 3: blocks (X depends_on Y -> X blocked by Y).
+    for blocked, blocker in blocks:
+        key = f"dep:{blocked}->{blocker}"
+        if state["links"].get(key):
+            continue
+        if dry_run:
+            log(f"[dry-run] blocked-by: {blocked} blocked by {blocker}")
+            continue
+        b, k = state["issues"][blocked], state["issues"][blocker]
+        gh.call("POST", f"/issues/{b['number']}/dependencies/blocked_by",
+                {"issue_id": k["id"]},
+                not_found_retries=LINK_NOT_FOUND_RETRIES)
+        state["links"][key] = True
+        save_state(args.state, state)
+        log(f"marked #{b['number']} blocked by #{k['number']}")
+
+    # Phase 4: supersedes -> cross-reference comment (GitHub backlinks it).
+    for older, newer in supersedes:
+        key = f"sup:{older}->{newer}"
+        if state["commented"].get(key):
+            continue
+        if dry_run:
+            log(f"[dry-run] comment: {older} superseded by {newer}")
+            continue
+        o, n = state["issues"][older], state["issues"][newer]
+        gh.call("POST", f"/issues/{o['number']}/comments",
+                {"body": f"Superseded by #{n['number']} "
+                         f"(beads `{newer}` superseded `{older}`)."},
+                not_found_retries=LINK_NOT_FOUND_RETRIES)
+        state["commented"][key] = True
+        save_state(args.state, state)
+        log(f"commented superseded-by on #{o['number']} -> #{n['number']}")
+
+    # Phase 5: close issues that were closed in beads (after linking, so
+    # sub-issue/dependency creation never races a closed parent).
+    for issue in issues:
+        if issue.get("status") != "closed":
+            continue
+        if state["closed"].get(issue["id"]):
+            continue
+        if dry_run:
+            log(f"[dry-run] close: {issue['id']}")
+            continue
+        rec = state["issues"][issue["id"]]
+        gh.call("PATCH", f"/issues/{rec['number']}",
+                {"state": "closed", "state_reason": "completed"})
+        state["closed"][issue["id"]] = True
+        save_state(args.state, state)
+        log(f"closed #{rec['number']} ({issue['id']})")
+
+    if dry_run:
+        log("dry run complete; re-run with --apply to migrate")
+        return
+
+    # Phase 6: verify via strongly consistent direct reads (never search).
+    if args.skip_verify:
+        log("verification skipped (--skip-verify)")
+        return
+    log("verifying via direct reads...")
+    failures = verify(gh, issues, state, parent_child, blocks)
+    if failures:
+        for f in failures:
+            log(f"VERIFY FAIL: {f}")
+        die(f"verification failed for {len(failures)} item(s); state file "
+            f"{args.state} is intact — fix and re-run to resume")
+    log(f"verification passed: {len(issues)} issues, "
+        f"{len(parent_child)} sub-issue links, {len(blocks)} dependencies")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the deliverables of #49 (research: 13 Jul 2026 session).

## What's here

- **ADR-0013** — the decision: GitHub Issues replaces beads for work tracking, with the evidence summarized (sub-issues/dependencies verified on personal repos; responsiveness concerns measured and mitigable; industry convergence on issues-as-agent-task-queue).
- **`docs/github-issues-workflow.md`** — the way of working: sub-issue hierarchy (Epic→Feature→Task), P0–P4 priority labels, `type: *` labels, native blocked-by dependencies, ready-work queries, and agent rules (notably: never the search API for time-sensitive reads — it's eventually consistent; `gh issue list`/direct GETs are strongly consistent).
- **`docs/beads-migration-runbook.md`** — per-repo procedure, post-migration checklist, rollback story.
- **`home/bin/bd-migrate-to-github`** — deterministic migrator (Python 3, stdlib only, auth via `gh auth token`):
  - creation in `(created_at, id)` order → reproducible numbering
  - idempotent resume: every step recorded in a state file immediately (atomic write); interrupt/re-run safe
  - paced writes (default 2 s ≈ 30/min, under the 80/min content-creation secondary limit); exponential backoff + jitter on 403/429/5xx honouring `Retry-After`
  - eventual-consistency aware: no search API anywhere; verification via direct GETs; brief 404-retry when linking freshly created issues
  - migrates hierarchy (`parent-child` → sub-issues, using **global issue IDs** as the API requires), `blocks` → blocked-by, `supersedes` → cross-reference comment, priority/type → labels, closed state; exports `bd remember` memories to markdown for triage
  - dry-run by default; `--apply` to execute; ends with a verification pass that exits non-zero on any mismatch

## Testing

- `py_compile` clean; markdownlint clean on the three new docs.
- Dry-run validated against this repo's real `bd export --all` (40 issues, 4 parent-child edges, 1 blocks, 1 supersedes, 3 memories) — full plan output reviewed; a supersedes edge-direction bug was caught this way and fixed (beads stores old→new, matching the `6mp`/`e0o` ground truth in our data).
- `--apply` has deliberately **not** been run: actually migrating this repo's beads database is follow-up work per the runbook, once this PR is reviewed.

## Out of scope

Retiring bd hooks/commands/permissions from `home/` and updating `/start-session` etc. — listed as follow-ups in the runbook and #49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcFkDPHNuzFjuAmxC5pteK