### PR TITLE
Guard /setup-repo label bootstrap against established taxonomies

### DIFF
--- a/home/commands/setup-repo.md
+++ b/home/commands/setup-repo.md
@@ -85,6 +85,12 @@ Warning: Default branch is 'master'. Consider renaming to 'main':
 
 ### 7. Work-tracking labels
 
+**Guard: skip this step in repos with an established label taxonomy.** Run
+`gh label list` first — if the repo already has a purposeful labelling scheme
+(e.g. `lifeos`, whose `kind:`/`effort:`/`area:`/`list:` labels are a format
+contract parsed by its mobile apps), do NOT add the standard set; the local
+taxonomy is authoritative. Only bootstrap repos with default/no labels.
+
 Create the standard work-tracking label set (see `agentic-coding-config`
 `docs/github-issues-workflow.md`). `--force` makes this idempotent —
 existing labels are updated, not duplicated:


### PR DESCRIPTION
The a-c-c half of #101 (the lifeos half is pmgledhill102/lifeos#936): `/setup-repo`'s label-bootstrap step now checks `gh label list` first and skips repos with a purposeful existing scheme — lifeos's labels are a format contract parsed by its mobile apps, so the standard P0–P4/`type:*` set must never be added there.

Closes #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcFkDPHNuzFjuAmxC5pteK