### PR TITLE
feat(skills): five small fixes — WebFetch fallback, gitleaks perms, cspell seed, setup-repo pairing + gotchas

### DIFF
--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -46,6 +46,14 @@
 - **PR-stacking discipline**: only claim "stacked on" when the second branch literally has the first as parent (`git log --oneline first..second` shows just the second's commits). Branching both off `main` and writing "stacked on PR #N" in the body is misleading — reviewers can merge in any order, and the second PR's diff includes the first's changes. If they're truly independent, branch each from `main` and don't say stacked
 - **Batch reads before edits**: When modifying multiple files, read all target files first, then make all edits — avoids "file not read yet" errors on parallel Edit calls
 - **Always create a tracking issue**: Even for quick single-file fixes, create a GitHub Issue in the repo before starting work — maintains the audit trail and keeps the habit consistent
+- **WebFetch 403? Fall back to curl + pandoc**: Some sites (UESP, other MediaWiki / Cloudflare-fronted wikis) reject WebFetch's User-Agent before serving content. On HTTP 403, don't burn time on alternative URLs — go straight to:
+
+  ```sh
+  curl -sS -L -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15" "$URL" -o /tmp/page.html
+  pandoc -f html -t gfm --wrap=none /tmp/page.html -o /tmp/page.md
+  ```
+
+  Then `Read` the markdown (or `grep` it for structured extraction). If the same site will be hit repeatedly, save the fetcher as a per-project script
 
 ## Shell Scripts
 

--- a/home/commands/setup-common.md
+++ b/home/commands/setup-common.md
@@ -68,12 +68,84 @@ Create `cspell.json` in the project root (if it doesn't already exist). If one e
     "*.lock",
     ".git"
   ],
-  "words": [],
+  "words": [
+    "actionlint",
+    "aquasecurity",
+    "bandit",
+    "brakeman",
+    "bridgecrewio",
+    "checkov",
+    "chezmoi",
+    "chezmoiexternal",
+    "cleanups",
+    "clippy",
+    "coreutils",
+    "cspell",
+    "dependabot",
+    "dotnet",
+    "editorconfig",
+    "errcheck",
+    "eslint",
+    "footgun",
+    "frontmatter",
+    "gitleaks",
+    "godoc",
+    "gofmt",
+    "gofumpt",
+    "goimports",
+    "golangci",
+    "gomod",
+    "gosec",
+    "gotchas",
+    "govet",
+    "govulncheck",
+    "hadolint",
+    "handoff",
+    "hashicorp",
+    "ineffassign",
+    "jsdoc",
+    "linters",
+    "lockfiles",
+    "markdownlint",
+    "mkdocs",
+    "mypy",
+    "nuget",
+    "phpdoc",
+    "phpstan",
+    "pipx",
+    "pkill",
+    "pytest",
+    "pyupgrade",
+    "rhysd",
+    "rubocop",
+    "ruff",
+    "rustdoc",
+    "rustfmt",
+    "rustsec",
+    "semgrep",
+    "shellcheck",
+    "shfmt",
+    "shivammathur",
+    "siloed",
+    "speedup",
+    "staticcheck",
+    "streetsidesoftware",
+    "subdirs",
+    "temurin",
+    "tflint",
+    "tradeoffs",
+    "trivy",
+    "tseslint",
+    "typecheck",
+    "worktree"
+  ],
   "dictionaries": ["en_GB", "softwareTerms", "companies", "misc"]
 }
 ```
 
 The `files` pattern limits cspell to prose-heavy file types — markdown, plain text, reStructuredText, and YAML. This avoids noise from code identifiers.
+
+The seeded `words` list is deliberate, not decoration: it covers the names of every tool these setup skills install and the config identifiers their own templates write (the YAML samples above are spell-checked too, since `.yml` matches the `files` pattern), plus recurring dev jargon the base dictionaries miss. Without the seed, the very first `pre-commit run --all-files` flags dozens of words the skill itself just wrote. Do **not** seed user- or project-specific proper nouns (personal handles, repo names) — leave those for the consumer to add as they surface — and never add a word that is actually a typo.
 
 Add a cspell pre-commit hook to `.pre-commit-config.yaml`:
 
@@ -156,6 +228,9 @@ Add to `.github/workflows/ci.yml` (or create if needed):
   gitleaks:
     name: Gitleaks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@<full-sha> # <version>
         with:
@@ -184,6 +259,8 @@ Add to `.github/workflows/ci.yml` (or create if needed):
 ```
 
 (`--error` for the same reason as the hook: without it findings don't fail the job.)
+
+The gitleaks job's `permissions:` block is required: the default `GITHUB_TOKEN` no longer grants `pull-requests: read`, and `gitleaks-action` needs it in PR context to fetch the PR's commit list — without it, the first PR run fails with `403 Resource not accessible by integration`. Job-level rather than workflow-level keeps it least-privilege; cspell and semgrep don't need it.
 
 Create a separate `.github/workflows/actionlint.yml` with a path filter (or add to existing CI with the same filter). `rhysd/actionlint` publishes no GitHub Action to pin, so use the official download script rather than `rhysd/actionlint@main` (a mutable branch reference that fails the repo's own semgrep gate):
 
@@ -273,6 +350,17 @@ The `cooldown` block is load-bearing, not a lint nit: this same skill installs a
 ### 9. Verify
 
 Run `pre-commit run --all-files` to confirm everything works. Fix any issues that come up.
+
+### 10. Closing summary
+
+End the closing summary with this reminder (verbatim or close to it):
+
+```text
+Local baseline applied. Run /setup-repo next to apply the GitHub-side
+settings (branch protection, squash-merge rules, secret scanning, labels).
+```
+
+The two commands are a pair that is easy to half-apply: this one writes local files, `/setup-repo` configures the remote (different preconditions, different blast radius — the split is deliberate). Naming what `/setup-repo` adds is the load-bearing part of the reminder; skip it only if `/setup-repo` was already run this session.
 
 ## Important
 

--- a/home/commands/setup-repo.md
+++ b/home/commands/setup-repo.md
@@ -37,8 +37,10 @@ If wiki or projects are currently enabled, note this in the summary but still di
 Set the default squash merge commit message to use the PR title:
 
 ```sh
-gh repo edit --squash-merge-commit-message pr-title
+gh repo edit --enable-squash-merge --squash-merge-commit-message pr-title
 ```
+
+`--enable-squash-merge` must be in the **same invocation** even though step 2 already enabled it: `gh` gates the message flag on the enable flag being present in the same call. Without it, `gh repo edit` prints its help text, exits 0, and applies nothing — the output looks like documentation, not an error, so check that it actually applied.
 
 ### 4. Secret scanning (public repos only)
 
@@ -52,7 +54,12 @@ If the repository is **private**, skip this step and note: "Secret scanning requ
 
 ### 5. Branch protection
 
-Auto-detect CI status check names by reading workflow files in `.github/workflows/`. Look for jobs triggered by `pull_request` events and extract their `name:` values — these are the status check contexts GitHub uses.
+Determine the CI status check names to require. Prefer deriving them from an **actual completed run** — `gh pr checks <n>` on a recent PR, or `gh api repos/{owner}/{repo}/commits/{sha}/check-runs --jq '.check_runs[].name'` — rather than reading the workflow YAML: the rendered check name can differ from the job key, and a wrong string here blocks every PR (see below). Fall back to reading `name:` values from `pull_request`-triggered jobs in `.github/workflows/` only when no run exists yet.
+
+Two hazards to warn the user about while doing this:
+
+- **Required checks are a rename trap.** Branch protection stores check names as opaque strings. Rename or remove a CI job and the old name is required forever, never reports, and every PR is blocked with no failing check to point at — nothing warns you. Whenever a CI job is renamed, removed, or a language port swaps one check for another, the protection contexts must be updated in the same change.
+- **Path-filtered jobs cannot be required checks.** A job behind a `paths:` filter never reports on PRs it skips, so PRs touching other files block forever. `/setup-common` and the language skills deliberately suggest path filters — those jobs are ineligible; only require checks that run on every PR.
 
 Apply branch protection to the default branch using the GitHub API. The JSON payload should contain:
 
@@ -121,3 +128,4 @@ After applying changes, verify the configuration took effect:
 - Branch protection PUT replaces the entire config. If a repo has custom protection rules (e.g., required reviewers from a team), review the current config before overwriting.
 - Some branch protection features require GitHub Pro on private repos. If the API returns a 403, explain this to the user.
 - The `enforce_admins` setting is the most important for agent safety — without it, admin-level tokens bypass all other branch protection rules.
+- Required status check names are stored as opaque strings — remind the user that renaming a CI job later silently orphans the requirement and blocks all PRs until the protection is updated.


### PR DESCRIPTION
Closes #86
Closes #78
Closes #77
Closes #80
Closes #112

Five small fixes bundled by agreement.

## #86 — WebFetch 403 fallback (`home/CLAUDE.md`)

New Process Guidelines bullet: on HTTP 403 from WebFetch (UESP, other UA-blocking MediaWiki/Cloudflare sites), go straight to `curl` with a browser UA piped through `pandoc` to markdown, then `Read` it. Tool-shape advice at the global level, same class as the heredoc ban — the issue's proposed wording, lightly tightened.

## #78 — gitleaks needs `pull-requests: read` (`setup-common`)

Job-level `permissions:` block added to the gitleaks CI job template, with the rationale inline (default `GITHUB_TOKEN` no longer grants it; `gitleaks-action` fetches the PR's commit list; first PR run 403s without it). Job-level not workflow-level — cspell/semgrep keep default restricted permissions, per the issue's acceptance criteria.

## #77 — cspell wordlist seeded (`setup-common`)

`"words": []` → 69 seeded entries: every tool the setup skills install, the identifiers their own YAML samples write, and recurring dev jargon. Verified sorted, unique, valid JSON. Two deliberate divergences from the issue's list: beads-era terms (`bd`, `dolt`, `embeddeddolt`, `beads`) are dropped — the issue predates the retirement — and sample-YAML identifiers (`aquasecurity`, `bridgecrewio`, `temurin`, `shivammathur`, golangci linter names) are added, because the template's `files` pattern includes `.yml`, so the skill's own workflow samples get spell-checked. Anti-acceptance honoured: no personal handles or repo names, and prose now tells the consumer to keep it that way.

## #80 — closing reminder to run `/setup-repo` (`setup-common`)

New step 10 ends the closing summary with the reminder, naming what `/setup-repo` adds (branch protection, squash-merge rules, secret scanning, labels) — the load-bearing part per the issue. Option 1 from the issue's analysis (reminder, not meta-command, not merge). No change to file-writing behaviour.

## #112 — two `/setup-repo` gotchas encoded

- **Squash-merge flag gating**: step 3 now includes `--enable-squash-merge` in the same invocation as `--squash-merge-commit-message`, with a warning that the failure mode is silent (help text, exit 0, nothing applied).
- **Required-check rename hazard**: step 5 now derives check names from an actual completed run (`gh pr checks` / check-runs API) in preference to workflow YAML, warns that protection stores names as opaque strings (rename a job → every PR blocked with nothing failing), and cautions that path-filtered jobs — which `/setup-common` and the language skills deliberately suggest — are ineligible as required checks. Echoed in the Important section.

**Not done from #112**: the "Related" note about a `--labels-only` mode for infra repos — it's flagged as "possibly worth" rather than asked for, and it's a feature, not a gotcha. Say the word and I'll file it as its own issue.

## Verification

- cspell JSON block extracted and validated (valid, 69 words, sorted, unique)
- `markdownlint-cli2` 0 issues; `chezmoi init --dry-run` clean
- gitleaks permissions block matches the fix proven in paul-context PR #6
