### PR TITLE
feat(hooks): rewrite 'gh pr checks --watch' to wait for check registration (re-merge of #120)

### DIFF
--- a/home/bin/gh-pr-checks-wait
+++ b/home/bin/gh-pr-checks-wait
@@ -1,0 +1,57 @@
+#!/bin/sh
+# gh-pr-checks-wait — bounded wait-until-registered wrapper for `gh pr checks`.
+#
+# GitHub takes a variable 0-60s+ to register check runs after a PR is
+# created, and `gh pr checks --watch` treats "no checks yet" as terminal
+# ("no checks reported") rather than pending — there is no native flag to
+# wait for registration. This wrapper polls until at least one check exists
+# (5s interval, ~2 min cap), then execs the real `gh pr checks` with the
+# original arguments untouched.
+#
+# Fail-open: if checks never register inside the cap, it execs anyway and
+# the user sees gh's own error rather than a hang. All failure modes of the
+# probe (offline, bad selector, auth) fall through the same way.
+#
+# Normally invoked via the prchecks-wait-claude-hook rewrite, but safe to
+# call directly: gh-pr-checks-wait <n> --watch [gh pr checks flags...]
+
+set -u
+
+# Probe with the original selector/repo args, minus the watch/display flags
+# that conflict with --json. gh pr checks arguments never contain whitespace
+# (PR number/URL/branch, -R owner/repo, flags), so a word-split rebuild is
+# safe here.
+probe_args=""
+skip_next=""
+for a in "$@"; do
+  if [ -n "$skip_next" ]; then skip_next=""; continue; fi
+  case "$a" in
+    --watch|--fail-fast|-w|--web) ;;
+    -i|--interval) skip_next=1 ;;
+    --interval=*) ;;
+    *) probe_args="$probe_args $a" ;;
+  esac
+done
+
+tries=0
+misses=0
+while [ "$tries" -lt 24 ]; do
+  # shellcheck disable=SC2086  # intentional word-split, see above
+  out=$(gh pr checks $probe_args --json name --jq 'length' 2>&1)
+  case "$out" in
+    [1-9]*)
+      break ;;                    # one or more checks registered — done waiting
+    0|*"no checks reported"*)
+      ;;                          # registration pending — keep polling
+    *)
+      # Some other failure (bad selector, offline, auth): the wait can't
+      # help, so give up after a few consecutive misses instead of sitting
+      # out the full cap before surfacing gh's real error.
+      misses=$((misses + 1))
+      [ "$misses" -ge 3 ] && break ;;
+  esac
+  tries=$((tries + 1))
+  sleep 5
+done
+
+exec gh pr checks "$@"

--- a/home/bin/prchecks-wait-claude-hook
+++ b/home/bin/prchecks-wait-claude-hook
@@ -1,0 +1,51 @@
+#!/bin/sh
+# prchecks-wait-claude-hook — Claude Code PreToolUse(Bash) hook.
+#
+# Rewrites `gh pr checks ... --watch` commands to go through
+# ~/.claude/bin/gh-pr-checks-wait, which waits (bounded) for GitHub to
+# register check runs before watching. Without this, a --watch issued in
+# the seconds after `gh pr create` exits immediately with "no checks
+# reported" — the registration lag is variable (0-60s+ observed), so a
+# fixed sleep after create doesn't fix it and penalises the wrong command.
+#
+# Mechanism: exit 0 emitting hookSpecificOutput.updatedInput, which
+# replaces the tool's arguments before it runs. Only the `gh pr checks`
+# substring is substituted, so compound commands (pipes, redirects,
+# leading env vars) keep their shape, and every other tool_input field is
+# carried over unchanged.
+#
+# Fast-exits with no output (command runs unmodified) when: the command
+# isn't a `gh pr checks ... --watch`, it's already wrapped, jq is missing,
+# or the wrapper isn't deployed/executable (fresh machine before
+# chezmoi apply). Non-watch `gh pr checks` calls pass through — poll loops
+# using --json handle the empty case themselves.
+
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty')
+
+# Fires on EVERY Bash call: the not-a-match case must be cheap.
+case "$cmd" in
+  *"gh pr checks"*) ;;
+  *) exit 0 ;;
+esac
+case "$cmd" in
+  *"--watch"*) ;;
+  *) exit 0 ;;
+esac
+case "$cmd" in
+  *gh-pr-checks-wait*) exit 0 ;;   # already wrapped — never rewrite twice
+esac
+
+wrapper="$HOME/.claude/bin/gh-pr-checks-wait"
+[ -x "$wrapper" ] || exit 0
+
+printf '%s' "$payload" | jq -c --arg w "$wrapper" '
+  .tool_input as $ti
+  | {hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      updatedInput: ($ti + {command: ($ti.command | sub("gh pr checks"; $w))})
+    }}'
+exit 0

