### PR TITLE
Credential broker client: helper plus skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,21 @@ required only when their manifest is detected (e.g. `pip-audit` only if
 project uses Beads, otherwise as a markdown report at
 `docs/reviews/repo-review-YYYY-MM-DD.md`.
 
+**GCP credentials:**
+
+```text
+/gcp-credentials  # request human-approved, short-lived GCP access for a session
+```
+
+Drives `home/bin/gcp-credentials`, the client half of the credential broker
+(ADR 021 in [`gcp-org-management`][gcp-org-management]). One Discord approval
+creates a grant of 1–7 days; inside it the helper silently re-mints 1-hour
+tokens **straight to disk**, so no credential ever reaches tool output, the
+transcript, or the model's context. Needs a request key and broker URL
+configured once per machine — see the command doc.
+
+[gcp-org-management]: https://github.com/pmgledhill102/gcp-org-management
+
 **Day-to-day coding:**
 Claude Code edits files → hooks auto-run → Claude sees failures → fixes
 them. No context spent on rules — tooling output *is* the context.

--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -1,0 +1,660 @@
+#!/bin/sh
+# gcp-credentials — obtain human-approved, short-lived GCP credentials from the
+# credential broker, without the credential ever entering the transcript.
+#
+# The broker (pmgledhill102/gcp-org-management, ADR 021) turns one human
+# approval into a *grant* of 1-7 days. Inside that window this helper silently
+# re-mints 1-hour GCP access tokens with no further approvals.
+#
+#   request  ask for credentials, show the verification phrase, wait for the
+#            decision, install the token, and start background refresh
+#   refresh  the refresh loop itself (started automatically by `request`;
+#            runnable in the foreground for debugging)
+#   status   report grant, refresh and gcloud state — never any secret
+#   release  stop refresh and remove the token locally, leaving the grant alive
+#   revoke   release, then kill the grant at the broker
+#
+# THE TOKEN NEVER REACHES STDOUT, STDERR OR A LOG. It is written straight from
+# curl's response into a 0600 file with jq, and is never held in a shell
+# variable, never echoed, and never passed as an argument. That property is the
+# reason the broker exists in this shape: no secret in tool output means no
+# secret in the transcript, and none in the model's context. Any change here
+# that could print it is a bug, not a style question.
+#
+# The request key is likewise never an argv: it travels in a POST body built via
+# jq's environment, or in a curl --config file, both mode 0600. Process listings
+# are readable by anything running as the same user.
+#
+# Exit codes:
+#   0  success
+#   1  runtime failure (broker unreachable, mint failed, bad response)
+#   2  usage error
+#   3  denied or revoked — a human said no
+#   4  timed out or expired — nobody answered, which is also a no
+#   5  rate limited by the broker
+#   6  not configured (no request key, or no broker URL)
+
+set -eu
+
+POLL_INTERVAL=5
+# 45 minutes, against a 1-hour token lifetime. Overridable because the refresh
+# loop is the least observable part of this helper, and a test that has to wait
+# three quarters of an hour to see one iteration is a test nobody runs.
+REFRESH_INTERVAL="${CREDENTIAL_BROKER_REFRESH_INTERVAL:-2700}"
+PROGRESS_EVERY=30
+DEFAULT_TTL=24h
+DEFAULT_TIER=sandbox
+DEFAULT_TIMEOUT=900 # the broker expires an unanswered card after 15 minutes
+HTTP_TIMEOUT=30
+TOKEN_LIFETIME=3600
+
+# Everything the broker client owns lives here. Deliberately not ~/.claude/:
+# that tree is chezmoi-managed from a public repo, and nothing but distance
+# stops a secret written there from being committed.
+CB_HOME="${CREDENTIAL_BROKER_HOME:-$HOME/.config/claude/credential-broker}"
+KEY_FILE="$CB_HOME/request-key"
+URL_FILE="$CB_HOME/url"
+GRANT_FILE="$CB_HOME/grant.json"
+TOKEN_FILE="$CB_HOME/access_token"
+PID_FILE="$CB_HOME/refresh.pid"
+LOG_FILE="$CB_HOME/refresh.log"
+GCLOUD_CONFIG=agent-broker
+
+# Every file this script creates holds either a secret or the state guarding
+# one, so restrict the lot rather than remembering to chmod each.
+umask 077
+
+PROG=$(basename "$0")
+TMPDIR_CB=""
+CB_KEY=""
+BROKER_URL=""
+
+cleanup() {
+    [ -n "$TMPDIR_CB" ] && [ -d "$TMPDIR_CB" ] && rm -rf "$TMPDIR_CB"
+    return 0
+}
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+die() {
+    # $1 = exit code, rest = message
+    rc=$1
+    shift
+    echo "$PROG: $*" >&2
+    exit "$rc"
+}
+
+usage() {
+    cat >&2 <<'USAGE'
+usage:
+  gcp-credentials request [options]   ask for credentials and install them
+  gcp-credentials refresh             run the refresh loop in the foreground
+  gcp-credentials status              show grant / refresh / gcloud state
+  gcp-credentials release             drop credentials locally, keep the grant
+  gcp-credentials revoke              kill the grant at the broker
+
+request options:
+  --purpose TEXT   why the access is needed (required; shown to the human)
+  --repo REPO      git remote to resolve to a project (default: origin here)
+  --project ID     explicit project id, bypassing repo resolution
+  --ttl DURATION   grant length, 24h-168h (default: 24h)
+  --tier NAME      role set (default: sandbox)
+  --timeout SECS   how long to wait for a decision (default: 900)
+  --no-refresh     install one token and do not start background refresh
+  --no-gcloud      write the token file but do not touch any gcloud config
+  --no-activate    configure the agent-broker gcloud config without activating
+USAGE
+    exit 2
+}
+
+# --- configuration -----------------------------------------------------------
+
+# load_key sets CB_KEY from the environment or the on-disk key.
+#
+# Both sources are trimmed. The broker compares the presented key without
+# trimming, so a trailing newline — which a file written with `echo`, a .env
+# file, or a secret manager will all happily add — returns a plain 401,
+# indistinguishable from a wrong key. Trimming here is what stops that hour.
+load_key() {
+    if [ -n "${CREDENTIAL_BROKER_REQUEST_KEY:-}" ]; then
+        CB_KEY=$(printf '%s' "$CREDENTIAL_BROKER_REQUEST_KEY" | tr -d '[:space:]')
+    elif [ -f "$KEY_FILE" ]; then
+        CB_KEY=$(tr -d '[:space:]' < "$KEY_FILE")
+    fi
+
+    # An empty key also returns 401, so refusing to send one is what keeps
+    # "not configured" distinguishable from "wrong key" at the far end.
+    [ -n "$CB_KEY" ] || die 6 "no request key. Set \$CREDENTIAL_BROKER_REQUEST_KEY (cloud sandboxes) or write one to $KEY_FILE with mode 0600 (local machines)."
+
+    # The key is interpolated into a curl --config line, which is quoted. A key
+    # containing a quote or backslash would break out of it; no legitimate key
+    # contains either, so refuse rather than escape.
+    case "$CB_KEY" in
+        *'"'* | *\\*) die 6 "request key contains a quote or backslash, which cannot be sent safely" ;;
+    esac
+}
+
+load_url() {
+    if [ -n "${CREDENTIAL_BROKER_URL:-}" ]; then
+        BROKER_URL="$CREDENTIAL_BROKER_URL"
+    elif [ -f "$URL_FILE" ]; then
+        BROKER_URL=$(tr -d '[:space:]' < "$URL_FILE")
+    fi
+    [ -n "$BROKER_URL" ] || die 6 "no broker URL. Set \$CREDENTIAL_BROKER_URL or write the Cloud Run URL to $URL_FILE."
+    # A trailing slash would produce //request, which Gin 301s to /request and
+    # curl follows as a GET, losing the body.
+    BROKER_URL=${BROKER_URL%/}
+}
+
+# write_header_cfg writes a curl --config file carrying the request key. Passing
+# it as -H would put it in argv, which every process on the machine can read.
+write_header_cfg() {
+    printf 'header = "X-Request-Key: %s"\n' "$CB_KEY" > "$1"
+}
+
+# --- HTTP --------------------------------------------------------------------
+
+# Each of these prints the HTTP status and leaves the body in the named file.
+# curl's own failures (DNS, TLS, connection refused) surface as 000.
+
+http_post_json() { # path bodyfile outfile
+    curl -sS -X POST -H 'Content-Type: application/json' \
+        --max-time "$HTTP_TIMEOUT" --data-binary "@$2" \
+        -o "$3" -w '%{http_code}' "$BROKER_URL$1"
+}
+
+http_get_authed() { # path outfile headercfg
+    curl -sS --max-time "$HTTP_TIMEOUT" -K "$3" \
+        -o "$2" -w '%{http_code}' "$BROKER_URL$1"
+}
+
+http_post_authed() { # path outfile headercfg
+    curl -sS -X POST --max-time "$HTTP_TIMEOUT" -K "$3" \
+        -o "$2" -w '%{http_code}' "$BROKER_URL$1"
+}
+
+# broker_error renders whatever the broker said about a failure. The broker
+# composes these itself; the agent-supplied purpose never comes back here.
+broker_error() { # responsefile
+    err=$(jq -r '.error // empty' < "$1" 2>/dev/null || true)
+    hint=$(jq -r '.hint // empty' < "$1" 2>/dev/null || true)
+    [ -n "$err" ] || err="no detail returned"
+    if [ -n "$hint" ]; then
+        printf '%s (%s)' "$err" "$hint"
+    else
+        printf '%s' "$err"
+    fi
+}
+
+# --- time --------------------------------------------------------------------
+
+# The broker always formats UTC RFC3339 with a Z, so one BSD format string plus
+# one GNU fallback covers both platforms this ships to.
+rfc3339_to_epoch() {
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$1" '+%s' 2>/dev/null ||
+        date -u -d "$1" '+%s' 2>/dev/null ||
+        echo ""
+}
+
+humanise_remaining() { # seconds
+    hr_s=$1
+    if [ "$hr_s" -le 0 ]; then
+        echo "expired"
+        return 0
+    fi
+    hr_d=$((hr_s / 86400))
+    hr_h=$(((hr_s % 86400) / 3600))
+    hr_m=$(((hr_s % 3600) / 60))
+    if [ "$hr_d" -gt 0 ]; then
+        echo "${hr_d}d ${hr_h}h"
+    elif [ "$hr_h" -gt 0 ]; then
+        echo "${hr_h}h ${hr_m}m"
+    else
+        echo "${hr_m}m"
+    fi
+}
+
+# --- token install -----------------------------------------------------------
+
+# do_exchange swaps the stored session token for a fresh 1-hour access token and
+# writes it to disk.
+#
+# The token goes from curl's output file into the token file through jq and
+# never anywhere else. It is not captured, not echoed, and not diffed. Note the
+# body is built by projecting exactly two fields out of the grant file, so a
+# future field added there cannot leak into a request by accident.
+#
+# Sets EX_EXPIRES, EX_GRANT_EXPIRES, EX_PROJECT, EX_SA on success.
+do_exchange() {
+    ex_body="$TMPDIR_CB/exchange-body.json"
+    ex_resp="$TMPDIR_CB/exchange-resp.json"
+
+    jq '{request_id: .request_id, session_token: .session_token}' < "$GRANT_FILE" > "$ex_body"
+
+    ex_code=$(http_post_json "/exchange" "$ex_body" "$ex_resp") || ex_code=000
+
+    case "$ex_code" in
+        200) ;;
+        000) rm -f "$ex_body"; die 1 "broker unreachable at $BROKER_URL — no credentials installed" ;;
+        401) rm -f "$ex_body"; die 1 "broker rejected the session token. The grant may have been revoked; request again." ;;
+        403) rm -f "$ex_body"; die 4 "the grant is no longer active (expired or revoked) — request again" ;;
+        *) rm -f "$ex_body"; die 1 "token exchange failed (HTTP $ex_code): $(broker_error "$ex_resp")" ;;
+    esac
+    rm -f "$ex_body"
+
+    if ! jq -e '(.access_token // "") != ""' < "$ex_resp" > /dev/null 2>&1; then
+        die 1 "broker returned no access token"
+    fi
+
+    # -j: no trailing newline. gcloud strips whitespace but other readers of
+    # access_token_file may not.
+    jq -j '.access_token' < "$ex_resp" > "$TOKEN_FILE.new"
+    chmod 600 "$TOKEN_FILE.new"
+    mv "$TOKEN_FILE.new" "$TOKEN_FILE"
+
+    EX_EXPIRES=$(jq -r '.expires_at // ""' < "$ex_resp")
+    EX_GRANT_EXPIRES=$(jq -r '.grant_expires_at // ""' < "$ex_resp")
+    EX_PROJECT=$(jq -r '.project // ""' < "$ex_resp")
+    EX_SA=$(jq -r '.service_account // ""' < "$ex_resp")
+    rm -f "$ex_resp"
+}
+
+gcloud_active_config() {
+    command -v gcloud > /dev/null 2>&1 || return 0
+    gcloud config configurations list --filter='is_active=true' \
+        --format='value(name)' 2> /dev/null | head -1 || true
+}
+
+# gcloud_install points gcloud at the token file via a dedicated configuration.
+#
+# A dedicated configuration rather than the active one: on a local machine the
+# active configuration belongs to the human, and silently repointing their
+# gcloud at an hour-long agent token is both surprising and hard to undo. The
+# name of the configuration displaced here is recorded in the grant file so
+# `release` and `revoke` can put it back.
+gcloud_install() { # project
+    if ! command -v gcloud > /dev/null 2>&1; then
+        echo "note: gcloud is not installed — the token is at $TOKEN_FILE for whatever reads it"
+        return 0
+    fi
+
+    if ! gcloud config configurations describe "$GCLOUD_CONFIG" > /dev/null 2>&1; then
+        gcloud config configurations create "$GCLOUD_CONFIG" --no-activate > /dev/null 2>&1 ||
+            die 1 "could not create the $GCLOUD_CONFIG gcloud configuration"
+    fi
+
+    # Scoped by CLOUDSDK_ACTIVE_CONFIG_NAME so these writes cannot land in
+    # whichever configuration happens to be active right now.
+    CLOUDSDK_ACTIVE_CONFIG_NAME="$GCLOUD_CONFIG" \
+        gcloud config set auth/access_token_file "$TOKEN_FILE" > /dev/null 2>&1
+    CLOUDSDK_ACTIVE_CONFIG_NAME="$GCLOUD_CONFIG" \
+        gcloud config set core/project "$1" > /dev/null 2>&1
+
+    if [ "$OPT_ACTIVATE" -eq 1 ]; then
+        gcloud config configurations activate "$GCLOUD_CONFIG" > /dev/null 2>&1
+    fi
+}
+
+gcloud_restore() {
+    command -v gcloud > /dev/null 2>&1 || return 0
+    gr_active=$(gcloud config configurations list --filter='is_active=true' \
+        --format='value(name)' 2> /dev/null | head -1 || true)
+    [ "$gr_active" = "$GCLOUD_CONFIG" ] || return 0
+
+    gr_prev=""
+    [ -f "$GRANT_FILE" ] && gr_prev=$(jq -r '.previous_gcloud_config // ""' < "$GRANT_FILE" 2> /dev/null || true)
+    [ -n "$gr_prev" ] || gr_prev=default
+
+    if gcloud config configurations activate "$gr_prev" > /dev/null 2>&1; then
+        echo "gcloud configuration restored to $gr_prev"
+    else
+        echo "warning: could not restore gcloud configuration $gr_prev; $GCLOUD_CONFIG is still active" >&2
+    fi
+}
+
+# --- refresh process ---------------------------------------------------------
+
+refresh_running() {
+    [ -f "$PID_FILE" ] || return 1
+    rr_pid=$(cat "$PID_FILE" 2> /dev/null || true)
+    [ -n "$rr_pid" ] || return 1
+    kill -0 "$rr_pid" 2> /dev/null
+}
+
+refresh_stop() {
+    if refresh_running; then
+        kill "$(cat "$PID_FILE")" 2> /dev/null || true
+        echo "background refresh stopped"
+    fi
+    rm -f "$PID_FILE"
+}
+
+refresh_start() {
+    refresh_stop > /dev/null 2>&1 || true
+    # Detached so it outlives the tool call that started it. Its output is a log
+    # file, never the session: a refresh failure must be discoverable without
+    # ever risking a token in tool output.
+    nohup "$0" refresh >> "$LOG_FILE" 2>&1 &
+    echo $! > "$PID_FILE"
+    chmod 600 "$PID_FILE"
+}
+
+# --- subcommands -------------------------------------------------------------
+
+cmd_request() {
+    OPT_PURPOSE=""
+    OPT_REPO=""
+    OPT_PROJECT=""
+    OPT_TTL="$DEFAULT_TTL"
+    OPT_TIER="$DEFAULT_TIER"
+    OPT_TIMEOUT="$DEFAULT_TIMEOUT"
+    OPT_REFRESH=1
+    OPT_GCLOUD=1
+    OPT_ACTIVATE=1
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --purpose) [ $# -ge 2 ] || usage; OPT_PURPOSE="$2"; shift 2 ;;
+            --repo) [ $# -ge 2 ] || usage; OPT_REPO="$2"; shift 2 ;;
+            --project) [ $# -ge 2 ] || usage; OPT_PROJECT="$2"; shift 2 ;;
+            --ttl) [ $# -ge 2 ] || usage; OPT_TTL="$2"; shift 2 ;;
+            --tier) [ $# -ge 2 ] || usage; OPT_TIER="$2"; shift 2 ;;
+            --timeout) [ $# -ge 2 ] || usage; OPT_TIMEOUT="$2"; shift 2 ;;
+            --no-refresh) OPT_REFRESH=0; shift ;;
+            --no-gcloud) OPT_GCLOUD=0; shift ;;
+            --no-activate) OPT_ACTIVATE=0; shift ;;
+            -h | --help) usage ;;
+            *) echo "$PROG: unknown option: $1" >&2; usage ;;
+        esac
+    done
+
+    # The human reads this on the approval card and has nothing else to go on.
+    # A request with no stated purpose is one they cannot sensibly approve.
+    [ -n "$OPT_PURPOSE" ] || die 2 "--purpose is required: the human sees it on the approval card and has nothing else to judge by"
+
+    case "$OPT_TIMEOUT" in
+        '' | *[!0-9]*) die 2 "--timeout must be a whole number of seconds" ;;
+    esac
+
+    if [ -z "$OPT_PROJECT" ] && [ -z "$OPT_REPO" ]; then
+        # The broker resolves a repo to its sandbox project, which is what lets
+        # a session ask for credentials with nothing configured per project.
+        OPT_REPO=$(git remote get-url origin 2> /dev/null || true)
+        [ -n "$OPT_REPO" ] || die 2 "no git origin remote here — pass --repo or --project"
+    fi
+
+    load_key
+    load_url
+    mkdir -p "$CB_HOME"
+    TMPDIR_CB=$(mktemp -d)
+
+    req_body="$TMPDIR_CB/request.json"
+    req_resp="$TMPDIR_CB/request-resp.json"
+    hdr_cfg="$TMPDIR_CB/headers.conf"
+
+    # env.CB_REQUEST_KEY, not --arg: jq arguments are argv, and argv is public.
+    CB_REQUEST_KEY="$CB_KEY" jq -n \
+        --arg project "$OPT_PROJECT" \
+        --arg repo "$OPT_REPO" \
+        --arg tier "$OPT_TIER" \
+        --arg purpose "$OPT_PURPOSE" \
+        --arg ttl "$OPT_TTL" \
+        '{request_key: env.CB_REQUEST_KEY, tier: $tier, purpose: $purpose, grant_ttl: $ttl}
+         + (if $project != "" then {project: $project} else {} end)
+         + (if $repo != "" then {repo: $repo} else {} end)' > "$req_body"
+
+    code=$(http_post_json "/request" "$req_body" "$req_resp") || code=000
+    rm -f "$req_body"
+
+    case "$code" in
+        200) ;;
+        000) die 1 "broker unreachable at $BROKER_URL — no request was opened" ;;
+        401) die 1 "broker rejected the request key. Check \$CREDENTIAL_BROKER_REQUEST_KEY or $KEY_FILE (a trailing newline is trimmed here, so this is a genuine mismatch)." ;;
+        404) die 1 "$(broker_error "$req_resp")" ;;
+        409) die 1 "$(broker_error "$req_resp")" ;;
+        429) die 5 "rate limited by the broker — wait before requesting again" ;;
+        502) die 1 "the broker could not reach the approval channel, so nobody was asked. Do not retry blindly; check the broker." ;;
+        *) die 1 "request failed (HTTP $code): $(broker_error "$req_resp")" ;;
+    esac
+
+    req_id=$(jq -r '.request_id // ""' < "$req_resp")
+    phrase=$(jq -r '.phrase // ""' < "$req_resp")
+    req_expires=$(jq -r '.expires_at // ""' < "$req_resp")
+    [ -n "$req_id" ] && [ -n "$phrase" ] || die 1 "broker returned an incomplete request response"
+
+    # The phrase is the entire session-binding mechanism: the human approves only
+    # if the card matches what is on screen here. It gets its own block, at the
+    # top, unmissable — burying it in log noise would quietly turn the check into
+    # reflex clicking, which is the failure mode the design depends on avoiding.
+    echo ""
+    echo "=================================================================="
+    echo "  APPROVAL REQUIRED — verification phrase:"
+    echo ""
+    echo "        $phrase"
+    echo ""
+    echo "  Approve in Discord ONLY if the card shows exactly this phrase."
+    echo "=================================================================="
+    if [ -n "$OPT_PROJECT" ]; then
+        echo "  project : $OPT_PROJECT"
+    else
+        echo "  repo    : $OPT_REPO (broker resolves it to a sandbox project)"
+    fi
+    echo "  tier    : $OPT_TIER"
+    echo "  grant   : $OPT_TTL"
+    echo "  purpose : $OPT_PURPOSE"
+    [ -n "$req_expires" ] && echo "  card expires at $req_expires (no answer means deny)"
+    echo ""
+
+    write_header_cfg "$hdr_cfg"
+    poll_resp="$TMPDIR_CB/poll.json"
+    elapsed=0
+    since_progress=0
+    transient=0
+
+    while :; do
+        code=$(http_get_authed "/requests/$req_id" "$poll_resp" "$hdr_cfg") || code=000
+        state=""
+        case "$code" in
+            200)
+                transient=0
+                state=$(jq -r '.state // "unknown"' < "$poll_resp")
+                ;;
+            401) die 1 "broker rejected the request key while polling" ;;
+            404) die 1 "the broker no longer knows this request" ;;
+            *)
+                # A cold-starting or briefly wobbly broker should not read as a
+                # denial. Persistent failure still has to fail.
+                transient=$((transient + 1))
+                [ "$transient" -lt 5 ] || die 1 "broker unreachable while waiting for a decision (HTTP $code)"
+                ;;
+        esac
+
+        case "$state" in
+            approved) break ;;
+            denied) die 3 "the request was DENIED. No credentials were issued; do not retry without asking the human first." ;;
+            revoked) die 3 "the grant was revoked before it could be used" ;;
+            expired) die 4 "nobody answered in time, which the broker treats as a deny. No credentials were issued." ;;
+            pending | "") ;;
+            *) die 1 "broker reported an unexpected state: $state" ;;
+        esac
+
+        if [ "$elapsed" -ge "$OPT_TIMEOUT" ]; then
+            die 4 "gave up waiting after ${OPT_TIMEOUT}s with no decision. Treat this as a deny."
+        fi
+        sleep "$POLL_INTERVAL"
+        elapsed=$((elapsed + POLL_INTERVAL))
+        since_progress=$((since_progress + POLL_INTERVAL))
+        if [ "$since_progress" -ge "$PROGRESS_EVERY" ]; then
+            echo "  ... still waiting for approval (${elapsed}s elapsed, phrase $phrase)"
+            since_progress=0
+        fi
+    done
+
+    GCLOUD_PREV=""
+    if [ "$OPT_GCLOUD" -eq 1 ] && [ "$OPT_ACTIVATE" -eq 1 ]; then
+        GCLOUD_PREV=$(gcloud_active_config)
+        # Recording agent-broker as its own predecessor would make `release` a
+        # no-op for every grant after the first.
+        if [ "$GCLOUD_PREV" = "$GCLOUD_CONFIG" ]; then
+            GCLOUD_PREV=""
+        fi
+    fi
+
+    jq --arg rid "$req_id" --arg prev "$GCLOUD_PREV" \
+        '{request_id: $rid, project: .project, service_account: .service_account,
+          grant_expires_at: .grant_expires_at, session_token: .session_token,
+          previous_gcloud_config: $prev}' < "$poll_resp" > "$GRANT_FILE"
+    chmod 600 "$GRANT_FILE"
+    rm -f "$poll_resp"
+
+    # Exchange before touching gcloud: pointing a configuration at a token file
+    # that does not exist yet would leave a failed run looking configured.
+    do_exchange
+
+    if [ "$OPT_GCLOUD" -eq 1 ]; then
+        gcloud_install "$EX_PROJECT"
+    fi
+
+    echo "credentials installed for $EX_PROJECT, grant expires $EX_GRANT_EXPIRES"
+    echo "  identity  : $EX_SA"
+    echo "  token file: $TOKEN_FILE (never print this file)"
+    if [ "$OPT_GCLOUD" -eq 1 ] && command -v gcloud > /dev/null 2>&1; then
+        if [ "$OPT_ACTIVATE" -eq 1 ]; then
+            echo "  gcloud    : configuration '$GCLOUD_CONFIG' is active; '$PROG release' restores ${GCLOUD_PREV:-the previous one}"
+        else
+            echo "  gcloud    : configuration '$GCLOUD_CONFIG' is ready but not active"
+        fi
+    fi
+
+    if [ "$OPT_REFRESH" -eq 1 ]; then
+        refresh_start
+        echo "  refresh   : running in the background until the grant expires (log: $LOG_FILE)"
+    fi
+}
+
+cmd_refresh() {
+    [ -f "$GRANT_FILE" ] || die 2 "no grant on this machine — run '$PROG request' first"
+    load_key
+    load_url
+    TMPDIR_CB=$(mktemp -d)
+
+    while :; do
+        grant_expires=$(jq -r '.grant_expires_at // ""' < "$GRANT_FILE")
+        [ -n "$grant_expires" ] || die 1 "grant file has no expiry"
+        grant_epoch=$(rfc3339_to_epoch "$grant_expires")
+        [ -n "$grant_epoch" ] || die 1 "could not parse grant expiry: $grant_expires"
+        remaining=$((grant_epoch - $(date -u '+%s')))
+
+        # The broker shortens the final token so it ends with the grant. Once
+        # under one token lifetime there is nothing left to refresh — sleep out
+        # the window, then remove the token so anything still reaching for it
+        # fails loudly rather than with an opaque 401.
+        if [ "$remaining" -le "$TOKEN_LIFETIME" ]; then
+            [ "$remaining" -gt 0 ] && sleep "$remaining"
+            rm -f "$TOKEN_FILE"
+            rm -f "$PID_FILE"
+            echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') grant expired; token removed. Request again to continue."
+            exit 0
+        fi
+
+        sleep "$REFRESH_INTERVAL"
+        do_exchange
+        echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') refreshed access token for $EX_PROJECT (expires $EX_EXPIRES)"
+    done
+}
+
+cmd_status() {
+    if [ ! -f "$GRANT_FILE" ]; then
+        echo "grant   : none on this machine"
+    else
+        st_project=$(jq -r '.project // "?"' < "$GRANT_FILE")
+        st_sa=$(jq -r '.service_account // "?"' < "$GRANT_FILE")
+        st_exp=$(jq -r '.grant_expires_at // ""' < "$GRANT_FILE")
+        st_epoch=$(rfc3339_to_epoch "$st_exp")
+        if [ -n "$st_epoch" ]; then
+            st_left=$((st_epoch - $(date -u '+%s')))
+            echo "grant   : $st_project, expires $st_exp ($(humanise_remaining "$st_left"))"
+        else
+            echo "grant   : $st_project, expires $st_exp"
+        fi
+        echo "identity: $st_sa"
+    fi
+
+    if [ -f "$TOKEN_FILE" ]; then
+        echo "token   : present at $TOKEN_FILE"
+    else
+        echo "token   : none installed"
+    fi
+
+    if refresh_running; then
+        echo "refresh : running (pid $(cat "$PID_FILE"))"
+    else
+        echo "refresh : not running"
+    fi
+
+    if command -v gcloud > /dev/null 2>&1; then
+        st_active=$(gcloud config configurations list --filter='is_active=true' \
+            --format='value(name)' 2> /dev/null | head -1 || true)
+        echo "gcloud  : active configuration '$st_active'"
+    fi
+}
+
+cmd_release() {
+    refresh_stop
+    if [ -f "$TOKEN_FILE" ]; then
+        rm -f "$TOKEN_FILE"
+        echo "access token removed"
+    fi
+    gcloud_restore
+    echo "the grant is still live at the broker — '$PROG revoke' ends it"
+}
+
+cmd_revoke() {
+    [ -f "$GRANT_FILE" ] || die 2 "no grant on this machine — nothing to revoke"
+    load_key
+    load_url
+    TMPDIR_CB=$(mktemp -d)
+
+    rv_id=$(jq -r '.request_id // ""' < "$GRANT_FILE")
+    [ -n "$rv_id" ] || die 1 "grant file has no request id"
+
+    hdr_cfg="$TMPDIR_CB/headers.conf"
+    rv_resp="$TMPDIR_CB/revoke.json"
+    write_header_cfg "$hdr_cfg"
+
+    code=$(http_post_authed "/requests/$rv_id/revoke" "$rv_resp" "$hdr_cfg") || code=000
+
+    refresh_stop
+    rm -f "$TOKEN_FILE"
+
+    case "$code" in
+        200) echo "grant revoked at the broker; refresh stopped and the token removed" ;;
+        404) echo "the broker no longer holds this grant; cleaned up locally" ;;
+        000) echo "warning: broker unreachable — cleaned up locally, but the grant may still be live. Retry, or disable the service account." >&2 ;;
+        *) echo "warning: revoke failed (HTTP $code): $(broker_error "$rv_resp"). Cleaned up locally; the grant may still be live." >&2 ;;
+    esac
+
+    gcloud_restore
+    rm -f "$GRANT_FILE"
+}
+
+# --- entry point -------------------------------------------------------------
+
+for tool in curl jq; do
+    command -v "$tool" > /dev/null 2>&1 || die 1 "$tool is required but not installed"
+done
+
+[ $# -ge 1 ] || usage
+subcommand="$1"
+shift
+
+case "$subcommand" in
+    request) cmd_request "$@" ;;
+    refresh) cmd_refresh ;;
+    status) cmd_status ;;
+    release) cmd_release ;;
+    revoke) cmd_revoke ;;
+    -h | --help | help) usage ;;
+    *) echo "$PROG: unknown subcommand: $subcommand" >&2; usage ;;
+esac

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -1,0 +1,178 @@
+Get GCP credentials for this session through the credential broker: request a human-approved grant, show the verification phrase the human must match, and install a short-lived token straight to disk. Use when a task needs GCP access and the session has none, or when a previously working grant has expired.
+
+## When to use this
+
+Reach for it when a GCP call fails for want of credentials, or before starting
+work you already know needs them — `gcloud`, Terraform against a GCP provider,
+a client library, anything that authenticates to Google Cloud.
+
+Signals that this is the right move:
+
+- `gcloud` reports no active account, or `ADC not found`
+- an API call returns 401/403 and no grant is installed
+  (`~/.claude/bin/gcp-credentials status` says `grant : none on this machine`)
+- a grant that was working has expired — see [Grant expired](#grant-expired)
+
+Do **not** request credentials speculatively. Every request pings a human on
+Discord and burns a little of their willingness to read the card carefully. One
+per session, when the work actually needs it.
+
+## How it works, in one paragraph
+
+The broker turns **one human approval into a grant** lasting 1–7 days. Inside
+that window a background loop silently re-mints 1-hour GCP access tokens with no
+further approvals. The human approves in Discord only if the card shows the same
+three-word phrase as the session — that match is what binds an approval to
+*this* session rather than to whichever request happened to arrive first. Design
+and trust model: ADR 021 in `pmgledhill102/gcp-org-management`.
+
+## Requesting
+
+```sh
+~/.claude/bin/gcp-credentials request --purpose "stand up an Apigee instance and its supporting infra"
+```
+
+The project is resolved from the repo's `origin` remote, so nothing needs
+configuring per project. Override with `--project <id>` if the broker cannot
+resolve it, or `--repo <remote>` when working outside a checkout.
+
+Useful options: `--ttl 72h` (1–7 days, default 24h), `--timeout 900`,
+`--no-gcloud` if you only want the token file.
+
+Write a **specific purpose**. It is the only thing the human has to judge the
+request by, and it is rendered on the card as untrusted, agent-written text.
+"deploy the Apigee bootstrap module to the sandbox" is approvable;
+"do some GCP work" is not.
+
+### Surface the phrase immediately
+
+The command prints a block like this:
+
+```text
+==================================================================
+  APPROVAL REQUIRED — verification phrase:
+
+        mint-copper-falcon
+
+  Approve in Discord ONLY if the card shows exactly this phrase.
+==================================================================
+```
+
+Relay the phrase to the user **verbatim, in your own reply, as the first thing
+you say** — do not leave it buried in tool output. Say what they are approving:
+
+> Requesting GCP credentials for `pmgledhill-apix-sbx` (sandbox tier, 24h).
+> **Verification phrase: `mint-copper-falcon`** — approve the Discord card only
+> if it shows exactly that.
+
+Then let the command keep polling. It exits by itself on a decision.
+
+## Reading the outcome
+
+| Exit | Meaning | What to do |
+| --- | --- | --- |
+| 0 | Installed | Carry on. Say which project and when the grant expires. |
+| 2 | Usage error | Fix the arguments. |
+| 3 | **Denied** or revoked | Stop. A human said no. Do not re-request without asking them why. |
+| 4 | Timed out / expired | Nobody answered, which the broker treats as a deny. Ask the user before retrying. |
+| 5 | Rate limited | Wait. Do not loop. |
+| 6 | Not configured | No request key or no broker URL — see [Setup](#setup-not-per-session). |
+| 1 | Broker unreachable or mint failed | Report it. Do not proceed as if credentials exist. |
+
+Never carry on without credentials after a non-zero exit. Silently falling back
+to whatever identity happens to be lying around is the exact failure the broker
+exists to prevent.
+
+## After a successful request
+
+Report only what the helper printed:
+
+> Credentials installed for `pmgledhill-apix-sbx`, grant expires 2026-08-13T11:33Z.
+> Background refresh is running.
+
+`gcloud` is pointed at the token through a dedicated `agent-broker`
+configuration, which is activated. `~/.claude/bin/gcp-credentials release`
+restores the configuration that was active before.
+
+## Things never to do
+
+- **Never print, `cat`, `grep`, `head` or otherwise read the token file.** The
+  whole design rests on the credential not entering the transcript. The helper
+  writes it from the HTTP response to disk without it passing through a shell
+  variable; reading it back undoes that in one tool call.
+- **Never run `gcloud auth print-access-token`** (or `print-identity-token`, or
+  `terraform output` on anything holding a token). Same reason.
+- **Never read `~/.config/gcloud`.** On a local machine that directory holds the
+  human's own long-lived admin refresh token. It is not yours, it is not scoped,
+  and it is not an hour long. If the broker path fails, the answer is to report
+  the failure, not to reach around it.
+- **Never ask the user to paste a token, key, or service-account JSON into the
+  session.** Anything pasted is in the transcript forever. If credentials are
+  needed, they come through the broker.
+- **Never pass the request key on a command line.** The helper reads it from the
+  environment or a 0600 file for a reason; `--key`-style arguments are visible in
+  process listings.
+- **Never re-request after a deny** without the user telling you to.
+
+For a tool that needs the token in an environment variable rather than a file,
+feed it from the file in the same command and never echo it:
+
+```sh
+GOOGLE_OAUTH_ACCESS_TOKEN="$(cat ~/.config/claude/credential-broker/access_token)" terraform plan
+```
+
+## Grant expired
+
+The grant, not the token, is what runs out. Symptoms:
+
+- `~/.claude/bin/gcp-credentials status` shows `token : none installed`, or a
+  grant whose expiry is in the past
+- `gcloud` fails with a missing-token-file error
+- the refresh log ends with `grant expired; token removed`
+
+That is the designed end of the window, not a fault. Request again — a fresh
+approval, a fresh phrase — and tell the user that is what you are doing:
+
+> The 24h grant expired. Requesting a new one; new phrase: `willow-basalt-heron`.
+
+Do not diagnose it as an auth bug, and do not go looking for another credential.
+
+## Other subcommands
+
+```sh
+~/.claude/bin/gcp-credentials status    # grant, token, refresh, gcloud — no secrets
+~/.claude/bin/gcp-credentials release   # drop the token locally, keep the grant
+~/.claude/bin/gcp-credentials revoke    # end the grant at the broker as well
+```
+
+`status` and `release` are pre-approved in `settings.json`; `request` and
+`revoke` prompt, because both reach the broker and one of them pings a human.
+
+Run `release` when finishing a session on a shared/local machine, so the human's
+gcloud configuration goes back to theirs. Run `revoke` when the access should
+end outright — after finishing a piece of work early, or if anything about the
+session looks wrong.
+
+## Setup (not per session)
+
+Two things are machine or environment properties, configured once, never pasted
+into a session:
+
+| What | Cloud sandbox | Local macOS |
+| --- | --- | --- |
+| Request key | `$CREDENTIAL_BROKER_REQUEST_KEY` | `~/.config/claude/credential-broker/request-key`, mode 0600 |
+| Broker URL | `$CREDENTIAL_BROKER_URL` | `~/.config/claude/credential-broker/url` |
+
+Exit 6 names both locations. If a machine is missing them, that is a setup task
+for the human — say so and stop; do not attempt to work around it.
+
+## Approval hygiene, for the human
+
+Worth restating when relaying a phrase, because it is the only real defence:
+
+- Approve **only** if the card's phrase matches the session's, character for
+  character.
+- A card arriving with no session running is grounds to deny, always.
+- The purpose text on the card is written by an agent and is marked untrusted.
+  Project, identity, tier and duration are composed by the broker and can be
+  relied on.

--- a/home/settings.json
+++ b/home/settings.json
@@ -283,6 +283,8 @@
       "Bash(yarn run *)",
       "Bash(yarn test *)",
       "Bash(~/.claude/bin/gh-pr-checks-wait *)",
+      "Bash(~/.claude/bin/gcp-credentials status)",
+      "Bash(~/.claude/bin/gcp-credentials release)",
       "mcp__github__add_comment_to_pending_review",
       "mcp__github__add_issue_comment",
       "mcp__github__add_reply_to_pull_request_comment",

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -44,6 +44,21 @@ prompt.
 
 See `docs/end-session-design.md` for the full rationale.
 
+### GCP credential broker client
+
+- `Bash(~/.claude/bin/gcp-credentials status)`
+- `Bash(~/.claude/bin/gcp-credentials release)`
+
+Exact commands, not a prefix — the deliberate omissions are the point.
+`status` only reports local state and `release` only undoes local state, so
+both are safe to run unattended. `request` is left prompting because it posts
+an approval card to Discord and pings a human, and `revoke` because it ends a
+grant the human granted; neither should happen without the user seeing it go
+by. `refresh` is started by `request` and is not meant to be invoked directly.
+
+See `home/commands/gcp-credentials.md` for the flow, and ADR 021 in
+`pmgledhill102/gcp-org-management` for the design.
+
 ### draw.io (CLI export, read-only)
 
 - `Bash(/Applications/draw.io.app/Contents/MacOS/draw.io *)`


### PR DESCRIPTION
Ships the client half of the GCP credential broker — the `bin/` helper and the skill that tells an agent when and how to use it. Built against the merged broker (`gcp-org-management` #265 / #267), so the wire shapes come from `handlers.go` rather than from the issue prose.

Closes #146

## What's here

| File | Purpose |
| --- | --- |
| `home/bin/gcp-credentials` | POSIX sh helper: `request` / `refresh` / `status` / `release` / `revoke` |
| `home/commands/gcp-credentials.md` | The skill: when to request, what to tell the human, what never to do |
| `home/settings.json`(`.md`) | Allow `status` and `release` only |
| `README.md` | A short pointer under Slash commands |

## The property that matters

**The token never reaches stdout, stderr, or a log.** It goes from curl's response file into a 0600 token file through `jq -j`, and is never assigned to a shell variable, echoed, or passed as an argument. The refresh loop logs `refreshed access token for <project> (expires <time>)` and nothing else. A test asserts the literal token string appears in neither the command output nor the refresh log.

**The request key is never an argv.** `jq --arg` would put it in a process listing, so the request body is built from `env.CB_REQUEST_KEY`, and the `X-Request-Key` header travels in a 0600 `curl --config` file rather than `-H`. Both key sources (`$CREDENTIAL_BROKER_REQUEST_KEY`, then `~/.config/claude/credential-broker/request-key`) are trimmed — the broker's `Verify` does not trim the presented value, so a trailing newline would return a bare 401 indistinguishable from a wrong key. An empty key is refused locally rather than sent, keeping "missing file", "empty file" and "wrong key" three different messages.

## Failing loudly

Every no-credential outcome has its own exit code and its own sentence, so an agent cannot quietly proceed:

| Code | Case |
| --- | --- |
| 3 | denied or revoked — "a human said no; do not retry" |
| 4 | timed out or expired — reported as a deny, per the ADR |
| 5 | rate limited |
| 6 | not configured (message names both key locations) |
| 1 | broker unreachable / mint failed / bad response |

A cold-starting broker is tolerated for up to five consecutive poll failures so a scale-from-zero wobble doesn't read as a denial; persistent failure still fails.

## Two judgement calls worth reviewing

**gcloud gets a dedicated configuration.** `gcloud config set auth/access_token_file` on the *active* configuration would silently repoint the human's own gcloud at an hour-long agent token. Instead the helper writes into an `agent-broker` configuration (scoped via `CLOUDSDK_ACTIVE_CONFIG_NAME`), activates it, and records the displaced name so `release` and `revoke` restore it. `--no-activate` and `--no-gcloud` opt out. Verified against a sandboxed `CLOUDSDK_CONFIG`; the real one was left alone.

**`--purpose` is required.** It is the only thing the human has to judge the card by, and `(none given)` makes the approval reflexive — which is the failure mode the phrase check depends on avoiding.

## Verification

44 assertions against a fake broker implementing the real wire shapes (in scratch, not committed — the durable end-to-end run is `gcp-org-management` #269): happy path, deny, expire, client timeout, rate limit, wrong key, missing key, unreachable broker, env-var key with a trailing newline, repo resolution from `git remote`, file modes, background refresh re-exchanging, refresh exiting cleanly at the grant boundary, and `release`/`revoke` cleanup. Plus `shellcheck`, `markdownlint`, and the chezmoi dry-run.

Not exercised against the live broker: `~/.config/claude/credential-broker/url` is not set on this machine and a real request would ping Discord. That is #269's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)