### PR TITLE
Warn in the refresh log before a grant expires

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -551,7 +551,18 @@ cmd_refresh() {
         # the window, then remove the token so anything still reaching for it
         # fails loudly rather than with an opaque 401.
         if [ "$remaining" -le "$TOKEN_LIFETIME" ]; then
-            [ "$remaining" -gt 0 ] && sleep "$remaining"
+            # Reached exactly once, at most one token lifetime out, and then the
+            # loop goes quiet until the window closes. So it doubles as the last
+            # warning: without it the log's only account of the ending is the
+            # past-tense line below, read after calls have already started
+            # failing. The message names the real remaining time rather than
+            # claiming a fixed hour — the loop wakes every REFRESH_INTERVAL, so
+            # this fires somewhere between a full token lifetime and the
+            # remainder after the previous wake.
+            if [ "$remaining" -gt 0 ]; then
+                echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') grant expires in $(humanise_remaining "$remaining") and will not refresh again — request a new grant before then to avoid an interruption"
+                sleep "$remaining"
+            fi
             rm -f "$TOKEN_FILE"
             rm -f "$PID_FILE"
             echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') grant expired; token removed. Request again to continue."


### PR DESCRIPTION
Closes #155.

Token rotation is the good half of this design — silent, and it needs nobody. Grant expiry can't be, because a new grant needs a human. So the least it can do is say so while there's still time to act. Until now the log's only account of the ending was written in the past tense, read after calls had already started failing.

## Where it goes

No new threshold logic. The wind-down branch in `cmd_refresh` is entered **exactly once**, when the remaining window drops under one token lifetime, and then sleeps out the rest in silence. That was already the last-warning point — it just never said anything.

```diff
 if [ "$remaining" -le "$TOKEN_LIFETIME" ]; then
-    [ "$remaining" -gt 0 ] && sleep "$remaining"
+    if [ "$remaining" -gt 0 ]; then
+        echo "... grant expires in $(humanise_remaining "$remaining") and will not refresh again — request a new grant before then to avoid an interruption"
+        sleep "$remaining"
+    fi
     rm -f "$TOKEN_FILE"
```

## On the timing, stated plainly

The loop wakes every `REFRESH_INTERVAL` (2700s) against a `TOKEN_LIFETIME` of 3600s, so the branch is entered with **900–3600 seconds** left. The warning lands 15–60 minutes ahead, not reliably at one hour — so the message names the real remaining time from `humanise_remaining` rather than promising an hour it would get wrong most of the time.

Tightening it would mean a second timer for the warning alone. Not worth it: the token in hand is still valid for up to an hour at that point, so even the worst case leaves room to request again without interrupting work.

## Checks

`shellcheck` clean, `sh -n` clean. Message rendered against the real function across the reachable range:

```
remaining=3600  -> grant expires in 1h 0m and will not refresh again
remaining=3540  -> grant expires in 59m ...
remaining=1800  -> grant expires in 30m ...
remaining=900   -> grant expires in 15m ...
```

`remaining=0` would render "expires in expired", but the `-gt 0` guard makes that unreachable — an already-expired grant falls through to the existing past-tense line.

Branched from `main`, independent of #151 — both touch `home/bin/gcp-credentials` but in different functions, so they merge in either order. Not stacked.

Found while reviewing the expiry path during gcp-org-management#269. Upstream: #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t76AgXyrrP9BvKPN9efdi