--- a/home/settings.json
+++ b/home/settings.json
@@ -284,6 +284,7 @@
       "Bash(yarn outdated *)",
       "Bash(yarn run *)",
       "Bash(yarn test *)",
+      "Bash(~/.claude/bin/gh-pr-checks-wait *)",
       "mcp__github__add_comment_to_pending_review",
       "mcp__github__add_issue_comment",
       "mcp__github__add_reply_to_pull_request_comment",
@@ -331,6 +332,11 @@
       {
         "matcher": "Bash",
         "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/bin/prchecks-wait-claude-hook",
+            "timeout": 10
+          },
           {
             "type": "command",
             "command": "~/.claude/bin/prepush-guard-claude-hook",

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -661,7 +661,35 @@ the user revisits it.
 
 ### PreToolUse (Bash)
 
-1. **PR-state push guard** — `~/.claude/bin/prepush-guard-claude-hook`.
+1. **pr-checks registration-race rewrite** —
+   `~/.claude/bin/prchecks-wait-claude-hook`. Rewrites
+   `gh pr checks ... --watch` commands (via `hookSpecificOutput.updatedInput`,
+   which replaces the tool's arguments before execution) to run through
+   `~/.claude/bin/gh-pr-checks-wait`. The wrapper polls until GitHub has
+   registered at least one check run (5s interval, ~2 min cap), then execs
+   the real `gh pr checks` with the original arguments. 10s timeout — the
+   hook itself only inspects and rewrites; the waiting happens in the
+   rewritten command.
+
+   Why: check runs register a variable 0-60s+ after `gh pr create`, and
+   `--watch` treats "no checks yet" as terminal ("no checks reported")
+   rather than pending — gh has no native wait-for-registration flag. A
+   deterministic rewrite beats a prose note that gets skipped under
+   momentum, and attaching the wait to the *checking* side (only when
+   `--watch` is present) beats a fixed sleep after `pr create`, which
+   penalises every PR creation and can still lose the race.
+
+   Fail-open/no-op when: the command isn't `gh pr checks ... --watch`,
+   it's already wrapped (never rewrites twice), `jq` is missing, or the
+   wrapper isn't deployed yet (fresh machine before `chezmoi apply`).
+   The wrapper itself gives up early (3 consecutive probe errors that
+   aren't "no checks reported" — bad selector, offline, auth) and always
+   falls through to the real command, so the worst case is gh's own error,
+   never a hang. The companion allow rule
+   `Bash(~/.claude/bin/gh-pr-checks-wait *)` keeps the rewritten command
+   auto-approved, matching the existing `Bash(gh pr checks *)` grant.
+
+2. **PR-state push guard** — `~/.claude/bin/prepush-guard-claude-hook`.
    Before any `git push` Claude makes, asks GitHub (`gh pr view <branch>`)
    whether the current branch's PR is already `MERGED`/`CLOSED`, and if so
    **blocks** with `exit 2` and instructions to start a fresh branch. 30s
@@ -686,7 +714,7 @@ the user revisits it.
    it inspects the **current** branch — a push naming a different refspec is
    waved through.
 
-2. **pre-commit lint gate** — `~/.claude/bin/precommit-claude-hook`. A single
+3. **pre-commit lint gate** — `~/.claude/bin/precommit-claude-hook`. A single
    script that runs the pre-commit framework against the repo's
    `.pre-commit-config.yaml` on the `git commit` / `git push` commands Claude
    makes via its Bash tool, **blocking** on failure with `exit 2` (the only


### PR DESCRIPTION
Closes #117

## Why this PR exists

**#120's changes never reached main.** The stacking backfired on merge order:

1. #115 merged to main at 08:42 — but its branch `feat/prepush-pr-state-guard` couldn't be auto-deleted, because it was the base of open PR #120. GitHub only auto-retargets a stacked PR when the base branch is *deleted*.
2. #120 therefore still targeted the dead branch, and merging it at 12:41 landed commit `3150bc5` on `feat/prepush-pr-state-guard` — not main. The tell: #117 stayed open, since `Closes` only fires on default-branch merges.

This PR is a clean `cherry-pick -x` of `3150bc5` onto current main — identical content (both hook scripts, settings.json hook entry + allow rule, settings.json.md docs), re-verified after the pick: JSON valid, shellcheck clean, markdownlint clean. Full design rationale and verification in #120.

After this merges, the stale `feat/prepush-pr-state-guard` remote branch should be deleted (it holds nothing else).

## Lesson for stacking discipline

Delete-branch-on-merge does **not** fire when the branch is the base of an open PR — so "GitHub retargets automatically" only holds if the stacked PR is still open when the base PR merges *and* the branch actually deletes. Safe orders: merge bottom-up waiting for each retarget to be confirmed, or retarget the stacked PR to main manually before merging it. Merging the stacked PR into an already-merged base silently strands the commit.
