### PR TITLE
fix(permissions): replace dead Write(path) allow rules with Edit(path)

### DIFF
--- a/home/commands/retrospective.md
+++ b/home/commands/retrospective.md
@@ -124,7 +124,7 @@ Wait for explicit confirmation. Don't proceed on ambiguous input.
    - **Resolve same-project same-day collisions** at write-time: if the target already exists, append `-2`, `-3`, … before `.md` until unique. Filesystem path checks `~/dev/paul-context/_incoming/<filename>`; Issue path checks for an open Issue with the same title (rare in practice — same project, same day, same topic — but the suffix prevents silent merge of two distinct retros).
    - **Pick the inbox path:**
      - **Filesystem inbox** (preferred): if `[ -d ~/dev/paul-context/_incoming ] && [ -w ~/dev/paul-context/_incoming ]`, `Write` the journal markdown to `~/dev/paul-context/_incoming/<filename>`. **No git operations against `paul-context`.**
-     - **GitHub Issue fallback** (sandbox / remote VM / no local clone): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Write(/tmp/**)` is auto-allowed), then file as a labeled Issue:
+     - **GitHub Issue fallback** (sandbox / remote VM / no local clone): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Edit(/tmp/**)` is auto-allowed, and `Edit` rules cover the `Write` tool), then file as a labeled Issue:
 
        ```sh
        gh issue create --repo pmgledhill102/paul-context \

--- a/home/settings.json
+++ b/home/settings.json
@@ -321,8 +321,9 @@
       "mcp__google-developer-knowledge__search_documents",
       "Read(~/.claude/retros.md)",
       "Read(~/.claude/settings.json)",
-      "Write(/tmp/**)",
-      "Write(~/dev/paul-context/_incoming/**)"
+      "Edit(/private/tmp/**)",
+      "Edit(/tmp/**)",
+      "Edit(~/dev/paul-context/_incoming/**)"
     ]
   },
   "hooks": {

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -588,26 +588,42 @@ run. Write/Edit access remains gated.
 - `Read(~/.claude/retros.md)`
 - `Read(~/.claude/settings.json)`
 
-### Write permissions (scratch space)
+### File-write permissions (scratch space)
+
+**Use `Edit(path)`, never `Write(path)`.** Path-scoped `Write(...)`
+rules are not consulted by the file permission check at all — only
+`Edit(...)` rules are, and an `Edit` rule covers *every* file-editing
+tool, `Write` included. A `Write(...)` rule is therefore dead config:
+it grants nothing and the CLI prints a warning about it on every
+start. This bit us for months — the two rules below were written as
+`Write(...)`, silently granted nothing, and the resulting prompts were
+misdiagnosed as a `/tmp` symlink problem (see the `/private/tmp` note
+below).
 
 `/tmp` on macOS is per-user, ephemeral, and the standard scratch space —
 nothing durable or shared lives there. The blast radius of allowing
-`Write` is "Claude can scribble in scratch space," which is exactly
+writes is "Claude can scribble in scratch space," which is exactly
 what scratch space is for.
 
 User-level CLAUDE.md forbids heredocs (`cat <<'EOF'`) and ANSI-C
 quoting in bash commands, so any multi-line content for `gh issue
 create --body-file`, `gh pr create --body-file`, etc. has to flow
-through a temp file. Auto-approving `Write(/tmp/**)` removes the
+through a temp file. Auto-approving `Edit(/tmp/**)` removes the
 double-prompt friction (one for the command, one for the temp file)
 that otherwise discourages the structured-body pattern.
 
-- `Write(/tmp/**)` — scratch space for staging long, structured content
+- `Edit(/tmp/**)` — scratch space for staging long, structured content
   (issue bodies, PR bodies, etc.) before passing to a CLI via
   `--body-file` or `$(cat ...)`. Restrict scope further to
-  `Write(/tmp/claude-*)` (with a naming-convention discipline) if the
+  `Edit(/tmp/claude-*)` (with a naming-convention discipline) if the
   broad rule ever feels uncomfortable.
-- `Write(~/dev/paul-context/_incoming/**)` — journal-draft inbox for
+- `Edit(/private/tmp/**)` — the same grant, spelled the way macOS
+  resolves it. `/tmp` is a symlink to `/private/tmp` there, and paths
+  reach the permission check already resolved (the session scratchpad
+  is handed to Claude as `/private/tmp/claude-<uid>/...`), so the
+  `/tmp/**` glob alone can miss. Both spellings are kept: Linux has no
+  such symlink and uses the `/tmp/**` form.
+- `Edit(~/dev/paul-context/_incoming/**)` — journal-draft inbox for
   the cross-repo retrospective skill. Drafts land here and are later
   promoted into `paul-context/journal/` by `/promote-journal-inbox`
   (run from `~/dev/paul-context/`). The directory is `.gitignored` in
@@ -615,7 +631,7 @@ that otherwise discourages the structured-body pattern.
   until promotion — content can't pollute `paul-context`'s git
   history regardless of what gets written. This single user-level
   rule replaces what would otherwise be N per-project
-  `Write(~/dev/paul-context/journal/**)` grants plus git-on-paul-context
+  `Edit(~/dev/paul-context/journal/**)` grants plus git-on-paul-context
   permissions in every project that runs `/end-session`. See
   `paul-context/decisions/2026-05-05-journal-inbox-promotion.md` for
   the full rationale.


### PR DESCRIPTION
Closes #106
Closes #81

## What

Path-scoped `Write(...)` rules are not consulted by the file permission check — only `Edit(...)` rules are, and an `Edit` rule covers *every* file-editing tool, `Write` included. Both entries in `permissions.allow` were dead config: they granted nothing, and the CLI printed a warning about each on every start, in every repo.

```diff
-"Write(/tmp/**)",
-"Write(~/dev/paul-context/_incoming/**)"
+"Edit(/private/tmp/**)",
+"Edit(/tmp/**)",
+"Edit(~/dev/paul-context/_incoming/**)"
```

The noise was the visible symptom; the real cost is that neither grant was in effect. Staging long `--body-file` content in `/tmp` (necessary because user-level CLAUDE.md bans heredocs) and writing journal drafts to `paul-context/_incoming/` for `/promote-journal-inbox` have both been prompting all along, despite being documented as auto-approved.

## #81 folded in

#81 asked for `Write(/private/tmp/**)` because macOS resolves `/tmp` through a symlink. Added as `Edit(/private/tmp/**)` — adding it as `Write(...)` would have landed a third dead rule and a third startup warning.

Worth noting the re-diagnosis: #81 (via #30) attributed the prompting entirely to the symlink, but the dead-rule bug is the larger part of it — `Write(/tmp/**)` would not have matched on Linux either. The symlink concern is still real (this session's own scratchpad is handed over as `/private/tmp/claude-501/...`, i.e. already resolved), so both spellings are kept: Linux has no such symlink and uses the `/tmp/**` form.

## Verification

A/B under a temp `HOME`, same command, same model, only the settings file differing. Settings validation runs before the auth check, so the auth error is a consistent floor in both runs and the warning lines are the only variable:

**Old (`git show HEAD:home/settings.json`):**
```
Permission allow rule (oldhome/.claude/settings.json): Write(/tmp/**) is not matched by file permission checks — only Edit(path) rules are. Use Edit(/tmp/**) instead (Edit rules cover all file-editing tools).
Permission allow rule (oldhome/.claude/settings.json): Write(~/dev/paul-context/_incoming/**) is not matched by file permission checks — only Edit(path) rules are. Use Edit(~/dev/paul-context/_incoming/**) instead (Edit rules cover all file-editing tools).
Not logged in · Please run /login
```

**New (this branch):**
```
Not logged in · Please run /login
```

No warnings. Gates run locally: `markdownlint-cli2` (0 issues), `chezmoi init --dry-run`, JSON parses, and the `settings.json` ↔ `settings.json.md` sync holds.

**Still to confirm after merge, on your side:** that the grants actually fire. That needs `chezmoi apply` plus a CLI restart, since the rules only take effect once deployed to `~/.claude/settings.json`. The check is a `Write` to a plain `/tmp/<file>` path (not the session scratchpad, which is allowed by a separate mechanism) landing without a prompt.

## Also in this PR

- `home/settings.json.md` — section renamed to "File-write permissions (scratch space)", now leads with **use `Edit(path)`, never `Write(path)`** and why, so the mistake doesn't recur. The `/private/tmp` rationale is recorded alongside it.
- `home/commands/retrospective.md:127` — corrected an inline claim that `Write(/tmp/**)` is auto-allowed, which was reinforcing the wrong pattern at the point of use.

## Note

The two `Read(...)` rules are untouched and fine — the CLI warns only about `Write(path)`, and stayed silent on `Read(path)` in both runs above.
