### PR TITLE
feat: retired-paths list and pruner so deletions reach machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,48 @@ jobs:
       - name: Run actionlint
         run: ./actionlint -color
 
+  retired-paths:
+    name: retired-paths validity
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Entries must be safe and actually retired
+        run: |
+          set -eu
+          list=home/retired-paths
+          if [ ! -f "$list" ]; then
+            echo "$list not present — nothing to validate."
+            exit 0
+          fi
+          rc=0
+          while IFS= read -r line || [ -n "$line" ]; do
+            path=$(printf '%s' "$line" | sed 's/[[:space:]]*$//')
+            case "$path" in
+              '' | '#'*) continue ;;
+            esac
+            # Must not escape ~/.claude/ — the pruner refuses these too, but
+            # failing here means a bad entry never reaches a machine.
+            case "$path" in
+              /* | *..*)
+                echo "::error file=$list::unsafe entry (absolute or ..): $path"
+                rc=1
+                continue
+                ;;
+            esac
+            # The whole point is that the file is GONE from home/. An entry
+            # that still exists would have the pruner delete a live file on
+            # every apply, and chezmoi restore it on the next one.
+            if [ -e "home/$path" ]; then
+              echo "::error file=$list::still present in home/ — retire the file first, or drop this entry: $path"
+              rc=1
+            fi
+          done < "$list"
+          if [ "$rc" -eq 0 ]; then
+            echo "All retired-paths entries are safe and refer to removed files."
+          fi
+          exit "$rc"
+
   settings-sync:
     name: settings.json ↔ settings.json.md sync
     if: github.event_name == 'pull_request'

--- a/README.md
+++ b/README.md
@@ -176,18 +176,40 @@ Two things follow, both non-obvious:
   external declaration* — they add the attribute the filename can't
   carry. A file named `home/run_onchange_cleanup.sh` deploys as a
   literal `~/.claude/run_onchange_cleanup.sh` and never executes.
-- **The fix belongs in `dotfiles`, not here.** Setting `exact = true` on
-  an archive external makes chezmoi remove target entries not present in
-  the archive. It must be scoped to the directories this repo wholly
-  owns — declare `.claude/commands` and `.claude/bin` as their own
-  externals. `exact = true` on `.claude` itself would delete Claude
-  Code's own runtime state: `projects/`, `todos/`, `plugins/`,
-  `history.jsonl`, `settings.local.json`.
+- **The mechanism is an explicit retired-paths list**, not `exact = true`.
+  Setting `exact` on an archive external makes chezmoi delete any target
+  entry not present in the archive — which would also delete files added
+  by hand on one machine that nobody remembers. (And `exact` on
+  `.claude` itself would delete Claude Code's own runtime state:
+  `projects/`, `todos/`, `plugins/`, `history.jsonl`,
+  `settings.local.json`.) A list is more tiresome to maintain, but its
+  blast radius is exactly what's written down.
 
-Until that lands, `/end-session` step 11 detects the drift (`chezmoi
-managed` minus the actual contents of `~/.claude/commands/` and
-`~/.claude/bin/`) and prints a `rm` line to paste. It's per-machine and
-manual, but it does catch every retired file, not just a hard-coded list.
+### Retiring a file
+
+Two files here do the work, so a retirement is a **single-repo change**:
+
+| File | Role |
+| --- | --- |
+| `home/retired-paths` | The list. One `~/.claude/`-relative path per line |
+| `home/bin/claude-prune-retired` | Reads the list, removes each path. Idempotent, refuses absolute paths and `..` |
+
+So: **delete the file from `home/`, add its path to `home/retired-paths`,
+same PR.** CI fails if an entry still exists in `home/`, so a premature
+or mistyped entry can't ship. `dotfiles` invokes
+`~/.claude/bin/claude-prune-retired` after each `chezmoi apply`
+([dotfiles#371][dotfiles-371]) — that's the only wiring it needs, and it
+never has to change again.
+
+Entries are permanent: a machine that hasn't been applied to in a year
+still needs them.
+
+`/end-session` step 11 remains the backstop. It compares `chezmoi
+managed` against the real contents of `~/.claude/commands/` and
+`~/.claude/bin/`, so it catches drift the list doesn't know about — a
+file retired without a list entry, or one left by another tool.
+
+[dotfiles-371]: https://github.com/pmgledhill102/dotfiles/issues/371
 
 [issue-125]: https://github.com/pmgledhill102/agentic-coding-config/issues/125
 

--- a/home/bin/claude-prune-retired
+++ b/home/bin/claude-prune-retired
@@ -1,0 +1,78 @@
+#!/bin/sh
+# claude-prune-retired — remove files retired from agentic-coding-config's
+# home/ that chezmoi left behind at ~/.claude/.
+#
+# chezmoi only adds and updates target files; it never removes a target whose
+# source was deleted. A retired slash command therefore survives at
+# ~/.claude/commands/ on every machine that ever applied a version containing
+# it, and Claude Code keeps listing it. This script closes that gap by
+# deleting an explicit list of retired paths (~/.claude/retired-paths).
+#
+# Why a list rather than `exact = true` on the externals: exact would prune
+# anything not in the archive, including files added by hand on one machine
+# that nobody remembers. The list is more tiresome to maintain but its blast
+# radius is exactly what is written down.
+#
+# Invoked by dotfiles after each `chezmoi apply` (pmgledhill102/dotfiles#371);
+# safe to run by hand at any time. Idempotent — a path already gone is a
+# no-op, so repeated runs converge and never error.
+#
+# Usage: claude-prune-retired [-n|--dry-run]
+# Exit: 0 always, unless the list itself is unreadable. Never fails an apply
+#       over a single bad entry — it warns and moves on.
+
+set -eu
+
+CLAUDE_DIR="${CLAUDE_DIR:-$HOME/.claude}"
+LIST="$CLAUDE_DIR/retired-paths"
+dry_run=0
+
+case "${1:-}" in
+    -n|--dry-run) dry_run=1 ;;
+    '') ;;
+    *) echo "usage: $(basename "$0") [-n|--dry-run]" >&2; exit 2 ;;
+esac
+
+# No list means nothing has been retired yet, or this machine predates the
+# mechanism. Either way there is nothing to do.
+[ -f "$LIST" ] || exit 0
+
+pruned=0
+while IFS= read -r line || [ -n "$line" ]; do
+    # Strip trailing whitespace; skip blanks and comments.
+    path=$(printf '%s' "$line" | sed 's/[[:space:]]*$//')
+    case "$path" in
+        '' | '#'*) continue ;;
+    esac
+
+    # Refuse anything that could escape ~/.claude/. A typo here would
+    # otherwise delete an arbitrary file on every machine, every apply.
+    case "$path" in
+        /* | *..*)
+            echo "claude-prune-retired: refusing unsafe entry: $path" >&2
+            continue
+            ;;
+    esac
+
+    target="$CLAUDE_DIR/$path"
+    [ -e "$target" ] || continue
+
+    # Directories are out of scope: the retired set is individual commands and
+    # scripts, and a stray directory entry should be looked at by a human.
+    if [ -d "$target" ]; then
+        echo "claude-prune-retired: skipping directory: $path" >&2
+        continue
+    fi
+
+    if [ "$dry_run" -eq 1 ]; then
+        echo "would prune $target"
+    else
+        rm -f "$target"
+        echo "pruned $target"
+    fi
+    pruned=$((pruned + 1))
+done < "$LIST"
+
+# $(( )) returns exit 1 when the result is 0, which would trip `set -e` on the
+# last increment — hence the explicit exit.
+exit 0

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -228,7 +228,9 @@ Suggested: rm ~/.claude/commands/old-thing.md ~/.claude/bin/legacy-script
 
 Don't `rm` automatically — the user might be testing an unstaged file, or these may belong to another tool. The check is "fast" (one `chezmoi managed` + two `find`s) so it runs unconditionally per session.
 
-Note this check is a *detector*, not the fix, and it is per-machine: clearing the list here does nothing for the same stale file on any other workstation. The permanent fix is `exact = true` on `.claude/commands` and `.claude/bin` as separately-declared archive externals in `dotfiles`, which makes `chezmoi apply` prune them everywhere. Do **not** propose a `run_onchange_` script in `agentic-coding-config`'s `home/` as an alternative — archive externals aren't source state, so the filename prefix is never interpreted and the script would just deploy as an inert file (see that repo's README, "Deleting a file here does not delete it on machines").
+Note this check is a *detector*, not the fix, and it is per-machine: clearing the list here does nothing for the same stale file on any other workstation. The fix is `~/.claude/bin/claude-prune-retired`, which deletes the paths listed in `~/.claude/retired-paths` and is invoked by `dotfiles` after each `chezmoi apply`. So when a stale file turns up here **and** it was retired from `agentic-coding-config`, the durable fix is to add its path to that repo's `home/retired-paths` — not just to `rm` it locally. Files this check surfaces that were *never* managed (left by another tool, or hand-written) don't belong in the list; `rm` those or leave them.
+
+Do **not** propose a `run_onchange_` script in `agentic-coding-config`'s `home/` as an alternative — archive externals aren't source state, so the filename prefix is never interpreted and the script would just deploy as an inert file (see that repo's README, "Deleting a file here does not delete it on machines").
 
 ### 12. Other worktrees (Tier 3 — surface)
 

--- a/home/retired-paths
+++ b/home/retired-paths
@@ -1,0 +1,31 @@
+# Files retired from this repo's home/ that must also be removed from
+# ~/.claude/ on every machine.
+#
+# WHY THIS FILE EXISTS: chezmoi only adds and updates target files. It never
+# removes a target whose source was deleted. So deleting home/commands/foo.md
+# leaves ~/.claude/commands/foo.md in place on every machine that ever applied
+# a version containing it — and Claude Code goes on offering /foo as a slash
+# command. See the README, "Deleting a file here does not delete it on
+# machines".
+#
+# HOW IT IS CONSUMED: ~/.claude/bin/claude-prune-retired reads this file and
+# removes each listed path. dotfiles invokes that script after each
+# `chezmoi apply` (pmgledhill102/dotfiles#371).
+#
+# FORMAT: one path per line, relative to ~/.claude/. Blank lines and lines
+# starting with # are ignored. Absolute paths and paths containing .. are
+# refused by both the pruner and CI.
+#
+# TO RETIRE A FILE: delete it from home/ and add its ~/.claude/-relative path
+# here, in the same PR. CI fails if an entry here still exists in home/, so a
+# premature or mistyped entry can't ship.
+#
+# Entries are permanent. Removing a line once the file is gone everywhere is
+# not worth the risk — a machine that hasn't been applied to in a year still
+# needs it. Group by retirement with a dated comment.
+
+# 2026-07-18 (d7a3f6d) — beads tracker retired in favour of GitHub Issues (#123)
+commands/bd-enable-server-mode.md
+commands/bd-import-github-issues.md
+commands/bd-modernize.md
+bin/bd-push-safe


### PR DESCRIPTION
Implements #125 with the **explicit retired-paths list**, per your call on the mechanism. Supersedes the scoped-`exact` recommendation documented in #130 — this PR corrects that text.

## Why the list, not `exact = true`

`exact` prunes anything not in the archive, including files added by hand on a machine nobody remembers. The list is more tiresome to maintain, but its blast radius is exactly what's written down. (`exact` on `.claude` itself would have been worse still — it would delete Claude Code's runtime state: `projects/`, `todos/`, `plugins/`, `history.jsonl`, `settings.local.json`.)

## The split that makes it not-tiresome

Both halves live **here**, so a retirement is a single-repo change:

| File | Role |
| --- | --- |
| `home/retired-paths` | The list — one `~/.claude/`-relative path per line, seeded with the four `bd-*` files from `d7a3f6d` |
| `home/bin/claude-prune-retired` | Reads the list, removes each path |

Delete the file from `home/`, add its path to `home/retired-paths`, same PR. `dotfiles` only ever has to invoke `~/.claude/bin/claude-prune-retired` after apply ([dotfiles#371](https://github.com/pmgledhill102/dotfiles/issues/371), rewritten to match) — three lines it never has to touch again. The alternative, keeping the list in dotfiles, would have split every retirement across two repos, which is exactly the friction that makes a manual list rot.

## Safety

The pruner refuses absolute paths and anything containing `..`, skips directories, is idempotent (a path already gone is a no-op), and never fails an apply over one bad entry — it warns and moves on.

The new **`retired-paths validity` CI job** rejects an entry that is absolute, contains `..`, or **still exists in `home/`**. That last case is the dangerous one: the pruner would delete a live file on every apply and chezmoi would restore it on the next, forever. Catching it in CI means a mistyped or premature entry never reaches a machine.

`home/bin/claude-prune-retired` is committed `100755`, so the GitHub tarball carries the executable bit through to `~/.claude/bin/` the same way the existing scripts do — no `executable = true` needed on the external.

## Also corrected from #130

- **README** — the "Retiring a file" procedure replaces the scoped-`exact` recommendation
- **`end-session.md` step 11** — now says the durable fix for a stale file that *was* managed is a `retired-paths` entry, not a local `rm`; and that files it surfaces which were never managed (left by another tool, hand-written) don't belong in the list. It stays the backstop, since it catches drift the list doesn't know about.

## Verification

- `shellcheck home/bin/claude-prune-retired` — clean
- `actionlint .github/workflows/ci.yml` — clean
- `markdownlint-cli2 "**/*.md"` — 0 issues across 29 files
- Pruner exercised against a fixture: deletes listed files, leaves unlisted ones, refuses `..` and `/etc/passwd`, second run is a clean no-op with exit 0
- CI guard exercised against both failure modes (`settings.json` as a still-present entry, `../escape` as unsafe) — correctly exits 1; passes on the real list

`home/settings.json` is untouched, so the settings-sync check doesn't apply. No new permission rule is needed — `dotfiles` invokes the pruner from a chezmoi script, not from a Claude session.

Refs #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSQkPFtdfciBorkd133TvS

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSQkPFtdfciBorkd133TvS)_