### PR TITLE
Default to merge-commit, not squash, for agentic PRs

### DIFF
--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -9,7 +9,8 @@
 ## Git Workflow
 
 - Always create feature branches for changes -- never commit directly to main
-- Create PRs with `mcp__github__create_pull_request` and merge via `mcp__github__merge_pull_request` (method: "squash", delete_branch: true)
+- Create PRs with `mcp__github__create_pull_request` and merge via `mcp__github__merge_pull_request` (`delete_branch: true`)
+- **Merge method: `merge` by default, `squash` only to clean up a messy branch, never `rebase`.** Squash replaces a branch's commits with a new SHA, so anything built on that branch still carries the originals and re-applies work `main` already has — conflicts resolved against a change that already landed. Rebase-merge has the same defect for the same reason. A merge commit puts the branch's actual commits in `main`, so a dependent branch rebases to a no-op. Agentic PRs arrive as one or two already-written commits, so squash's benefit — collapsing WIP noise — is usually nothing, while its cost is paid every time. Reach for `squash` when the branch genuinely has fixup/WIP commits or several that aren't individually meaningful. The known trade-off: `git bisect` can descend into a commit that never passed CI on its own — use `git bisect --first-parent`, and `git log --first-parent` for the PR-level view
 - Watch the CI checks and ensure they pass
 - Don't merge your own PRs - let them be reviewed by someone else
 - Before pushing follow-up commits to a PR branch, always check the PR is still open via `mcp__github__pull_request_read` (method: "get"). The user often reviews and merges PRs via the GitHub UI while work continues — if already merged, create a new branch and PR instead

--- a/home/commands/setup-common.md
+++ b/home/commands/setup-common.md
@@ -320,6 +320,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
+`--squash` here is deliberate and is the one place it stays. The global default is merge-commit (see the Git Workflow section of `~/.claude/CLAUDE.md`), because squash's SHA rewrite punishes stacked branches — but a Dependabot PR is a single-commit version bump that nothing is ever stacked on, and one commit per bump keeps `main` readable. Don't "fix" this to match the default.
+
 Also ensure `.github/dependabot.yml` exists with the base structure. If it doesn't exist, create it:
 
 ```yaml

--- a/home/commands/setup-repo.md
+++ b/home/commands/setup-repo.md
@@ -32,8 +32,8 @@ Apply all settings in a single `gh repo edit` call:
 ```sh
 gh repo edit \
   --delete-branch-on-merge \
+  --enable-merge-commit \
   --enable-squash-merge \
-  --enable-merge-commit=false \
   --enable-rebase-merge=false \
   --enable-auto-merge \
   --allow-update-branch \
@@ -41,17 +41,24 @@ gh repo edit \
   --enable-projects=false
 ```
 
+**Why both merge-commit and squash, and never rebase.** Merge-commit is the default (see the Git Workflow section of `~/.claude/CLAUDE.md`): squash replaces a branch's commits with a new SHA, so anything stacked on it re-applies work `main` already has. Rebase-merge shares that defect and offers no cleanup in return, so it is disabled outright rather than left as a tempting third button. Squash stays enabled for the case it is actually good at — a branch carrying WIP or fixup commits.
+
+GitHub has no "default merge method" field; the only levers are these three booleans, so leaving rebase enabled is what lets it drift back into use.
+
 If wiki or projects are currently enabled, note this in the summary but still disable them. Most hobby projects don't use these features.
 
-### 3. Squash merge commit message format
+### 3. Merge commit message formats
 
-Set the default squash merge commit message to use the PR title:
+Set both message formats, so whichever method a PR uses produces a useful commit subject:
 
 ```sh
 gh repo edit --enable-squash-merge --squash-merge-commit-message pr-title
