### PR TITLE
docs: adopt end-session-design from dotfiles

### DIFF
--- a/docs/end-session-design.md
+++ b/docs/end-session-design.md
@@ -1,0 +1,168 @@
+# /end-session — Design & Retrospective
+
+This document captures the reasoning behind the `/end-session` slash command's shape — in particular why its Phase 1 gather runs inside a shell script rather than inline.
+
+- Command spec: [`home/commands/end-session.md`](../home/commands/end-session.md)
+- Scripts: [`home/bin/`](../home/bin/)
+
+## What `/end-session` does
+
+Single-invocation tidy-up to leave a repo at a verifiable "clean walk-away" point: fetch + prune, rebase `main`, prune dead branches (merged and squash-merged), surface outstanding PRs / stashes / assigned issues / stale Claude files / worktrees, then offer the retrospective.
+
+Every step is classified by how much human judgment it needs:
+
+- **Tier 1** — auto-act, no prompt (fetch, pull, read-only lists).
+- **Tier 2** — auto-act behind one batched confirmation (branch deletes, push-if-ahead).
+- **Tier 3** — surface only, user drives (open PRs, in-progress issues, stashes, user-started processes).
+
+When in doubt we downgrade a tier rather than upgrade.
+
+## Retrospective — why the script split exists
+
+Two observations from using the command in anger.
+
+> This section is a record of the April 2026 design work, not a
+> description of today's pipeline. It refers to `bd dolt push`, which was
+> genuinely one of the original 14 calls — beads was the tracker at the
+> time and has since been retired (see
+> [ADR-0013](../adrs/0013-github-issues-for-work-tracking.md)). Left as
+> written: editing it would falsify the measurement rather than update it.
+
+### Observation 1 — recurring approval prompts
+
+Two steps of Phase 1 triggered explicit approval prompts every run, even though every individual sub-command in them was already on the permission allowlist:
+
+- Step 1 (state gather) — a compound `echo "===pwd==="; pwd; echo "===status==="; git status ...` block.
+- Step 6 Batch B (squash-merged detection) — a pipeline of `git for-each-ref | awk | grep | while read … git diff …`.
+
+**Root cause.** The Claude Code permission matcher sees a Bash tool call as a single command string. A pattern like `Bash(git status *)` matches a call whose command begins with `git status` — it does **not** match a compound block that happens to contain `git status` alongside other commands. So compound blocks never match a narrow allow rule no matter how many of their pieces are allowed individually.
+
+Three ways to fix this:
+
+1. Pre-approve the exact compound strings. Brittle — any whitespace edit breaks the match.
+2. Split the block into N individual tool calls. Works for Step 1 but not for Step 6 Batch B's pipeline, and inflates tool-call count / output noise.
+3. Extract the compound logic into a script and allow the script's path. One rule; shellcheck-testable; editable without reshuffling permissions.
+
+We picked (3).
+
+### Observation 2 — round-trip latency dominates
+
+The original Phase 1 issued ~14 sequential Bash tool calls. For each one: the model emits the call, the runtime runs the command (often network-bound — `git fetch`, `gh run list`, `gh pr list`, `bd dolt push`), the result comes back, the model reads it and emits the next call. With a large context (1M), every round trip costs meaningful seconds of model latency **independent of** the command's own runtime.
+
+Of those 14 calls, 8 are independent read-only queries with no inter-dependencies — they can all run in parallel after `git fetch`. Serialising them doubled the latency for no correctness benefit.
+
+Extracting the gather into a script that runs `git fetch` first, then fans out the 8 reads with `&` + `wait`, collapses:
+
+- ~8 sequential tool calls into 1.
+- Summed serial network latency into max-of-parallel.
+- ~7 model-turn round-trips (each ~3–8s at 1M context) into 1.
+
+Measured on the `dotfiles` repo (2026-04-21): Phase 1 gather wall time dropped from an estimated ~70s total to ~15s end-to-end (fetch-dominated). The remaining steps (Tier 2 destructive actions, `bd dolt push`, summary) are serial because they either need a y/n or depend on prior output.
+
+### Decision
+
+Extract two scripts, land one allow rule, rewrite Phase 1 to consume sectioned output. `/retrospective` was deliberately left alone — it's short, doesn't have multi-line approval blockers, and its value is in agentic reasoning rather than fixed commands; parallelisation would buy nothing.
+
+## Architecture
+
+```text
+/end-session  (home/commands/end-session.md)
+    │
+    ├── Step 1  → ~/.claude/bin/end-session-gather-state
+    │                  │
+    │                  ├── git fetch --all --prune --tags   (blocks)
+    │                  └── parallel fan-out:
+    │                        ├── local_state   (status, branch, log, origin)
+    │                        ├── stashes
+    │                        ├── worktrees
+    │                        ├── merged_brs
+    │                        ├── main_ci       (gh run list)
+    │                        ├── open_prs      (gh pr list)
+    │                        ├── gh_assigned   (gh issue list)
+    │                        └── stale_claude_files (~/.claude drift scan)
+    │
+    ├── Steps 2, 3, 6A, 8–12  → read sections from gather output (no tool call)
+    ├── Step 4          → prompt on dirty/unpushed (reads local_state)
+    ├── Step 5          → git checkout main + git pull --rebase
+    ├── Step 6 Batch B  → ~/.claude/bin/end-session-squash-merged
+    ├── Step 7          → git log origin/main..HEAD (conditional push)
+    ├── Step 13         → background process housekeeping
+    └── Step 14         → agent-authored summary
+```
+
+## Output protocol — gather script
+
+```text
+===<section> (exit=<N>)===
+<section stdout+stderr>
+```
+
+Sections, in emission order: `fetch`, `local_state`, `stashes`, `worktrees`, `merged_brs`, `main_ci`, `open_prs`, `gh_assigned`, `stale_claude_files`.
+
+Progress pings go to stderr (`[gather] …`) so a human watching sees something move without polluting the parseable stream on stdout.
+
+### Exit code semantics
+
+| Outcome | Meaning |
+| --- | --- |
+| `exit=0`, empty content | Clean result — treat as "none". |
+| `exit=0`, content | Normal data — parse for the corresponding step. |
+| `exit != 0`, content `gh-unavailable` | Silent skip (no `gh` installed). Steps 3 and 8 degrade. |
+| `exit != 0`, other content | Real error — surface before continuing Phase 1. |
+
+Sections where empty output is expected (e.g., `merged_brs` grep returning no matches) append `|| true` inside the script so `exit=0` remains meaningful.
+
+## The squash-merged script
+
+Emits branches that satisfy both:
+
+1. `upstream: gone` — the tracking branch was deleted upstream (typical after a GitHub squash-merge + auto-delete).
+2. `git diff --quiet main..<branch>` succeeds — the branch's tree is already represented on main.
+
+Both are required. Rule 1 alone would include legitimate un-merged branches whose remote was deleted; rule 2 alone can't easily distinguish branches the user hasn't merged yet. Together, they identify branches whose content has landed via squash-merge and are safe for `-D`.
+
+## Permission model
+
+One allow rule covers both scripts and any future `end-session-*` sibling:
+
+```text
+Bash(~/.claude/bin/end-session-*)
+```
+
+Scope rationale: the prefix binds to scripts installed from this repo (`home/bin/end-session-*` deploys to `~/.claude/bin/end-session-*`). Scripts outside `~/.claude/bin/` aren't covered, so a rogue `end-session-*` elsewhere on disk still prompts.
+
+If the tilde pattern turns out not to match on some future Claude Code version, the fallback is an absolute path or a `bash $HOME/.claude/bin/end-session-*` form.
+
+## When to extract a step into a script vs keep it inline
+
+Favour a script when any of these hold:
+
+- The block is multi-line / pipelined in a way no single allow rule can match.
+- Multiple independent reads can be run in parallel inside it.
+- The logic is worth shellcheck-testing in isolation.
+- A future reader needs to see "what this step runs" without hunting through markdown.
+
+Keep it inline in the command spec when:
+
+- It's a single shell command that matches an existing allow rule.
+- It needs per-item user judgment between sub-commands (would break into separate prompts anyway).
+- It's runtime-level (background process state, agent memory) that can't run from a detached shell.
+
+## Rollout
+
+The scripts live in `home/bin/end-session-*` in this repo, committed `100755`. This repo's `home/` is mounted at `~/.claude/` on each machine via a chezmoi archive external declared in [dotfiles](https://github.com/pmgledhill102/dotfiles), so they materialise at `~/.claude/bin/end-session-*` (with exec bit) only after a `chezmoi apply`. On a typical machine that's `dotup`.
+
+This matters because a merged PR to this repo's `main` does not land in `~/.claude/bin/` until chezmoi refreshes the external and applies. The external carries a `refreshPeriod`, so a merge is not picked up instantly. The first `/end-session` invocation on a machine after merging a change here should be preceded by `dotup`.
+
+## Maintenance
+
+- **ShellCheck**: CI's `home/bin/` scan covers the scripts. Run locally with `shellcheck home/bin/end-session-*` before pushing.
+- **Paired files**: `settings.json` and `settings.json.md` are paired — any change to the allow rule must update both.
+- **Adding a section to the gather**: add a `run_section` or `run_sh` call in the script, extend the section table in `commands/end-session.md`, then add a step (or fold into an existing step) that reads the new section.
+- **New sibling script**: name it `end-session-<purpose>` and commit it `100755`; the existing permission rule covers it.
+
+## Non-goals
+
+- **Replacing `/retrospective`'s flow.** It doesn't suffer from the same approval-prompt or latency issues, and its value is in agentic reasoning — parallel gather has nothing to buy.
+- **Parallelising the destructive steps.** Tier 2 actions need a y/n each; splitting them across parallel processes would hide prompts.
+- **Auto-merging PRs or auto-closing issues.** Explicit non-goal of the command itself (see `Guardrails` in the spec).


