### PR TITLE
feat(hooks): pre-push guard blocks pushes to branches with merged/closed PRs

### DIFF
--- a/home/bin/prepush-guard-claude-hook
+++ b/home/bin/prepush-guard-claude-hook
@@ -1,0 +1,69 @@
+#!/bin/sh
+# prepush-guard-claude-hook — Claude Code PreToolUse(Bash) hook.
+#
+# Blocks `git push` to a branch whose PR has already been merged or closed.
+# The failure this prevents: the user merges the PR via the GitHub UI
+# mid-session (branch auto-deletes), and the next push silently recreates an
+# orphaned remote branch — the only tell is `* [new branch]` in output nobody
+# reads. Recovery costs a cleanup cycle every time (new branch, cherry-pick,
+# delete orphan, new PR). The prose rule in CLAUDE.md ("check the PR is still
+# open before pushing") failed twice in one session; this enforces it.
+#
+# Authority is `gh pr view <branch>`: local state is useless here (the stale
+# remote-tracking ref survives the remote deletion until a fetch --prune).
+# gh prefers an open PR for the branch when one exists, so re-using a branch
+# name after an old PR merged still pushes fine once a new PR is open.
+#
+# Fail-open by design: no gh, no network, no repo, detached HEAD, or any
+# lookup error -> allow the push. The guard exists to stop one specific
+# silent mistake, not to make pushing fragile. Honours --no-verify as the
+# escape hatch, same as precommit-claude-hook.
+#
+# Limitation: checks the CURRENT branch. A push that names a different
+# refspec than the checked-out branch is waved through unexamined.
+
+set -u
+
+# --- Read payload; degrade gracefully without jq. -------------------------
+command -v jq >/dev/null 2>&1 || exit 0
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty')
+cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty')
+
+# --- Fast-exit: fires on EVERY Bash call, so not-a-push must be cheap. ----
+case "$cmd" in
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+case "$cmd" in
+  *" --no-verify "*|*" --no-verify") exit 0 ;;      # standard escape hatch
+  *" --delete "*|*" --delete"|*" -d "*) exit 0 ;;   # deleting, not pushing work
+  *" --tags"*) exit 0 ;;                            # tag pushes have no PR
+esac
+
+command -v gh >/dev/null 2>&1 || exit 0
+
+# --- Resolve the branch being pushed (current branch; see limitation). ----
+if [ -n "$cwd" ]; then
+  git() { command git -C "$cwd" "$@"; }
+fi
+branch=$(git symbolic-ref --short -q HEAD) || exit 0   # detached HEAD
+default=$(git symbolic-ref --short -q refs/remotes/origin/HEAD | sed 's|^origin/||')
+[ -n "$default" ] && [ "$branch" = "$default" ] && exit 0
+
+# --- Ask GitHub. Any failure (no PR, offline, auth) -> allow. -------------
+if [ -n "$cwd" ]; then
+  pr=$(cd "$cwd" && gh pr view "$branch" --json state,number,url 2>/dev/null) || exit 0
+else
+  pr=$(gh pr view "$branch" --json state,number,url 2>/dev/null) || exit 0
+fi
+state=$(printf '%s' "$pr" | jq -r '.state // empty')
+case "$state" in
+  MERGED|CLOSED) ;;
+  *) exit 0 ;;
+esac
+
+number=$(printf '%s' "$pr" | jq -r '.number')
+url=$(printf '%s' "$pr" | jq -r '.url')
+printf 'push blocked: PR #%s for branch %s is already %s (%s).\n\nPushing now would silently recreate the deleted remote branch as an orphan.\nStart from fresh main instead:\n  git checkout main && git pull --rebase && git checkout -b <new-branch>\nthen cherry-pick or re-apply the new commits and open a new PR.\n\n(If recreating this branch is genuinely intended, re-run with --no-verify.)\n' "$number" "$branch" "$state" "$url" >&2
+exit 2

--- a/home/settings.json
+++ b/home/settings.json
@@ -333,6 +333,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "~/.claude/bin/prepush-guard-claude-hook",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "~/.claude/bin/precommit-claude-hook",
             "timeout": 120
           }

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -661,7 +661,32 @@ the user revisits it.
 
 ### PreToolUse (Bash)
 