+gh api -X PATCH repos/{owner}/{repo} -f merge_commit_title=PR_TITLE -f merge_commit_message=PR_BODY
 ```
 
-`--enable-squash-merge` must be in the **same invocation** even though step 2 already enabled it: `gh` gates the message flag on the enable flag being present in the same call. Without it, `gh repo edit` prints its help text, exits 0, and applies nothing — the output looks like documentation, not an error, so check that it actually applied.
+`--enable-squash-merge` must be in the **same invocation** as `--squash-merge-commit-message` even though step 2 already enabled it: `gh` gates the message flag on the enable flag being present in the same call. Without it, `gh repo edit` prints its help text, exits 0, and applies nothing — the output looks like documentation, not an error, so check that it actually applied.
+
+The merge-commit format needs the API directly: `gh repo edit` has **no** `--merge-commit-title`/`--merge-commit-message` flags, only the squash pair. The API also accepts just three title/message combinations — `PR_TITLE`+`PR_BODY`, `PR_TITLE`+`BLANK`, and the default `MERGE_MESSAGE`+`PR_TITLE`. Anything else returns a 422 naming the valid set. `PR_TITLE`+`PR_BODY` is the one that matches what squash does with `pr-title`, so `main`'s log reads the same whichever method a PR used.
 
 ### 4. Secret scanning (public repos only)
 
@@ -79,7 +86,7 @@ Apply branch protection to the default branch using the GitHub API. The JSON pay
 - `required_pull_request_reviews`: `null` (solo developer — cannot require approvals from others)
 - `enforce_admins`: `true` (critical — prevents admin-level tokens and coding agents from bypassing rules)
 - `restrictions`: `null` (not applicable for personal repos)
-- `required_linear_history`: `true` (complements squash-only strategy)
+- `required_linear_history`: `false` — **do not set this true.** Linear history blocks merge commits on the protected branch outright, and merge-commit is the default method (step 2). A repo with both applied cannot merge a PR at all by the sanctioned route, and the failure appears at merge time on an approved, green PR — long after the setting that caused it. It reads like a tidy-up worth restoring; it isn't
 - `allow_force_pushes`: `false`
 - `allow_deletions`: `false`
 
@@ -133,8 +140,8 @@ In `--labels-only` mode, verify with `gh label list` alone — confirm the nine 
 
 After a full run, verify the configuration took effect:
 
-- Run `gh repo view --json deleteBranchOnMerge,squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed` and confirm values match
-- Run `gh api repos/{owner}/{repo}/branches/{default_branch}/protection` and confirm the protection rules are in place
+- Run `gh repo view --json deleteBranchOnMerge,squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed` and confirm values match — expect `mergeCommitAllowed` and `squashMergeAllowed` true, `rebaseMergeAllowed` false
+- Run `gh api repos/{owner}/{repo}/branches/{default_branch}/protection` and confirm the protection rules are in place, and specifically that `required_linear_history.enabled` is `false` — if it is true, merge commits are blocked and step 5 did not apply as intended
 - Display a final summary showing all applied settings
 
 ## Important


### PR DESCRIPTION
Closes #148

Squash replaces a branch's commits with a new SHA, so anything built on that branch still carries the originals — rebasing onto `main` re-applies work `main` already has, and the conflicts are resolved against a change that already landed. Rebase-merge shares the defect for the same reason. Merge-commit is the only one of the three that avoids it.

Squash's benefit is collapsing WIP noise, and agentic PRs arrive as one or two already-written commits — so the cost is paid every time for a cleanup that isn't needed. `home/bin/end-session-squash-merged` exists *because* squash breaks `git branch --merged`: a bespoke tool paying squash's tax.

The rule and the practice had already diverged — this repo's recent merges are merge commits (`#145`, `#144`, `#143`), not squashes.

## The trap this turned up

`/setup-repo` step 5 set `required_linear_history: true`, described as complementing the squash-only strategy. **Linear history blocks merge commits outright.** Any repo where `/setup-repo` ran fully would refuse a merge commit — at merge time, on an approved and green PR, long after the setting that caused it. This repo only escaped because it has no branch protection at all (`404 Branch not protected`).

So the merge method and the protection rule had to move together. The flag is now `false`, with the reason written next to it so it doesn't get tidied back as an obvious-looking improvement.

## Changes

| File | Change |
| --- | --- |
| `home/CLAUDE.md` | `merge` by default, `squash` only for a messy branch, never `rebase` — with the reasoning and the bisect trade-off |
| `setup-repo.md` §2 | Enable merge-commit **and** squash; disable rebase |
| `setup-repo.md` §3 | Merge-commit message format alongside the squash one |
| `setup-repo.md` §5 | `required_linear_history` → `false` |
| `setup-repo.md` §8 | Verification covers the new expected values |
| `setup-common.md` | A note on why Dependabot keeps `--squash` |

## One correction worth flagging

I first wrote §3 using `gh repo edit --merge-commit-title/--merge-commit-message`. **Those flags don't exist** — `gh repo edit` only has the squash pair. `gh repo edit --help` caught it before it shipped. The merge-commit format needs `gh api -X PATCH`, and the API accepts only three title/message combinations (a 422 names the valid set); `PR_TITLE`+`PR_BODY` is the one matching what squash does with `pr-title`, so `main`'s log reads the same either way. Both facts are now in the file.

## Deliberately unchanged

- **`setup-common.md`'s Dependabot auto-merge keeps `gh pr merge --auto --squash`.** A single-commit version bump has nothing stacked on it, and one commit per bump keeps `main` readable. Now carries a note so it doesn't read as an oversight.
- **`end-session.md`'s squash-merged branch detection stays.** Legacy branches and other repos still need it.

## The trade-off, stated rather than hidden

`git bisect` can descend into a commit that never passed CI on its own. `git bisect --first-parent` handles it, and `git log --first-parent` keeps the PR-level view. Both are named in the CLAUDE.md rule.

## Applied to this repo separately

`delete_branch_on_merge` → `true`, and `allow_rebase_merge` → `false`. 43 stale remote branches deleted (all with merged PRs, all content-contained in `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)