### PR TITLE
docs: explain why deleting a file here doesn't delete it on machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,38 @@ the project-level `CLAUDE.md` and `AGENTS.md`) stays in the
 repo and never lands at `~/.claude/`. No `.chezmoiignore` needed for these
 — the archive filter handles it cleanly.
 
+### Deleting a file here does not delete it on machines
+
+chezmoi only **adds and updates** target files. Delete
+`home/commands/foo.md` and `~/.claude/commands/foo.md` survives on every
+machine that ever applied a version containing it — and Claude Code goes
+on listing `/foo` as an available slash command. This bit us with the
+retired `bd-*` commands ([#125][issue-125]).
+
+Two things follow, both non-obvious:
+
+- **A `run_onchange_` script in `home/` will not work.** Archive
+  externals are extracted to the target path verbatim; their filenames
+  are *not* parsed for chezmoi attribute prefixes. That's why `exact`,
+  `executable`, `private` and `readonly` exist as *fields on the
+  external declaration* — they add the attribute the filename can't
+  carry. A file named `home/run_onchange_cleanup.sh` deploys as a
+  literal `~/.claude/run_onchange_cleanup.sh` and never executes.
+- **The fix belongs in `dotfiles`, not here.** Setting `exact = true` on
+  an archive external makes chezmoi remove target entries not present in
+  the archive. It must be scoped to the directories this repo wholly
+  owns — declare `.claude/commands` and `.claude/bin` as their own
+  externals. `exact = true` on `.claude` itself would delete Claude
+  Code's own runtime state: `projects/`, `todos/`, `plugins/`,
+  `history.jsonl`, `settings.local.json`.
+
+Until that lands, `/end-session` step 11 detects the drift (`chezmoi
+managed` minus the actual contents of `~/.claude/commands/` and
+`~/.claude/bin/`) and prints a `rm` line to paste. It's per-machine and
+manual, but it does catch every retired file, not just a hard-coded list.
+
+[issue-125]: https://github.com/pmgledhill102/agentic-coding-config/issues/125
+
 ## Slash commands
 
 Each `/setup-*` command contains:

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -228,6 +228,8 @@ Suggested: rm ~/.claude/commands/old-thing.md ~/.claude/bin/legacy-script
 
 Don't `rm` automatically — the user might be testing an unstaged file, or these may belong to another tool. The check is "fast" (one `chezmoi managed` + two `find`s) so it runs unconditionally per session.
 
+Note this check is a *detector*, not the fix, and it is per-machine: clearing the list here does nothing for the same stale file on any other workstation. The permanent fix is `exact = true` on `.claude/commands` and `.claude/bin` as separately-declared archive externals in `dotfiles`, which makes `chezmoi apply` prune them everywhere. Do **not** propose a `run_onchange_` script in `agentic-coding-config`'s `home/` as an alternative — archive externals aren't source state, so the filename prefix is never interpreted and the script would just deploy as an inert file (see that repo's README, "Deleting a file here does not delete it on machines").
+
 ### 12. Other worktrees (Tier 3 — surface)
 
 From gather section `worktrees`. If more than one entry, list non-primary worktrees with their branch. If any have uncommitted work, flag with `*`. Don't remove anything.


### PR DESCRIPTION
Investigation output for #125, plus the verification that closes out #123. **No behaviour change** — the actual fix for #125 has to land in `dotfiles`; see below.

## What I found

#125 proposes a `run_onchange_cleanup-retired-files.sh` in `home/`. **That cannot work**, and the reason is worth writing down because it isn't obvious:

Archive externals are extracted to the target path **verbatim**. Their filenames are never parsed for chezmoi attribute prefixes — which is exactly why `exact`, `executable`, `private` and `readonly` exist as *fields on the external declaration* rather than filename prefixes. `home/run_onchange_cleanup.sh` would deploy as an inert `~/.claude/run_onchange_cleanup.sh` and never execute.

The mechanism that does work is the issue's rejected alternative, `exact = true` — but **scoped**. Declaring `.claude/commands` and `.claude/bin` as their own archive externals with `exact = true` makes `chezmoi apply` prune anything not in the archive, in exactly the two directories this repo wholly owns. It's also self-maintaining: no retired-paths list to keep updated, and every future retirement is caught automatically.

The issue's worry about `exact` is right but understated. `exact = true` on `.claude` itself wouldn't just delete user-added files — it would delete Claude Code's own runtime state: `projects/`, `todos/`, `plugins/`, `history.jsonl`, `settings.local.json`. Scoping is not optional.

Verified against chezmoi's `chezmoiexternal-format` reference (`www.chezmoi.io` is blocked by this sandbox's network policy; read from the docs source in `twpayne/chezmoi`).

## What's in this PR

- **README** — new *"Deleting a file here does not delete it on machines"* section under "What deploys vs what doesn't": the drift, the `run_onchange` dead end, and the scoped-`exact` fix with its blast-radius warning
- **`home/commands/end-session.md`** — step 11 now says it's a per-machine *detector* rather than the fix, and warns the next reader off the same dead end

## #123 — verified complete, no changes needed

The source-side work already landed in `d7a3f6d` ("feat(tracking): retire beads from global config", 2026-07-18), before the issue was filed. Against its acceptance criteria:

| Criterion | Status |
| --- | --- |
| No `bd-*` commands in a fresh session's skill list | Source: yes, all three gone. On machines: still listed — that's #125, not a gap here |
| `grep -riE 'beads\|bd' home/` returns only `bd-migrate-to-github` | Effectively yes — plus one line of *historical prose* in `retrospective.md` §"What changed", which reads "a 2026-07 revision retired the `bd` tracker entirely". I left it: it explains why the current flow looks the way it does, and deleting it wouldn't make anything less bd-ish |
| `retrospective.md` outputs actions as GitHub Issues with no bd fallback | Yes — already true |
| `bin/bd-migrate-to-github` retired last | Kept, as the issue instructs |

## Follow-ups I'm filing separately

- A `dotfiles` issue for the scoped-`exact` externals — the actual fix for #125, which can't be done from this repo (`home/CLAUDE.md`: "do not reach across repos to make the edit yourself")
- An issue to delete `bd-migrate-to-github` + `docs/beads-migration-runbook.md` once the last repo is off beads

## Assumptions

You didn't get to pick between the mechanism options I offered, so I've written up **scoped `exact` externals** as the recommendation — self-maintaining, no manual list. The tradeoff is that a hand-added file in `~/.claude/commands/` or `~/.claude/bin/` would be deleted on apply. Say the word and I'll switch the dotfiles ask to the retired-list script instead. Likewise `bd-migrate-to-github` is kept per the issue's own instruction, not deleted.

Verification: `markdownlint-cli2 "**/*.md"` — 0 issues across 29 files. No `home/bin/` or `.tmpl` changes, so shellcheck and the chezmoi template test are unaffected; `settings.json` untouched, so the sync check doesn't apply.

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSQkPFtdfciBorkd133TvS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSQkPFtdfciBorkd133TvS)_