### PR TITLE
fix(setup-skills): golangci v2 schema, working semgrep gate, retire mirrors hooks, no pre-commit install

### DIFF
--- a/home/commands/setup-common.md
+++ b/home/commands/setup-common.md
@@ -47,13 +47,11 @@ repos:
 
 Look up the latest release tag for each repo and use those for the `rev:` values.
 
-After creating/updating the config, run:
-
-```sh
-pre-commit install
-```
+Do **not** run `pre-commit install` — nothing should write to `.git/hooks`. The config file is the source of truth, and it is enforced from two directions: a global Claude Code `PreToolUse` hook runs pre-commit on every `git commit`/`git push` Claude makes, and CI runs `pre-commit run --all-files` on every push. Manual terminal commits are CI-backed. Mention this model in the closing summary so the user knows why no git hook was installed.
 
 If `pre-commit` is not installed, tell the user to install it (`brew install pre-commit`) and stop.
+
+When adding hooks for a tool that is already a project or system dependency (prettier, eslint, golangci-lint, …), prefer a `repo: local` hook invoking the project's own binary over a `pre-commit/mirrors-*` repo — the mirrors pin their own copy of the tool, so the hook and the project can silently run different versions (and several mirrors are archived).
 
 ### 3. cspell (spell checking)
 
@@ -113,12 +111,16 @@ Add a semgrep pre-commit hook to `.pre-commit-config.yaml`:
     rev: <latest tag>
     hooks:
       - id: semgrep
-        args: ['--config', 'auto']
+        args: ["--config", "auto", "--error"]
+        pass_filenames: false
 ```
 
 Look up the latest release tag and use it for the `rev:` value.
 
-The `--config auto` flag uses Semgrep's curated rulesets appropriate for the languages detected in the repo.
+The `--config auto` flag uses Semgrep's curated rulesets appropriate for the languages detected in the repo. The other two lines matter:
+
+- `--error` — semgrep exits 0 on findings by default, so without it the hook always passes and the gate is decorative.
+- `pass_filenames: false` — pre-commit hands hooks explicit filenames, and giving semgrep explicit paths makes it bypass its own default excludes (notably `*_test.go`), reporting findings CI never sees. Scanning the repo instead keeps hook and CI seeing the same thing.
 
 ### 6. .gitignore
 
@@ -155,10 +157,10 @@ Add to `.github/workflows/ci.yml` (or create if needed):
     name: Gitleaks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@<full-sha> # <version>
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@<full-sha> # <version>
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -166,8 +168,8 @@ Add to `.github/workflows/ci.yml` (or create if needed):
     name: Spell Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: streetsidesoftware/cspell-action@v6
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: streetsidesoftware/cspell-action@<full-sha> # <version>
         with:
           files: '**/*.{md,txt,rst,yaml,yml}'
 
@@ -177,11 +179,13 @@ Add to `.github/workflows/ci.yml` (or create if needed):
     container:
       image: semgrep/semgrep
     steps:
-      - uses: actions/checkout@v4
-      - run: semgrep scan --config auto
+      - uses: actions/checkout@<full-sha> # <version>
+      - run: semgrep scan --config auto --error
 ```
 
