### PR TITLE
ADR-0016: where capability lives — environment, repo, or content

### DIFF
--- a/adrs/0016-capability-delivery-principles.md
+++ b/adrs/0016-capability-delivery-principles.md
@@ -1,0 +1,215 @@
+# ADR-0016: Where capability lives — environment, repo, or content
+
+- **Status**: Proposed (2026-08-13)
+- **Date**: 2026-08-13
+- **Tags**: architecture, cloud, plugins, portability, claude-code
+- **Scope**: user (applies to all personal repos and agent surfaces)
+
+## Context
+
+[ADR-0014](0014-portable-agent-config-architecture.md) chose mechanisms:
+skills as the portable unit, an AGENTS.md policy core, a dual-manifest
+plugin, and — for cloud sessions — project-scope enablement committed to
+each repo's `.claude/settings.json`.
+
+That decision is sound for what it was aimed at. But it answers "how do
+we distribute agent config" without asking "is this thing agent config
+at all", and the first real cloud-sandbox exercise (2026-08-12, the GCP
+credential broker in `cloud-run-behind-apix`) showed the gap. Making a
+repo able to reach Google Cloud from a sandbox needed:
+
+- `gcloud` installed in the VM
+- `dl.google.com` and the broker host on the network allowlist
+- `CREDENTIAL_BROKER_URL` and `CREDENTIAL_BROKER_REQUEST_KEY` set
+- the broker client helper and its skill available to the session
+
+Only the last is agent config. The rest are properties of the *machine*
+and its *network*, and none of them varies by repository. Following
+ADR-0014 point 3 literally would have committed Claude-proprietary JSON
+into a repo — one that also carries an `AGENTS.md` for other providers —
+in order to configure something that is not about that repo.
+
+The question the estate keeps re-deriving, once per surface, is: **when a
+session needs a capability, where should the thing that grants it live?**
+This ADR answers that so the next mechanism can be chosen without
+re-litigating the last one.
+
+## Decision
+
+Adopt five principles, applied in order, when deciding where any piece of
+agent-enabling configuration belongs.
+
+### 1. Classify before choosing a mechanism
+
+Every requirement is either an **environment capability** or **project
+configuration**:
+
+- **Environment capability** — a property of the machine, its network, or
+  the credentials obtainable from it. It does not vary by repository, and
+  two repos needing it want it *identical*. Toolchains, network reach,
+  credential brokering, OS packages.
+- **Project configuration** — genuinely specific to one repository. Its
+  conventions, its pre-approved commands, which skills it uses, its
+  build and test commands.
+
+The classification determines the mechanism, and it is the step that was
+missing:
+
+| Concern | Lives in | Reaches cloud via |
+| ------- | -------- | ----------------- |
+| Toolchain, OS packages, network allowlist | Cloud environment config | Setup script + allowed domains |
+| Credentials and broker endpoints | Cloud environment config | Environment variables |
+| Portable skills and policy | This repo, delivered as content | Plugin, or setup-script placement |
+| Repo conventions, permissions, build commands | The repo's own `.claude/` | Part of the clone |
+
+A repo pointed at a `gcp-enabled` environment gains GCP access with
+**zero files committed**. That is the correct outcome, and ADR-0014's
+route could not express it.
+
+### 2. Provider-specific coupling belongs on provider-specific surfaces
+
+Prefer the surface that is *already* provider-specific, and prefer one
+outside version control where a choice exists.
+
+The Claude Code cloud environment config is Claude-only and lives outside
+any repository, so Claude-only plumbing costs nothing there. Committing
+`extraKnownMarketplaces` into a repo does the opposite: it plants
+vendor-proprietary configuration in a directory that Codex, OpenCode and
+Cursor also read, to solve a problem only one vendor has.
+
+This does not forbid the plugin route. It scopes it: use it for **project
+configuration**, where per-repo declaration is the point, and not for
+**environment capability**, where it is a tax.
+
+### 3. Portable content, provider-specific delivery
+
+The portability commitment in ADR-0014 is about *content* — SKILL.md
+bodies, AGENTS.md policy. Delivery is free to be provider-specific,
+because delivery is not what other providers read.
+
+A setup script placing provider-neutral `SKILL.md` files into a
+container's skills directory is not a portability violation. The content
+stays neutral; only the placement is Claude-aware; the repo stays empty.
+Plugins are *one* delivery vehicle, not the definition of the content.
+
+Corollary: never let a delivery mechanism's idiom leak into content. The
+hardcoded `~/.claude/bin/...` paths in the broker skill are exactly this
+failure — a delivery assumption written into portable text, which then
+broke on a surface where the assumption did not hold.
+
+### 4. Repo footprint proportional to what is genuinely project-specific
+
+A repository should not have to carry a vendor's plumbing to be usable.
+Every committed line of agent config is a line a human reviews, a line
+that drifts, and a line that must be repeated across N repos.
+
+When a mechanism requires per-repo files, that cost is justified only if
+the thing being configured is genuinely per-repo.
+
+### 5. Defer substance to a pinned, versioned single source
+
+Where a provider surface must hold something, it holds **one line** that
+defers to versioned content in this repo:
+
+```bash
+#!/bin/bash
+curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/v1.3.0/cloud/bootstrap.sh | bash
+```
+
+Two properties make this work:
+
+- **Pin to a tag or commit, never a branch.** A mutable ref means any
+  compromise of this repo reaches every sandbox that starts afterwards.
+- **The version bump is the release.** Cloud environments snapshot the
+  setup script's result and re-run only when the script changes, so
+  editing the pinned version is what rolls the change out — deliberate
+  and visible, rather than content shifting underneath a cached image.
+
+`curl | bash` is a supply-chain surface, accepted knowingly here: the
+source is our own repo, pinned, over TLS, into an ephemeral
+single-tenant container. It would not be acceptable on a durable host.
+
+## Consequences
+
+### Positive
+
+- A repo becomes GCP-capable by *selecting an environment*, committing
+  nothing. The N-repos tax disappears for the whole class.
+- Vendor lock-in concentrates on a surface that is already vendor-owned
+  and outside version control, keeping repos honestly multi-provider.
+- The classification is reusable: the next capability (AWS, a private
+  registry, a VPN) is placed by asking one question rather than
+  re-arguing mechanisms.
+- Environments become named capability profiles — `gcp-enabled`,
+  `default` — which is a legible model for a human to reason about.
+- Pinned bootstrap gives an explicit release channel, with cache
+  invalidation as the deployment trigger rather than a nuisance.
+
+### Negative / trade-offs
+
+- **Environment config is invisible to the repo.** Nothing in a checkout
+  says which environment a session ran in, so a failure that depends on
+  environment state is harder to reproduce. Mitigation: the bootstrap
+  script logs its pinned version at session start.
+- **Environments proliferate.** Capability profiles multiply as
+  combinations appear; there is no inheritance between them, so shared
+  setup is copied. Watch for this before it becomes its own maintenance
+  problem.
+- **Two distribution paths persist.** Plugin for project configuration,
+  bootstrap for environment capability. That is more machinery than
+  picking one, and the boundary needs policing.
+- **This narrows ADR-0014 point 3.** Project-scope plugin enablement
+  remains correct for skills and policy, but is no longer the default
+  answer for everything reaching a cloud session. ADR-0014 is amended,
+  not superseded, and #48 should be re-read against this.
+- **A cached environment can serve stale content** for up to its expiry
+  if a version bump is forgotten. The pin makes this visible but does
+  not prevent it.
+
+### Open question, blocking principle 3
+
+Whether Claude Code reads `~/.claude/skills/` when the **setup script
+creates it inside the container** is unverified. The documentation states
+that user-scope config does not reach cloud sessions, but that refers to
+*the developer's machine* not transferring — a `~/.claude/` that exists
+in the container is a different question. Principle 3's zero-footprint
+skill delivery depends on the answer. It is cheap to test in a live
+sandbox and should be settled before this ADR is ratified.
+
+If the answer is no, principle 3 still holds in spirit but its delivery
+falls back to the plugin route for skills specifically, and the
+zero-footprint claim weakens to "toolchain and credentials only".
+
+## Alternatives considered
+
+**Commit plugin enablement to every repo (ADR-0014 point 3 applied
+universally).** Rejected as the general answer for the reasons in
+principles 2 and 4: vendor JSON in multi-provider repos, repeated N
+times, for capabilities that are not per-repo. Retained for project
+configuration, where per-repo declaration is the intent.
+
+**Clone the whole of `home/` into the sandbox from the setup script.**
+Rejected. It reintroduces the drift that per-repo copies already
+demonstrated — a copied client diverged from upstream within a day
+(#150, #152) — and it delivers project configuration through an
+environment-scoped mechanism, which is principle 1 backwards.
+
+**`CLAUDE_CODE_PLUGIN_SEED_DIR` to pre-populate the plugin cache.**
+Kept as a fallback if marketplace fetching proves incompatible with the
+network allowlist, not as the plan: seeding restores snapshot staleness
+for content that should be fresh at session start.
+
+**Do nothing; decide case by case.** Rejected — that is the current
+state, and it has produced one re-derivation per surface, with the
+`~/.claude/bin/` path assumption baked in along the way.
+
+## References
+
+- [ADR-0014](0014-portable-agent-config-architecture.md) — mechanisms this
+  ADR classifies the use of
+- [ADR-0015](0015-tiered-adrs.md) — tier conventions; this is a user-tier
+  decision
+- #48 — plugin distribution, to be re-read against principle 1
+- #150, #152, #153, #154, #155 — findings from the 2026-08-12 sandbox run
+  that motivated this
+- gcp-org-management#269 — the validation exercise that surfaced it

--- a/adrs/0016-capability-delivery-principles.md
+++ b/adrs/0016-capability-delivery-principles.md
@@ -1,8 +1,8 @@
 # ADR-0016: Where capability lives — environment, repo, or content
 
-- **Status**: Proposed (2026-08-13)
+- **Status**: Accepted (2026-08-13), validated on Claude Code and Codex
 - **Date**: 2026-08-13
-- **Tags**: architecture, cloud, plugins, portability, claude-code
+- **Tags**: architecture, cloud, plugins, portability, claude-code, codex
 - **Scope**: user (applies to all personal repos and agent surfaces)
 
 ## Context
@@ -36,10 +36,45 @@ re-litigating the last one.
 
 ## Decision
 
-Adopt five principles, applied in order, when deciding where any piece of
+Adopt six principles, applied in order, when deciding where any piece of
 agent-enabling configuration belongs.
 
-### 1. Classify before choosing a mechanism
+### 1. Adding a capability changes nothing in the repo
+
+Working in a coding agent on one of these repos should come with cloud
+capabilities, and **acquiring them must be invisible to the repo**. No
+committed file records that sessions here can reach Google Cloud, and
+none is edited to give them that reach.
+
+This is the claim the other four serve. Three reasons it is more than
+tidiness:
+
+- **Capability is per-session, not per-project.** One sandbox has GCP
+  access, a collaborator's does not, a laptop has it by another route.
+  A repo asserting "sessions here have GCP" states something true for
+  some people, some of the time.
+- **It is a runtime property in a design-time artefact.** The repo
+  outlives the capability and nothing updates it when the environment
+  changes, so it goes stale in silence — the same failure as a vendored
+  copy, one level up.
+- **It is the precondition for working across providers.** An
+  `extraKnownMarketplaces` block is Claude-only; committed to a repo a
+  Codex session also reads, it is dead weight that makes the repo *look*
+  vendor-specific when it is not. Capability supplied by the environment
+  is the only form every provider can express, because each supplies it
+  its own way and the repo never learns which.
+
+**A repo may declare a need; it must not implement the capability.** A
+line in `AGENTS.md` saying tasks here need GCP access via the broker is
+prose — portable, vendor-neutral, and it does not break when the
+mechanism changes. What must not appear is anything that *provides* the
+access: marketplace declarations, a vendored helper, credentials, paths.
+
+Declaring the need is also the answer to the obvious objection, that an
+invisible capability is undiscoverable. The requirement stays visible.
+Only its implementation moves.
+
+### 2. Classify before choosing a mechanism
 
 Every requirement is either an **environment capability** or **project
 configuration**:
@@ -66,15 +101,24 @@ A repo pointed at a `gcp-enabled` environment gains GCP access with
 **zero files committed**. That is the correct outcome, and ADR-0014's
 route could not express it.
 
+Concretely, per surface:
+
+| Surface | Capability arrives via | Repo footprint |
+| ------- | ---------------------- | -------------- |
+| Claude Code cloud sandbox | setup script → `cloud/bootstrap.sh` → `~/.claude/skills` | none |
+| Codex cloud sandbox | setup script → `cloud/bootstrap.sh` → `~/.agents/skills` | none |
+| Local terminal (macOS) | chezmoi → `~/.claude`, plus the refresh daemon | none |
+| Self-hosted sandbox | superseded by the vendors' own | n/a |
+
 Note the column headings carefully: they say which surface **owns** a
 concern, not which surface holds its **implementation**. The first draft
 of this ADR was read — by its own author — as licence to put `apt-get`
-lines in a setup script, which principle 5 then forbids two sections
+lines in a setup script, which principle 6 then forbids two sections
 later. The environment *triggers* a toolchain install by choosing to
 call the bootstrap, and by what it passes; what gets installed stays
 versioned here with everything else.
 
-### 2. Provider-specific coupling belongs on provider-specific surfaces
+### 3. Provider-specific coupling belongs on provider-specific surfaces
 
 Prefer the surface that is *already* provider-specific, and prefer one
 outside version control where a choice exists.
@@ -89,7 +133,7 @@ This does not forbid the plugin route. It scopes it: use it for **project
 configuration**, where per-repo declaration is the point, and not for
 **environment capability**, where it is a tax.
 
-### 3. Portable content, provider-specific delivery
+### 4. Portable content, provider-specific delivery
 
 The portability commitment in ADR-0014 is about *content* — SKILL.md
 bodies, AGENTS.md policy. Delivery is free to be provider-specific,
@@ -105,7 +149,7 @@ hardcoded `~/.claude/bin/...` paths in the broker skill are exactly this
 failure — a delivery assumption written into portable text, which then
 broke on a surface where the assumption did not hold.
 
-### 4. Repo footprint proportional to what is genuinely project-specific
+### 5. Repo footprint proportional to what is genuinely project-specific
 
 A repository should not have to carry a vendor's plumbing to be usable.
 Every committed line of agent config is a line a human reviews, a line
@@ -114,7 +158,7 @@ that drifts, and a line that must be repeated across N repos.
 When a mechanism requires per-repo files, that cost is justified only if
 the thing being configured is genuinely per-repo.
 
-### 5. Defer substance to a pinned, versioned single source
+### 6. Defer substance to a pinned, versioned single source
 
 Where a provider surface must hold something, it holds **one line** that
 defers to versioned content in this repo:
@@ -174,25 +218,50 @@ single-tenant container. It would not be acceptable on a durable host.
   if a version bump is forgotten. The pin makes this visible but does
   not prevent it.
 
-### Open question, blocking principle 3
+### Questions this was held open for, now answered
 
-Whether Claude Code reads `~/.claude/skills/` when the **setup script
-creates it inside the container** is unverified. The documentation states
-that user-scope config does not reach cloud sessions, but that refers to
-*the developer's machine* not transferring — a `~/.claude/` that exists
-in the container is a different question. Principle 3's zero-footprint
-skill delivery depends on the answer. It is cheap to test in a live
-sandbox and should be settled before this ADR is ratified.
+Ratification waited on whether a `~/.claude` **created inside a
+container** is read at all — the documentation says user-scope config
+does not reach cloud sessions, but it means the developer's laptop does
+not transfer, which is a different claim. Both halves are now settled by
+running it:
 
-If the answer is no, principle 3 still holds in spirit but its delivery
-falls back to the plugin route for skills specifically, and the
-zero-footprint claim weakens to "toolchain and credentials only".
+- **Claude Code, 2026-08-13.** A sandbox session listed the skill from a
+  container-created `~/.claude/skills` and invoked it **unprompted**, via
+  the Skill tool, on finding `gcloud auth list` empty. Discovery works
+  without being told the skill exists.
+- **Codex, 2026-08-13.** The same bootstrap, unchanged, installed into
+  `~/.agents/skills` and Codex listed `gcp-credentials` among its custom
+  skills. The helper ran on `codex-universal` with no modification —
+  POSIX `sh`, `curl` and `jq` are all present — and reached the broker
+  through Codex's proxy.
+
+Two vendors, one mechanism, nothing committed to the repo being worked
+on. That is principle 1 demonstrated rather than asserted, and it is why
+this ADR is Accepted rather than Proposed.
+
+Codex needs configuration Claude does not, which belongs in the
+environment and not here: agent-phase internet is **off by default** and
+must be enabled, and the optional restriction to `GET`/`HEAD`/`OPTIONS`
+blocks the broker outright, since `/request`, `/exchange` and `/revoke`
+are all `POST`. Setup-script `export`s do not survive into the agent
+phase either, so variables belong in the environment's own settings. All
+of it is recorded in [`cloud/README.md`](../cloud/README.md).
+
+### Still unverified
+
+Whether Claude Code follows a **symlinked** skill directory. The Claude
+result above was obtained with a real directory; the canonical layout now
+places the file at `~/.agents/skills` with `~/.claude/skills` pointing at
+it. If Claude stops listing the skill, that is why, and the fallback is a
+real copy in both locations. This does not affect the principles: it is
+an implementation detail of one delivery mechanism.
 
 ## Alternatives considered
 
 **Commit plugin enablement to every repo (ADR-0014 point 3 applied
 universally).** Rejected as the general answer for the reasons in
-principles 2 and 4: vendor JSON in multi-provider repos, repeated N
+principles 3 and 5: vendor JSON in multi-provider repos, repeated N
 times, for capabilities that are not per-repo. Retained for project
 configuration, where per-repo declaration is the intent.
 
@@ -217,7 +286,7 @@ state, and it has produced one re-derivation per surface, with the
   ADR classifies the use of
 - [ADR-0015](0015-tiered-adrs.md) — tier conventions; this is a user-tier
   decision
-- #48 — plugin distribution, to be re-read against principle 1
+- #48 — plugin distribution, to be re-read against principle 2
 - #150, #152, #153, #154, #155 — findings from the 2026-08-12 sandbox run
   that motivated this
 - gcp-org-management#269 — the validation exercise that surfaced it

--- a/adrs/0016-capability-delivery-principles.md
+++ b/adrs/0016-capability-delivery-principles.md
@@ -57,7 +57,7 @@ missing:
 
 | Concern | Lives in | Reaches cloud via |
 | ------- | -------- | ----------------- |
-| Toolchain, OS packages, network allowlist | Cloud environment config | Setup script + allowed domains |
+| Toolchain, OS packages, network allowlist | Cloud environment config | Setup script + allowed domains, deferring to a versioned script |
 | Credentials and broker endpoints | Cloud environment config | Environment variables |
 | Portable skills and policy | This repo, delivered as content | Plugin, or setup-script placement |
 | Repo conventions, permissions, build commands | The repo's own `.claude/` | Part of the clone |
@@ -65,6 +65,14 @@ missing:
 A repo pointed at a `gcp-enabled` environment gains GCP access with
 **zero files committed**. That is the correct outcome, and ADR-0014's
 route could not express it.
+
+Note the column headings carefully: they say which surface **owns** a
+concern, not which surface holds its **implementation**. The first draft
+of this ADR was read — by its own author — as licence to put `apt-get`
+lines in a setup script, which principle 5 then forbids two sections
+later. The environment *triggers* a toolchain install by choosing to
+call the bootstrap, and by what it passes; what gets installed stays
+versioned here with everything else.
 
 ### 2. Provider-specific coupling belongs on provider-specific surfaces
 


### PR DESCRIPTION
Closes #157. **Status: Proposed** — this is a draft to argue with, not a fait accompli.

ADR-0014 chose mechanisms. It never asked whether a given requirement is agent config *at all*, and the first cloud-sandbox run found the gap: making a repo GCP-capable needed `gcloud` installed, two allowlist entries, two environment variables, and the broker client — and **only the last is agent config**. The rest are properties of the machine and its network, identical for every repo that wants them.

Applied literally, ADR-0014 point 3 would have committed Claude-proprietary JSON into a repo that also carries an `AGENTS.md`, to configure something that isn't about that repo. The missing step was classification, not mechanism.

## The five principles

1. **Classify before choosing a mechanism** — environment capability vs project configuration. A repo pointed at a `gcp-enabled` environment gains GCP access with *zero files committed*; ADR-0014's route couldn't express that.
2. **Provider-specific coupling belongs on provider-specific surfaces** — prefer one already vendor-owned and outside version control. Doesn't forbid the plugin route; scopes it.
3. **Portable content, provider-specific delivery** — a setup script placing neutral `SKILL.md` files isn't a portability violation. Corollary: the hardcoded `~/.claude/bin/` paths were a delivery assumption leaking into portable text, which then broke where the assumption didn't hold.
4. **Repo footprint proportional to what's genuinely project-specific.**
5. **Defer substance to a pinned, versioned single source** — one line in the vendor surface. Pin to a tag, never a branch; the version bump *is* the release, with cache invalidation as the deployment trigger.

## What I'd most like argued with

**Principle 2 is the load-bearing one.** It's the claim that changes the most downstream, and it cuts against ADR-0014 point 3 — which I've framed as *amended, not superseded*. If you disagree with the framing, the rest reshuffles.

**Principle 5 accepts `curl | bash`.** Stated as a knowing trade — own repo, pinned, TLS, ephemeral single-tenant container, and explicitly not acceptable on a durable host. Reasonable people refuse this outright.

**The negatives are real and I've listed them**, including two I'd watch: environments proliferate with no inheritance, and nothing in a checkout says which environment a session ran in.

## Blocking ratification

Whether Claude Code reads `~/.claude/skills/` when the **setup script creates it inside the container**. The docs say user-scope config doesn't reach cloud, but that's about *your laptop* not transferring — a `~/.claude/` existing in the container is a different question. Principle 3's zero-footprint claim depends on it, it's cheap to test in the live sandbox, and if the answer is no the claim weakens to "toolchain and credentials only".

That's why this is Proposed rather than Accepted.

`markdownlint-cli2` clean. `Scope: user` per ADR-0015. Branched from `main`, independent of #151 and #156 — different files, merges in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t76AgXyrrP9BvKPN9efdi