### PR DESCRIPTION
Moves `end-session-design.md` here from `dotfiles`. Tracked in [pmgledhill102/dotfiles#385](https://github.com/pmgledhill102/dotfiles/issues/385), which removes it there.

## Why it belongs here

`/end-session`'s command spec (`home/commands/end-session.md`) and both its scripts (`home/bin/end-session-*`) live in this repo. The document explaining *why* they are shaped that way stayed behind in `dotfiles` after the migration, where both its header links pointed at `home/dot_claude/` — a path that no longer exists there.

The dead links were the smaller problem. Separating the design doc from the thing it designs let it drift: it documented `bd_progress` and `bd_preflight` gather sections that the live script does not have, a `Step 14 → bd dolt push` that is now the summary step, and omitted `gh_assigned` and `stale_claude_files`, which the script does emit. That content was corrected in `dotfiles` first, so what lands here is already accurate against `home/bin/end-session-gather-state`.

## Path corrections made in the move

- Header links → `home/commands/end-session.md` and `home/bin/`
- Architecture diagram root → `home/commands/end-session.md`
- **Permission model** — scope rationale now describes `home/bin/end-session-*` deploying to `~/.claude/bin/end-session-*`, rather than chezmoi rendering `executable_` source names
- **Rollout** — rewritten for this repo: scripts committed `100755`, `home/` mounted at `~/.claude/` via the chezmoi archive external declared in `dotfiles`, and the `refreshPeriod` meaning a merge here is not picked up instantly. Replaces the old text about a local chezmoi source clone and a machine-specific working-copy path.
- **Maintenance** — ShellCheck invocation now `shellcheck home/bin/end-session-*`; new-sibling guidance says commit `100755` rather than name it `executable_*`

## Two things the move itself made necessary

**"Measured on this repo" → "Measured on the `dotfiles` repo".** The 2026-04-21 latency measurement was taken there; moving the file would otherwise have silently reattributed it to this one.

**A note on the Observation 2 retrospective.** It refers to `bd dolt push`, which reads like a stale beads reference but is accurate history — beads was the tracker in April 2026, and that call really was one of the original 14. Editing it would falsify the measurement rather than update it, so it stays, now with a blockquote saying so and pointing at [ADR-0013](https://github.com/pmgledhill102/agentic-coding-config/blob/main/adrs/0013-github-issues-for-work-tracking.md), to stop a future reader "fixing" it.

## Verification

- `markdownlint-cli2` against this repo's config — 0 issues
- All three relative links resolve: `home/commands/end-session.md`, `home/bin/`, `adrs/0013-github-issues-for-work-tracking.md`
- No `dot_claude`, `executable_`, chezmoi-source-clone or machine-specific path references remain

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEzFLESmAENUNGcgJbUEjQ)_