### PR TITLE
Mark ADR-0014 and ADR-0015 as Accepted

### DIFF
--- a/adrs/0014-portable-agent-config-architecture.md
+++ b/adrs/0014-portable-agent-config-architecture.md
@@ -1,6 +1,6 @@
 # ADR-0014: Portable agent-config architecture (skills-first, provider-neutral core)
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-08-09, ratified via PR #143)
 - **Date**: 2026-08-09
 - **Tags**: claude-code, codex, opencode, skills, plugins, architecture
 - **Scope**: user (applies to all personal repos and agent surfaces)

--- a/adrs/0015-tiered-adrs.md
+++ b/adrs/0015-tiered-adrs.md
@@ -1,6 +1,6 @@
 # ADR-0015: Tiered ADRs — personal, user-level, and repo-level decision records
 
-- **Status**: Proposed
+- **Status**: Accepted (2026-08-09, ratified via PR #143)
 - **Date**: 2026-08-09
 - **Tags**: workflow, adr, documentation
 - **Scope**: user (applies to all personal repos)


### PR DESCRIPTION
Part of #136. Follow-up to #143: both ADRs merged with `Status: Proposed`; since #143 was owner-reviewed and merged, this flips them to `Accepted (2026-08-09, ratified via PR #143)`. Two-line diff, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jURFzVAohShzjt5qZvr2N

---
_Generated by [Claude Code](https://claude.ai/code/session_013jURFzVAohShzjt5qZvr2N)_