-Create a separate `.github/workflows/actionlint.yml` with a path filter (or add to existing CI with the same filter):
+(`--error` for the same reason as the hook: without it findings don't fail the job.)
+
+Create a separate `.github/workflows/actionlint.yml` with a path filter (or add to existing CI with the same filter). `rhysd/actionlint` publishes no GitHub Action to pin, so use the official download script rather than `rhysd/actionlint@main` (a mutable branch reference that fails the repo's own semgrep gate):
 
 ```yaml
 name: Actionlint
@@ -196,15 +200,20 @@ jobs:
     name: Actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: rhysd/actionlint@main
+      - uses: actions/checkout@<full-sha> # <version>
+      - name: Download actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Run actionlint
+        run: ./actionlint -color
 ```
 
-Don't duplicate if any of these jobs already exist. Look up latest action versions. All action references should use pinned commit SHAs with a version comment, e.g.:
+Don't duplicate if any of these jobs already exist. Every `uses:` reference must be pinned to a full commit SHA with a version comment — look up the latest release of each action and substitute the real SHA for `<full-sha>`, e.g.:
 
 ```yaml
-- uses: actions/checkout@<full-sha> # v4
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 ```
+
+A floating tag (`@v4`) or branch (`@main`) is a mutable reference — it fails the semgrep gate installed above (`github-actions-mutable-action-tag` is a blocking finding), so samples committed with floating tags fail their own repo's CI.
 
 ### 8. Dependabot auto-merge
 
@@ -223,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@<full-sha> # <version>
       - run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -251,9 +260,13 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 If `.github/dependabot.yml` already exists, read it first and ensure the `github-actions` ecosystem entry is present. Don't duplicate entries.
+
+The `cooldown` block is load-bearing, not a lint nit: this same skill installs auto-merge, so without a cooldown a freshly published malicious or broken version can land on `main` with nobody looking at it. Seven days gives upstream time to yank a bad release first. Every ecosystem entry — here and in the language skills — carries the same block (semgrep's `dependabot-missing-cooldown` rule blocks on entries without one).
 
 > **Note:** Auto-merge requires branch protection or rulesets with required status checks enabled on the default branch. Without this, `--auto` merges immediately without waiting for CI.
 

--- a/home/commands/setup-docker.md
+++ b/home/commands/setup-docker.md
@@ -51,8 +51,8 @@ jobs:
     name: Hadolint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3.1.0
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: hadolint/hadolint-action@<full-sha> # <version>
         with:
           dockerfile: Dockerfile
 
@@ -60,8 +60,8 @@ jobs:
     name: Trivy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@master
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: aquasecurity/trivy-action@<full-sha> # <version>
         with:
           scan-type: 'fs'
           scanners: 'misconfig'
@@ -88,6 +88,8 @@ Read `.github/dependabot.yml` and add the `docker` ecosystem entry if it isn't a
       - "dependencies"
       - "docker"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 6. Verify

--- a/home/commands/setup-dotnet.md
+++ b/home/commands/setup-dotnet.md
@@ -107,8 +107,8 @@ jobs:
     name: Build & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-dotnet@<full-sha> # <version>
         with:
           dotnet-version: '8.0.x'
       - run: dotnet restore
@@ -119,8 +119,8 @@ jobs:
     name: Dependency Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-dotnet@<full-sha> # <version>
         with:
           dotnet-version: '8.0.x'
       - run: dotnet tool install --global dotnet-outdated-tool
@@ -146,6 +146,8 @@ Read `.github/dependabot.yml` and add the `nuget` ecosystem entry if it isn't al
       - "dependencies"
       - "dotnet"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 7. Verify

--- a/home/commands/setup-go.md
+++ b/home/commands/setup-go.md
@@ -4,33 +4,39 @@ Set up Go linting, formatting, and security scanning for this project. Assumes `
 
 ### 1. golangci-lint
 
-Create `.golangci.yml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+Create `.golangci.yml` in the project root (if it doesn't already exist). If one exists, review and suggest additions — and if it's in the v1 schema (top-level `linters-settings`, no `version` key), migrate it: golangci-lint v2 rejects v1 configs outright.
 
 ```yaml
+# golangci-lint v2 schema. The v1 layout (top-level linters-settings, gosimple
+# as its own linter) is rejected outright by v2.
+version: "2"
+
 linters:
   enable:
     - errcheck
     - govet
     - staticcheck
     - unused
-    - gosimple
     - ineffassign
-    - typecheck
-    - goimports
     - revive
     - misspell
     - gosec
+  settings:
+    revive:
+      rules:
+        - name: exported
+          severity: warning
 
-linters-settings:
-  goimports:
-    local-prefixes: # Leave empty — user should set to their module path
-  revive:
-    rules:
-      - name: exported
-        severity: warning
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - <module path>  # set to the module path from go.mod
 
 issues:
-  exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
 
@@ -38,7 +44,14 @@ run:
   timeout: 5m
 ```
 
-Tell the user to set `local-prefixes` under `goimports` to their Go module path.
+Replace `<module path>` with the module path from `go.mod`. v2 schema gotchas, in case you are adapting an existing config:
+
+- `gosimple` was merged into `staticcheck` and `typecheck` was never a real enableable linter — neither may appear in `enable:`.
+- Formatting tools (`gofmt`, `goimports`, `gofumpt`) live in the top-level `formatters:` block, not `linters:`.
+- A settings key that is present but empty parses as `null` and fails `golangci-lint config verify` — even though `golangci-lint run` tolerates it. Omit the key entirely rather than leaving it blank. (`run` is generally more permissive than `config verify`, and CI runs `config verify` first — so a config can pass locally and still fail CI.)
+- v1's `issues.exclude-use-default` is gone; exclusions are configured under `linters.exclusions`.
+
+After writing the config, run `golangci-lint config verify` to confirm it parses — not just `golangci-lint run`.
 
 ### 2. .gitignore
 
@@ -64,15 +77,15 @@ Append these repos to the existing `.pre-commit-config.yaml`:
   - repo: https://github.com/golangci/golangci-lint
     rev: <latest tag>
     hooks:
+      - id: golangci-lint-config-verify
       - id: golangci-lint
-
-  - repo: https://github.com/tekwizely/pre-commit-golang
-    rev: <latest tag>
-    hooks:
-      - id: go-fumpt
+      - id: golangci-lint-fmt
 ```
 
-Look up the latest release tag for each repo and use those for the `rev:` values.
+Look up the latest release tag and use it for the `rev:` value. All three hooks come from the one binary, so hook and CI can never run different versions:
+
+- `golangci-lint-config-verify` catches the run/verify strictness gap locally instead of in CI (it only fires when `.golangci.yml` changes).
+- `golangci-lint-fmt` runs the `formatters:` block (`gofmt`/`goimports`), replacing any separate formatting hook — do not add `tekwizely/pre-commit-golang` alongside it.
 
 ### 4. GitHub Actions workflow
 
@@ -91,18 +104,18 @@ jobs:
     name: Go Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-go@<full-sha> # <version>
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@<full-sha> # <version>
 
   govulncheck:
     name: Govulncheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-go@<full-sha> # <version>
         with:
           go-version-file: go.mod
       - name: Install govulncheck
@@ -134,6 +147,8 @@ Read `.github/dependabot.yml` and add the `gomod` ecosystem entry if it isn't al
       - "dependencies"
       - "go"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 7. Verify

--- a/home/commands/setup-java.md
+++ b/home/commands/setup-java.md
@@ -128,8 +128,8 @@ jobs:
     name: Spotless & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-java@<full-sha> # <version>
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -140,12 +140,12 @@ jobs:
     name: OWASP Dependency Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-java@<full-sha> # <version>
         with:
           distribution: 'temurin'
           java-version: '21'
-      - uses: dependency-check/Dependency-Check_Action@main
+      - uses: dependency-check/Dependency-Check_Action@<full-sha> # <version>
         with:
           project: '${{ github.repository }}'
           path: '.'
@@ -171,6 +171,8 @@ Read `.github/dependabot.yml` and add the `maven` ecosystem entry if it isn't al
       - "dependencies"
       - "java"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 If the project uses Gradle instead of Maven, use `gradle` as the `package-ecosystem` value.

--- a/home/commands/setup-markdown.md
+++ b/home/commands/setup-markdown.md
@@ -47,15 +47,25 @@ Append these repos to the existing `.pre-commit-config.yaml`:
     rev: <latest tag>
     hooks:
       - id: markdownlint-cli2
+```
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: <latest tag>
+Look up the latest release tag and use it for the `rev:` value.
+
+For the prettier hook, do **not** use `pre-commit/mirrors-prettier` — it is archived and no longer receives releases. Use a `repo: local` hook running the project's own binary. If the project has a `package.json`, add prettier as a devDependency (`npm install -D prettier`) and use:
+
+```yaml
+  - repo: local
     hooks:
       - id: prettier
+        name: prettier
+        entry: npx --no-install prettier --write
+        language: system
         types_or: [markdown]
 ```
 
-Look up the latest release tag for each repo and use those for the `rev:` values.
+(`--no-install` matters: without it, a missing `node_modules` makes npx silently download some other version instead of failing.)
+
+If the project has no `package.json` (a docs-only repo), either install prettier globally (`brew install prettier`) and use `entry: prettier --write`, or skip the prettier hook — markdownlint-cli2 already covers lint-level formatting.
 
 ### 4. GitHub Actions workflow
 
@@ -69,8 +79,8 @@ Create or update the CI workflow to include a markdown lint job that only runs w
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: DavidAnson/markdownlint-cli2-action@<full-sha> # <version>
 ```
 
 Add a path filter on the workflow trigger so this job only runs when relevant files change:

--- a/home/commands/setup-node.md
+++ b/home/commands/setup-node.md
@@ -67,25 +67,24 @@ coverage/
 
 ### 4. Add pre-commit hooks
 
-Append these repos to the existing `.pre-commit-config.yaml`:
+Append this repo to the existing `.pre-commit-config.yaml`. Use `repo: local` hooks running the project's own binaries — not the `pre-commit/mirrors-*` repos: `mirrors-prettier` is archived and no longer receives releases, and both mirrors pin their own copy of the tool, so the hook and `package.json` can silently run different versions.
 
 ```yaml
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: <latest tag>
+  - repo: local
     hooks:
       - id: prettier
-
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: <latest tag>
-    hooks:
+        name: prettier
+        entry: npx --no-install prettier --write
+        language: system
+        types_or: [javascript, jsx, json, css, markdown]
       - id: eslint
+        name: eslint
+        entry: npx --no-install eslint
+        language: system
         types: [javascript]
-        additional_dependencies:
-          - eslint
-          - '@eslint/js'
 ```
 
-Look up the latest release tag for each repo and use those for the `rev:` values.
+`--no-install` matters: without it, a missing `node_modules` makes npx silently download some other version instead of failing. Both tools must be devDependencies — `npm install -D prettier eslint @eslint/js` if they aren't already.
 
 ### 5. GitHub Actions workflow
 
@@ -104,8 +103,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -117,8 +116,8 @@ jobs:
     name: npm Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
         with:
           node-version-file: '.node-version'
       - run: npm audit --audit-level=high
@@ -143,6 +142,8 @@ Read `.github/dependabot.yml` and add the `npm` ecosystem entry if it isn't alre
       - "dependencies"
       - "javascript"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 7. Verify

--- a/home/commands/setup-php.md
+++ b/home/commands/setup-php.md
@@ -93,8 +93,8 @@ jobs:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: shivammathur/setup-php@<full-sha> # <version>
         with:
           php-version: '8.3'
       - run: composer install --no-progress
@@ -104,8 +104,8 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: shivammathur/setup-php@<full-sha> # <version>
         with:
           php-version: '8.3'
       - run: composer install --no-progress
@@ -115,8 +115,8 @@ jobs:
     name: Composer Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: shivammathur/setup-php@<full-sha> # <version>
         with:
           php-version: '8.3'
       - run: composer audit
@@ -141,6 +141,8 @@ Read `.github/dependabot.yml` and add the `composer` ecosystem entry if it isn't
       - "dependencies"
       - "php"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 7. Verify

--- a/home/commands/setup-python.md
+++ b/home/commands/setup-python.md
@@ -118,15 +118,15 @@ jobs:
     name: Ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: astral-sh/ruff-action@<full-sha> # <version>
 
   typecheck:
     name: Mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: astral-sh/setup-uv@<full-sha> # <version>
       - run: uv sync
       - run: uv run mypy .
 
@@ -134,8 +134,8 @@ jobs:
     name: Bandit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: astral-sh/setup-uv@<full-sha> # <version>
       - run: uv tool run bandit -r . -c pyproject.toml
 ```
 
@@ -168,6 +168,8 @@ Read `.github/dependabot.yml` and add the `pip` ecosystem entry if it isn't alre
       - "dependencies"
       - "python"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 If `pyproject.toml` is in a subdirectory rather than the repo root, adjust `directory` accordingly.

--- a/home/commands/setup-ruby.md
+++ b/home/commands/setup-ruby.md
@@ -78,8 +78,8 @@ jobs:
     name: RuboCop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: ruby/setup-ruby@<full-sha> # <version>
         with:
           bundler-cache: true
       - run: bundle exec rubocop
@@ -88,8 +88,8 @@ jobs:
     name: Brakeman
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: ruby/setup-ruby@<full-sha> # <version>
         with:
           bundler-cache: true
       - run: gem install brakeman
@@ -99,8 +99,8 @@ jobs:
     name: Bundler Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: ruby/setup-ruby@<full-sha> # <version>
         with:
           bundler-cache: true
       - run: gem install bundler-audit
@@ -128,6 +128,8 @@ Read `.github/dependabot.yml` and add the `bundler` ecosystem entry if it isn't 
       - "dependencies"
       - "ruby"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 6. Verify

--- a/home/commands/setup-rust.md
+++ b/home/commands/setup-rust.md
@@ -114,7 +114,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@<full-sha> # <version>
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -124,7 +124,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@<full-sha> # <version>
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -134,8 +134,8 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: rustsec/audit-check@<full-sha> # <version>
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -143,8 +143,8 @@ jobs:
     name: Cargo Deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: EmbarkStudios/cargo-deny-action@<full-sha> # <version>
 ```
 
 Don't duplicate if Rust lint jobs already exist. Look up latest action versions.
@@ -166,6 +166,8 @@ Read `.github/dependabot.yml` and add the `cargo` ecosystem entry if it isn't al
       - "dependencies"
       - "rust"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 8. Verify

--- a/home/commands/setup-shell.md
+++ b/home/commands/setup-shell.md
@@ -69,8 +69,8 @@ jobs:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: ludeeus/action-shellcheck@master
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: ludeeus/action-shellcheck@<full-sha> # <version>
         with:
           scandir: '.'
 ```

--- a/home/commands/setup-terraform.md
+++ b/home/commands/setup-terraform.md
@@ -73,8 +73,8 @@ jobs:
     name: Terraform Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: hashicorp/setup-terraform@<full-sha> # <version>
       - run: terraform fmt -check -recursive
       - run: terraform init -backend=false
       - run: terraform validate
@@ -83,8 +83,8 @@ jobs:
     name: TFLint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: terraform-linters/setup-tflint@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: terraform-linters/setup-tflint@<full-sha> # <version>
       - run: tflint --init
       - run: tflint --recursive
 
@@ -92,12 +92,12 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: aquasecurity/trivy-action@v0.35.0
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: aquasecurity/trivy-action@<full-sha> # <version>
         with:
           scan-type: config
           scan-ref: .
-      - uses: bridgecrewio/checkov-action@v12
+      - uses: bridgecrewio/checkov-action@<full-sha> # <version>
         with:
           directory: .
           framework: terraform
@@ -122,6 +122,8 @@ Read `.github/dependabot.yml` and add the `terraform` ecosystem entry if it isn'
       - "dependencies"
       - "terraform"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 6. Verify

--- a/home/commands/setup-typescript.md
+++ b/home/commands/setup-typescript.md
@@ -93,28 +93,24 @@ coverage/
 
 ### 5. Add pre-commit hooks
 
-Append these repos to the existing `.pre-commit-config.yaml`:
+Append this repo to the existing `.pre-commit-config.yaml`. Use `repo: local` hooks running the project's own binaries — not the `pre-commit/mirrors-*` repos: `mirrors-prettier` is archived and no longer receives releases, and both mirrors pin their own copy of the tool, so the hook and `package.json` can silently run different versions.
 
 ```yaml
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: <latest tag>
+  - repo: local
     hooks:
       - id: prettier
-        types_or: [typescript, tsx, javascript, jsx, json, css, markdown]
-
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: <latest tag>
-    hooks:
+        name: prettier
+        entry: npx --no-install prettier --write
+        language: system
+        types_or: [ts, tsx, javascript, jsx, json, css, markdown]
       - id: eslint
-        types_or: [typescript, tsx]
-        additional_dependencies:
-          - eslint
-          - typescript
-          - typescript-eslint
-          - '@eslint/js'
+        name: eslint
+        entry: npx --no-install eslint
+        language: system
+        types_or: [ts, tsx]
 ```
 
-Look up the latest release tag for each repo and use those for the `rev:` values.
+`--no-install` matters: without it, a missing `node_modules` makes npx silently download some other version instead of failing. Both tools must be devDependencies — `npm install -D prettier eslint typescript typescript-eslint @eslint/js` if they aren't already.
 
 ### 6. GitHub Actions workflow
 
@@ -133,8 +129,8 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -146,8 +142,8 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
         with:
           node-version-file: '.node-version'
           cache: 'npm'
@@ -158,8 +154,8 @@ jobs:
     name: npm Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
         with:
           node-version-file: '.node-version'
       - run: npm audit --audit-level=high
@@ -184,6 +180,8 @@ If the `npm` ecosystem is already configured in `.github/dependabot.yml` (e.g. f
       - "dependencies"
       - "javascript"
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
 ```
 
 ### 8. Verify


### PR DESCRIPTION
Closes #109
Closes #110
Closes #111
Closes #91

Four related setup-skill fixes, bundled into one PR by agreement.

## #109 — `/setup-go` emitted a golangci-lint v1 config that v2 rejects

- Sample `.golangci.yml` rewritten in the v2 schema (`version: "2"` first, `linters.settings`, top-level `formatters:` block; `gosimple` and `typecheck` dropped from `enable:`), modeled on the proven config in `automate-inbox`.
- **Validated for real**: the exact YAML block in the skill was extracted and passes `golangci-lint config verify` on v2.12.2 locally.
- The empty-settings-key trap (parses as `null`; passes `run`, fails `config verify`) is documented, the sample uses a `<module path>` placeholder instead of an empty key, and the skill now tells the executing agent to run `config verify`, not just `run`.
- Pre-commit hooks move to the official `golangci/golangci-lint` repo — `golangci-lint-config-verify` + `golangci-lint` + `golangci-lint-fmt` (ids verified against the repo's `.pre-commit-hooks.yaml`). One binary drives hook, formatter, and CI; `tekwizely/pre-commit-golang` is gone.

## #110 — `/setup-common` failed its own semgrep gate

- semgrep hook: `--error` (it exits 0 on findings otherwise — the gate was decorative) and `pass_filenames: false` (explicit paths bypass semgrep's default excludes, so the hook flagged `*_test.go` findings CI never saw). CI job gets `--error` to match.
- `cooldown: default-days: 7` on the dependabot sample — and on **every ecosystem entry in all twelve skills** that emit one, since the semgrep rule fires per-entry and the same skill installs auto-merge. Rationale prose added where auto-merge is installed.
- Every `uses:` in every skill's samples switches from floating tags (`@v4`, `@main`, `@master`) to a `@<full-sha> # <version>` placeholder the executing agent must resolve — the samples previously contradicted the skill's own pinning instruction, and `github-actions-mutable-action-tag` is a blocking finding. Placeholders rather than real SHAs: the skills already instruct looking up latest versions at execution time, and hard-coded SHAs in the docs would only go stale. The one real SHA (the example line) is `actions/checkout@de0fac2…# v6.0.2`, taken from this repo's own CI.
- `rhysd/actionlint@main` (a branch reference — the worst case) is replaced with the official download-script pattern, same as this repo's `ci.yml`. rhysd publishes no GitHub Action to pin.

## #111 — archived `mirrors-prettier`

- `setup-typescript`, `setup-node`, `setup-markdown`: `mirrors-*` blocks replaced with `repo: local` hooks running the project's own binary via `npx --no-install` (without the flag, a missing `node_modules` silently downloads some other version). Tools become devDependencies — no more `additional_dependencies` drift against `package.json`.
- Two scope notes: **`setup-node` wasn't named in the issue** but carried the identical block, so it's included. And **`mirrors-eslint` is not actually archived** (checked: `archived: false`, pushed 2026-07-25) — the issue's claim only holds for `mirrors-prettier` — but it's replaced anyway on the version-drift argument the issue itself makes.
- `setup-markdown` handles the docs-only repo with no `package.json`: global prettier, or skip the hook (markdownlint-cli2 already covers lint-level formatting).
- The general rule lands in `setup-common`: prefer local hooks over `mirrors-*` wherever the tool is a project/system dependency.

## #91 — stop running `pre-commit install`

- `setup-common` no longer installs the git hook; it now explains the enforcement model instead (global `precommit-claude-hook` for Claude's commits/pushes — verified working in #89's close-out — plus CI `pre-commit run --all-files`; manual commits are CI-backed) and instructs the closing summary to say so.
- `pre-commit run --all-files` stays as the local verification step, per the issue.
- Audited all fifteen skills: `setup-common` was the only one running `install`; the language skills only append hooks (acceptance criterion "no setup-* skill runs pre-commit install" holds).

## Verification

- Sample `.golangci.yml` extracted from the doc → `golangci-lint config verify` passes on v2.12.2
- golangci hook ids checked against `golangci/golangci-lint` `.pre-commit-hooks.yaml`
- `mirrors-prettier` archived / `mirrors-eslint` not archived confirmed via the GitHub API
- No floating `@vN` / `@main` / `@master` refs remain in any sample (grep-clean)
- `markdownlint-cli2` 0 issues; `chezmoi init --dry-run` clean