-1. **pre-commit lint gate** — `~/.claude/bin/precommit-claude-hook`. A single
+1. **PR-state push guard** — `~/.claude/bin/prepush-guard-claude-hook`.
+   Before any `git push` Claude makes, asks GitHub (`gh pr view <branch>`)
+   whether the current branch's PR is already `MERGED`/`CLOSED`, and if so
+   **blocks** with `exit 2` and instructions to start a fresh branch. 30s
+   timeout.
+
+   This enforces mechanically what the CLAUDE.md prose rule ("check the PR is
+   still open before pushing follow-up commits") failed to: the user merges a
+   PR via the GitHub UI mid-session, the branch auto-deletes, and the next
+   push silently recreates it as an orphan — `* [new branch]` in unread output
+   is the only tell, and recovery costs a cleanup cycle. GitHub is the
+   authority because local state is useless here: the stale remote-tracking
+   ref survives the remote deletion until a `fetch --prune`.
+
+   **Fail-open by design** — the guard stops one specific silent mistake
+   without making pushing fragile. It allows the push when: the command isn't
+   a `git push`; `--no-verify` is present (escape hatch, e.g. deliberately
+   recreating a branch); the push is `--delete`/`-d` or `--tags`; `gh` or
+   `jq` is missing; HEAD is detached; the branch is the default branch; the
+   branch has no PR; the PR is open; or the lookup fails for any reason
+   (offline, auth). `gh pr view` prefers an open PR when one exists, so
+   re-using a branch name under a new PR is not a false positive. Limitation:
+   it inspects the **current** branch — a push naming a different refspec is
+   waved through.
+
+2. **pre-commit lint gate** — `~/.claude/bin/precommit-claude-hook`. A single
    script that runs the pre-commit framework against the repo's
    `.pre-commit-config.yaml` on the `git commit` / `git push` commands Claude
    makes via its Bash tool, **blocking** on failure with `exit 2` (the only


### PR DESCRIPTION
Closes #46

## What

New `PreToolUse(Bash)` hook — `home/bin/prepush-guard-claude-hook` — that runs before any `git push` Claude makes. It asks `gh pr view <current-branch>` for the branch's PR state; `MERGED`/`CLOSED` blocks the push (`exit 2`) with instructions to start a fresh branch off main. Option 1 from the issue's preference order.

The failure it prevents: user merges the PR via the GitHub UI mid-session, the branch auto-deletes, the next push silently recreates it as an orphan (`* [new branch]` in unread output is the only tell), and recovery costs a cleanup cycle — this bit twice in one session despite the CLAUDE.md prose rule.

## Design

- **GitHub is the authority.** Local state cannot detect the condition — the stale remote-tracking ref survives the remote deletion until a `fetch --prune`. The one API call is proportionate to a push, which is itself a network op.
- **Fail-open.** The guard stops one specific silent mistake without making pushing fragile. It allows on: `--no-verify` (escape hatch for deliberately recreating a branch), `--delete`/`-d`/`--tags` pushes, missing `gh`/`jq`, detached HEAD, the default branch (also skips the API call on every main push), no PR, an open PR, or any lookup failure (offline/auth).
- **No false positive on branch-name reuse**: `gh pr view` prefers an open PR for the branch when one exists, so a new PR on an old name pushes fine.
- **Known limitation, documented in the script and settings.json.md**: it inspects the *current* branch. A push naming a different refspec than the checked-out branch is waved through unexamined — Claude effectively always pushes the current branch, so this trades completeness for simplicity.
- Runs before `precommit-claude-hook` in the hook list (one cheap API call before a potentially full `--all-files` lint). 30s timeout.

## Verification

Tested against **live repo state**, all seven cases:

| Case | Result |
| --- | --- |
| non-push command | exit 0 (fast path) |
| push on `main` | exit 0 |
| push on `fix/setup-skills-sweep` (PR #113, merged) | **blocked, exit 2**, full message names PR/state/URL |
| same with `--no-verify` | exit 0 |
| push on `feat/small-fixes-sweep` (PR #114, open) | exit 0 |
| push on a no-PR branch | exit 0 |
| `gh` stripped from PATH | exit 0 |

`shellcheck` clean (POSIX sh, no bashisms); `settings.json` ↔ `settings.json.md` updated together; markdownlint and chezmoi dry-run clean.

## Note

The block message tells Claude to re-run with `--no-verify` when recreating the branch is intended — the same escape hatch `precommit-claude-hook` honours, so one flag consistently bypasses both gates (and CI remains the backstop either way).
