### PR TITLE
Add strategic review and ADRs 0014/0015 for portable agent config (#136)

### DIFF
--- a/adrs/0014-portable-agent-config-architecture.md
+++ b/adrs/0014-portable-agent-config-architecture.md
@@ -1,0 +1,111 @@
+# ADR-0014: Portable agent-config architecture (skills-first, provider-neutral core)
+
+- **Status**: Proposed
+- **Date**: 2026-08-09
+- **Tags**: claude-code, codex, opencode, skills, plugins, architecture
+- **Scope**: user (applies to all personal repos and agent surfaces)
+
+## Context
+
+This repo's content is delivered exclusively by chezmoi mounting `home/`
+at `~/.claude/` on local machines. Two shifts have broken that model's
+coverage:
+
+1. **Most work now runs in cloud sandboxes**, which never read
+   `~/.claude/` — on Claude and Codex alike, only repo-committed config,
+   managed settings, and environment setup scripts reach a session.
+2. **Multiple providers are in play** (Claude Code, OpenAI Codex,
+   OpenCode), and the ecosystem has standardised: AGENTS.md for
+   instructions, the open Agent Skills spec (SKILL.md, ~44 clients) for
+   workflows, Claude-shaped `hooks.json` now shared by Codex, plugin
+   marketplaces on both Claude and Codex — with Codex reading Claude's
+   plugin manifest directly.
+
+The full evidence base is in
+[#136](https://github.com/pmgledhill102/agentic-coding-config/issues/136)
+and the [strategic review](../docs/reviews/strategic-review-2026-08-09.md).
+
+## Decision
+
+Restructure this repo around a **provider-neutral content core with thin
+per-provider adapters**, distributed as a plugin, with an explicitly
+machine-local residue left on the chezmoi path.
+
+1. **Workflows become skills.** The command library converts from
+   Claude-format `commands/*.md` to SKILL.md skills (Agent Skills spec).
+   Skills are the portable unit: native in Claude Code, Codex (its
+   primary customisation unit), OpenCode, Gemini CLI, Cursor and
+   Copilot. Skill bodies avoid `$ARGUMENTS`/`` !`cmd` ``/`@file`
+   templating, which Codex rejects; arguments arrive as free text.
+2. **Policy becomes an AGENTS.md-format core.** The portable part of
+   `home/CLAUDE.md` (git workflow, work tracking, process guidelines)
+   is maintained once in AGENTS.md form. Claude Code consumes it via
+   the documented `CLAUDE.md` → `@AGENTS.md` import bridge;
+   Codex/OpenCode read it natively. Claude-specific guidance (MCP tool
+   mappings) lives in a Claude adapter, not the core.
+3. **Distribution is a dual-manifest plugin in this repo.** The repo
+   becomes its own marketplace: Claude `.claude-plugin/marketplace.json`
+   plus the portable `plugin.json` / `.agents/plugins/marketplace.json`
+   metadata Codex discovers. One plugin ships skills, hooks and the
+   policy core to both providers.
+   - **Local machines**: plugin installed at user scope (bootstrap step
+     in dotfiles).
+   - **Cloud sessions**: project-scope enablement in each repo's
+     committed `.claude/settings.json` (`extraKnownMarketplaces` +
+     `enabledPlugins`), added by `/setup-common` so every repo gains it
+     on its next setup refresh.
+4. **Hooks port to the shared `hooks.json` shape** (identical event
+   names on Claude and Codex). Scripts move into the plugin and are
+   referenced plugin-relative, not via `~/.claude/bin/`. An OpenCode JS
+   shim is written only if OpenCode becomes a daily driver.
+5. **The machine-local residue stays on chezmoi**: permissions
+   allowlist, statusline, machine-specific policy fragment, MCP wiring
+   (in dotfiles). The `home/` external shrinks to exactly this set,
+   using the existing `retired-paths` machinery for the cutover.
+6. **The permissions allowlist is frozen.** It remains a local-machine
+   convenience; no proactive curation; additions only on real local
+   friction. It is not ported to other providers (no common model
+   exists) and is absent from cloud by design — the sandbox risk model
+   makes that acceptable.
+7. **Issue #48 is re-scoped** to implement this architecture
+   (skills-first, dual manifest) rather than a commands-directory port.
+
+## Consequences
+
+### Positive
+
+- One content core reaches local Claude, cloud Claude, Codex (local and
+  cloud), and OpenCode — the "lost personal content in sandboxes"
+  problem is closed by construction, not per-machine sync.
+- Skills' progressive disclosure preserves the repo's low-context-cost
+  design principle; nothing loads until invoked.
+- The chezmoi surface shrinks to config that is genuinely
+  machine-local, ending the false expectation that `~/.claude/` content
+  follows the user everywhere.
+- Betting on published specs (AGENTS.md, Agent Skills) replaces betting
+  on one vendor's directory layout.
+
+### Negative / trade-offs
+
+- A migration period with content in two shapes (commands and skills);
+  the `retired-paths` mechanism must be driven carefully to avoid
+  duplicate commands on local machines.
+- Cloud reach requires a one-time `.claude/settings.json` commit per
+  repo (mitigated by folding it into `/setup-common`).
+- Codex parity for argument-templated commands means rewording, not
+  mechanical conversion.
+- The public repo constrains content to public-safe material (already
+  true; private context stays in paul-context).
+
+## Alternatives considered
+
+- **Keep chezmoi-only delivery** — leaves every cloud session without
+  personal config; rejected as the status quo being reviewed.
+- **Per-repo `.claude/` duplication** — copies commands/skills into
+  every repo; N-way drift, no user-level story; rejected.
+- **Cloud environment setup scripts writing `~/.claude` / `~/.codex`
+  in-container** — undocumented whether either cloud agent honours it;
+  usable as an experiment, not a foundation.
+- **Claude-only plugin (original #48 shape)** — solves cloud Claude but
+  leaves Codex/OpenCode out just as the formats converge; superseded by
+  the dual-manifest approach.

--- a/adrs/0015-tiered-adrs.md
+++ b/adrs/0015-tiered-adrs.md
@@ -1,0 +1,92 @@
+# ADR-0015: Tiered ADRs — personal, user-level, and repo-level decision records
+
+- **Status**: Proposed
+- **Date**: 2026-08-09
+- **Tags**: workflow, adr, documentation
+- **Scope**: user (applies to all personal repos)
+
+## Context
+
+Per-repo ADRs have proven one of the highest-value habits in this
+estate: decisions survive context loss, agents can read the "why" before
+proposing changes, and `/repo-review` audits them for currency.
+
+But decisions don't all have repo-sized scope, and the estate already
+routes around that fact informally: `paul-context/decisions/` holds
+private cross-repo decisions (the a-c-c split, the journal-inbox
+pattern), this repo's `adrs/` holds agentic-workflow decisions that
+affect every repo (GitHub Issues for tracking, and now ADR-0014), and
+project repos hold their own. The tiers exist; nothing declares them,
+so a session in a project repo has no reliable way to discover that a
+user-level decision applies, and there is no convention for a repo
+deviating from a higher-tier decision.
+
+## Decision
+
+Make the existing three tiers explicit, with declared scope, a
+discovery path, and supersession rules — no new tooling or repos.
+
+### The tiers
+
+| Tier | Home | Holds | Visibility |
+| --- | --- | --- | --- |
+| **Personal** | `paul-context/decisions/` | Life/estate decisions, private rationale, repo registry choices | Private |
+| **User** | `agentic-coding-config/adrs/` | How I work with agents and repos, across the estate (workflow, tooling, conventions) | Public |
+| **Repo** | `<repo>/adrs/` | Architecture and technology choices for that repo | Repo's own |
+
+### Conventions
+
+1. **Every ADR declares its scope** with a `Scope:` header line —
+   `personal`, `user`, or `repo` — so a reader (human or agent) knows
+   the blast radius without inferring it from the repo it sits in.
+2. **Placement follows scope, not convenience.** The authoring test:
+   *would this decision still bind if the current repo were archived?*
+   If yes, it is not repo-tier. Public-safe cross-repo decisions go to
+   the user tier here; anything private goes to the personal tier.
+3. **Discovery is via the policy file.** The portable policy core
+   (ADR-0014) states where user-tier ADRs live; each repo's own policy
+   file (`CLAUDE.md`/`AGENTS.md`) already points agents at its local
+   `adrs/`. Higher tiers are consulted on demand — linked, not copied,
+   so there is one source of truth and no sync burden.
+4. **Lower tiers may deviate, explicitly.** A repo ADR can override a
+   user-tier decision for that repo only, and must reference the ADR it
+   deviates from and why (mirroring how repo CLAUDE.md label taxonomies
+   already override the a-c-c defaults). Silent divergence is the
+   failure mode this rule exists to prevent.
+5. **Numbering stays per-home** (each ADR directory keeps its own
+   sequence); cross-tier references use full URLs, which also work from
+   sandbox sessions with no local clones.
+6. **`/repo-review` audits tier fit**: flag ADRs whose content outgrew
+   their declared scope (a repo ADR that other repos now depend on
+   should be promoted to user tier, with a stub left behind).
+
+## Consequences
+
+### Positive
+
+- A decision made once binds everywhere it should, and agents can find
+  it from any repo — including sandbox sessions, via URLs.
+- Deviations become visible and reasoned instead of silent drift.
+- Zero new infrastructure: three existing homes, one new header line,
+  one authoring question.
+
+### Negative / trade-offs
+
+- Scope classification is a judgment call; the review backstop is
+  `/repo-review`, not enforcement.
+- Personal-tier decisions remain invisible to sandbox sessions (private
+  repo) — public-safe summaries must be duplicated to the user tier
+  when agents need them, a deliberate cost of the public/private split.
+- Promoting an ADR between tiers moves its URL; stubs mitigate but
+  don't eliminate stale links.
+
+## Alternatives considered
+
+- **Single central ADR repo for everything** — breaks "decision lives
+  with the code it governs" for repo-tier ADRs and forces
+  public/private into one home; rejected.
+- **Copying applicable user ADRs into each repo** — guarantees drift;
+  linking beats copying; rejected.
+- **A dedicated shared-tier per repo-group** (e.g. per-domain ADR
+  repos) — no current grouping needs it; the user tier covers today's
+  sharing; revisit if a genuine multi-repo domain emerges.

--- a/docs/reviews/strategic-review-2026-08-09.md
+++ b/docs/reviews/strategic-review-2026-08-09.md
@@ -1,0 +1,221 @@
+# Strategic review: mission and approach in a cloud-first, multi-provider world
+
+- **Date**: 2026-08-09
+- **Tracking**: [#136](https://github.com/pmgledhill102/agentic-coding-config/issues/136)
+- **Decisions arising**: [ADR-0014](../../adrs/0014-portable-agent-config-architecture.md)
+  (portable architecture), [ADR-0015](../../adrs/0015-tiered-adrs.md) (tiered ADRs)
+
+This review answers the seven questions in #136: what this repo is actually
+for, which assets genuinely add value, and whether the approach is forcing
+things into a box that no longer fits.
+
+## 1. Verdict up front
+
+**The box is not being forced — the ecosystem moved toward this repo's
+model.** Since January, the things this repo bet on (markdown-encoded
+workflows, lean policy files, hooks as enforcement, config-as-code) have
+become cross-provider standards: AGENTS.md for policy, the Agent Skills
+spec (SKILL.md) for workflows, Claude-shaped `hooks.json` for lifecycle
+hooks (now also Codex's format), and plugin marketplaces for distribution.
+
+What *has* broken is the **delivery mechanism**. The chezmoi →
+`~/.claude/` pipeline only reaches local machines, and most work now
+happens in cloud sandboxes that never read it. The content is right; the
+pipe is pointed at the wrong place.
+
+## 2. Mission
+
+The repo's contents decompose into four concerns with different
+portability needs. Naming them separately is the core clarification —
+previous framing ("Claude Code config") bundled them and hid the fact
+that only one of the four is inherently machine-local.
+
+| Concern | Examples here | Must reach | Portable form |
+| --- | --- | --- | --- |
+| **Policy** — how agents should behave | `home/CLAUDE.md` | every provider, every surface | AGENTS.md content core |
+| **Workflows** — repeatable procedures | `/setup-*`, `/repo-review`, session lifecycle | every provider, every surface | SKILL.md skills |
+| **Enforcement** — quality gates | PreToolUse guards, terraform fmt hook | Claude + Codex (shared `hooks.json` shape); CI remains the backstop everywhere | portable hooks + CI |
+| **Machine bootstrap** — local conveniences | permissions allowlist, statusline, MCP wiring | local machines only | chezmoi (shrunken residue) |
+
+Restated mission: **this repo is the portable definition of how I work
+with any coding agent, on any surface** — a provider-neutral content core
+(policy, skills, hooks) plus thin per-provider adapters — with a small,
+explicitly machine-local residue still delivered by chezmoi/dotfiles.
+
+## 3. What changed since January (evidence)
+
+Full research is in #136 and its comments; the load-bearing facts:
+
+- **Cloud sessions ignore user-level config** on both Claude and Codex.
+  Only repo-committed config, org managed settings, and environment
+  setup scripts reach a sandbox. The permissions allowlist, user hooks,
+  and user commands are silently absent from most sessions now.
+- **Claude plugins reach cloud sessions** when enabled at project scope
+  in a committed `.claude/settings.json` (`extraKnownMarketplaces` +
+  `enabledPlugins`). This is the one personal-account mechanism that
+  closes the cloud gap.
+- **Agent Skills (SKILL.md) is an open spec with ~44 clients**, including
+  Codex, OpenCode, Cursor, Gemini CLI, and Copilot. The vendor-neutral
+  `.agents/skills/` (project) and `~/.agents/skills/` (user) paths are
+  scanned natively by Codex, OpenCode, and Gemini CLI.
+- **Codex deprecated custom prompts in favour of skills** and auto-
+  migrates plugin `commands/` to skills — but rejects `$ARGUMENTS`,
+  `$1..$n`, `` !`cmd` `` and `@file` templating as unsupported.
+- **Codex adopted Claude's hook model** (same event names, matcher
+  groups, `hooks.json`) and **reads Claude's `.claude-plugin/plugin.json`
+  manifest**, so one plugin repo can serve both providers.
+- **AGENTS.md is read by every major agent except Claude Code**, whose
+  documented bridge is a `CLAUDE.md` containing `@AGENTS.md`.
+- **No standard exists for permissions**; Claude, Codex and OpenCode
+  each have incompatible models.
+
+## 4. Asset-by-asset verdicts
+
+| Asset | Verdict | Summary |
+| --- | --- | --- |
+| `/setup-*` library (15 provider-neutral commands) | **Keep → convert** | Highest-value content; convert to SKILL.md skills |
+| `/repo-review` | **Keep → convert** | Same as above |
+| `/start-session`, `/end-session` + `bin/` gather scripts | **Keep → transform** | Surface-aware rework; plugin-relative paths |
+| `/retrospective` | **Keep → trim** | Already sandbox-aware; remove residual local assumptions |
+| `/promote-journal-inbox` | **Keep as-is** | Local-only by design (runs from the paul-context clone) |
+| `home/CLAUDE.md` | **Split** | Portable policy core + Claude adapter + machine-local fragment |
+| `settings.json` permissions allowlist | **Demote / freeze** | Local convenience only; stop investing |
+| Guard hooks (prepush, precommit, prchecks-wait, terraform fmt) | **Keep → port** | Move to portable `hooks.json` (Claude + Codex shape) |
+| Statusline (`cship`), MCP wiring (dotfiles) | **Keep local** | Machine-bootstrap residue |
+| chezmoi archive external + `retired-paths` | **Shrink** | Delivers only the residue after migration; retired-paths machinery drives the cutover |
+
+### 4.1 The command library → skills
+
+Fifteen of twenty-one commands contain zero Claude-specific references;
+they are provider-neutral procedures that happen to live in a
+Claude-shaped directory. Converting them to SKILL.md skills makes them
+loadable by every major agent, and skills' progressive-disclosure model
+matches the library's own design principle (load only when invoked).
+
+Conversion caveat: heavy `$ARGUMENTS` / `` !`cmd` `` / `@file` templating
+does not port to Codex skills. The setup library barely uses these;
+where a command does, the skill body should absorb the argument as free
+text ("the user names the target repo in their request") rather than
+positional substitution.
+
+### 4.2 Session lifecycle
+
+`/start-session` and `/end-session` encode real, hard-won workflow (the
+three-tier action model, the gather-script pattern) and stay. Their
+transforms: reference scripts via plugin-relative paths instead of
+`~/.claude/bin/`, and make machine-specific steps (chezmoi drift check,
+stash hygiene) conditional on the surface — a sandbox session has no
+chezmoi and no long-lived stashes.
+
+### 4.3 Retrospective — smaller job than feared
+
+The concern in #136 was that `/retrospective` is "highly opinionated
+around locally running agents". On inspection that is mostly **already
+fixed**: the May–August revisions added the GitHub-Issue journal
+fallback for sandboxes, banned direct settings edits in favour of a-c-c
+issues, and retired `retros.md`. What remains local-flavoured:
+
+- reads `~/.claude/settings.json` and `~/.claude/projects/<p>/memory/`
+  (absent or empty in sandboxes — steps should degrade explicitly);
+- routing heuristics assume the dotfiles/a-c-c/paul-context triad
+  (fine — that is the actual estate);
+- the "approval friction" dimension is meaningless in a sandbox and
+  should be skipped there, replaced by a cloud-specific dimension:
+  *what config/context was missing from this sandbox session?* — which
+  is exactly the signal that feeds this repo's backlog.
+
+### 4.4 Policy file split
+
+`home/CLAUDE.md` mixes three audiences and should split along the
+concern boundary:
+
+- **Portable core** (git workflow, work tracking, process guidelines,
+  commit/PR style): becomes the AGENTS.md-format policy source, delivered
+  to each provider by its adapter.
+- **Claude adapter** (MCP tool mappings, `mcp__github__*` preferences):
+  Claude-only delivery.
+- **Machine-local fragment** ("~/.claude is chezmoi-managed", zsh word-
+  splitting, macOS paths): stays chezmoi-deployed, never reaches cloud.
+
+### 4.5 Permissions allowlist — demoted honestly
+
+The ~280-rule allowlist absorbed significant curation effort and is now
+bypassed by most sessions (cloud sandboxes run their own permission
+model against isolated, disposable infrastructure — the lower risk is
+real, not negligence). It is not portable to Codex or OpenCode. Decision
+(ADR-0014): keep it as a frozen local-machine convenience; additions
+only when local friction actually bites; no proactive curation; the
+retrospective's "approval friction" dimension stops feeding it except
+for local sessions.
+
+## 5. Tiered ADRs
+
+Per-repo ADRs are among the highest-value habits here, and the tiers
+already exist implicitly: `paul-context/decisions/` holds private
+cross-repo decisions, a-c-c `adrs/` holds agentic-workflow decisions,
+each project repo holds its own. ADR-0015 makes the model explicit —
+three tiers (personal-private, user-public, repo), a `Scope` header
+field, discovery via each repo's policy file, and cross-tier
+supersession rules — without inventing new infrastructure.
+
+## 6. Google Cloud credentials for sandbox agents (the unsolved gap)
+
+No runbook exists for giving a sandbox agent scoped GCP access. The
+shape of the solution (to be validated when the runbook is written):
+
+1. **Per-project dedicated service account** for agent use, named so
+   audit logs are unambiguous (e.g. `agent-sandbox@<project>`), with the
+   minimal role set for the task at hand — never a personal identity or
+   an owner-role account.
+2. **Short-lived credentials preferred**: mint access tokens via
+   `gcloud auth print-access-token --impersonate-service-account` from a
+   trusted machine when kicking off work, or use service-account key +
+   tight roles + scheduled rotation where a session must self-serve.
+   (Cloud sandboxes have no OIDC identity to federate today, so full
+   keyless workload-identity federation is not currently available —
+   revisit if the platform exposes one.)
+3. **Delivery via environment secrets**: the key/token lives in the
+   cloud environment's secret env vars, scoped to the one environment
+   that needs it — never committed, never pasted into prompts.
+4. **Standing revocation path**: document the one-liner to disable the
+   SA and the expectation that sandbox-facing SAs are disposable.
+
+## 7. Boundary with dotfiles
+
+dotfiles' mission — a consistent feel across local environments — is
+untouched; what shrinks is the *agent config* passing through it.
+
+- **dotfiles keeps**: machine bootstrap, secrets (age), MCP wiring
+  (`claude mcp add`), shell/OS config, and the chezmoi external that
+  delivers this repo's machine-local residue (permissions, statusline,
+  local policy fragment).
+- **This repo keeps**: everything portable — policy core, skills, hooks,
+  plugin packaging — delivered by plugin install / repo commit rather
+  than file-mount.
+- **The cutover** uses the existing `retired-paths` machinery: as
+  content migrates to the plugin, retire the corresponding
+  `~/.claude/commands/*` and `~/.claude/bin/*` paths so machines don't
+  see duplicates. The dotfiles-side change (external `include` narrows,
+  plugin install added to bootstrap) needs an issue filed in dotfiles
+  from a session with access there.
+
+## 8. Decision on #48
+
+**Reshape, then proceed.** #48 predates the Codex/skills findings; the
+plugin remains the right distribution vehicle for Claude surfaces, but
+its content should be skills-first (not a commands-directory port), its
+manifests dual (Claude `.claude-plugin/` + portable `plugin.json` so
+Codex can consume the same repo), and its layout anchored on the
+vendor-neutral `.agents/skills/` convention. Details in ADR-0014.
+
+## 9. Follow-on work
+
+Filed as sub-issues of #136:
+
+- Reshape and implement plugin distribution (existing #48, re-scoped)
+- Convert the provider-neutral command library to SKILL.md skills
+- Split `home/CLAUDE.md` into portable core + adapter + local fragment
+- Surface-aware rework of session-lifecycle commands; retrospective trim
+- Write the sandbox GCP credentials runbook
+- Implement tiered ADR conventions (ADR-0015)
+- Shrink the chezmoi-deployed surface to the machine-local residue


### PR DESCRIPTION
Deep-dive review answering #136: mission restated as a provider-neutral content core (policy/workflows/enforcement) with a machine-local residue; asset-by-asset keep/transform/retire verdicts; permissions allowlist demoted to frozen local convenience; GCP sandbox-credential runbook sketched; dotfiles boundary redrawn.

ADR-0014 (Proposed): skills-first architecture — SKILL.md content core, AGENTS.md policy with CLAUDE.md import bridge, dual-manifest plugin distribution reaching Claude and Codex including cloud sessions; re-scopes #48.

ADR-0015 (Proposed): tiered ADRs — personal/user/repo tiers with declared Scope, link-based discovery, and explicit cross-tier supersession.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

Claude-Session: https://claude.ai/code/session_013jURFzVAohShzjt5qZvr2N