### PR TITLE
Add renew, and make refresh mint before it sleeps

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -89,10 +89,15 @@ usage() {
     cat >&2 <<'USAGE'
 usage:
   gcp-credentials request [options]   ask for credentials and install them
-  gcp-credentials refresh             run the refresh loop in the foreground
+  gcp-credentials renew               mint one token from an existing grant
+  gcp-credentials refresh [--background]
+                                      run the refresh loop (default: foreground)
   gcp-credentials status              show grant / refresh / gcloud state
   gcp-credentials release             drop credentials locally, keep the grant
   gcp-credentials revoke              kill the grant at the broker
+
+after a container restart, when the grant is still live but the loop is not:
+  gcp-credentials refresh --background   mints immediately, then keeps going
 
 request options:
   --purpose TEXT   why the access is needed (required; shown to the human)
@@ -533,11 +538,61 @@ cmd_request() {
     fi
 }
 
+# renew mints one token from the existing grant and exits.
+#
+# This is the recovery path that was missing. A refresh loop killed by a
+# container restart leaves a perfectly valid grant next to a stale token, and
+# before this every route to a new token was wrong for that situation: `request`
+# pings a human for an approval that is not needed, and `refresh` sleeps a full
+# interval before its first exchange. Neither the grant nor the human is the
+# problem, so neither should be involved.
+#
+# Needs the broker URL but not the request key: /exchange authenticates with the
+# session token from the grant file, not the key.
+cmd_renew() {
+    [ -f "$GRANT_FILE" ] || die 2 "no grant on this machine — run '$PROG request' first"
+    load_url
+    TMPDIR_CB=$(mktemp -d)
+
+    do_exchange
+
+    echo "token renewed for $EX_PROJECT (expires $EX_EXPIRES)"
+    echo "  identity: $EX_SA"
+    echo "  grant   : expires $EX_GRANT_EXPIRES"
+    if ! refresh_running; then
+        echo "  note    : background refresh is not running — '$PROG refresh --background' restarts it"
+    fi
+}
+
 cmd_refresh() {
+    if [ "${1:-}" = "--background" ]; then
+        [ -f "$GRANT_FILE" ] || die 2 "no grant on this machine — run '$PROG request' first"
+        refresh_start
+        echo "background refresh started (pid $(cat "$PID_FILE")); log: $LOG_FILE"
+        return 0
+    fi
+
     [ -f "$GRANT_FILE" ] || die 2 "no grant on this machine — run '$PROG request' first"
     load_key
     load_url
     TMPDIR_CB=$(mktemp -d)
+
+    # Mint once before entering the rhythm, rather than sleeping first.
+    #
+    # The old order was written for the steady state, where a token was just
+    # installed and the next is due in an interval. It was exactly wrong for the
+    # case that needs this loop restarted — a container restart kills the
+    # process, the filesystem survives, and the token ages out while a valid
+    # grant sits unused. Sleeping first left that session credentialless for a
+    # full interval.
+    #
+    # The cost is one redundant mint when `request` starts the loop moments
+    # after its own exchange. That is a superseded 1-hour token and a duplicate
+    # audit-log line, which is a better trade than any freshness heuristic: no
+    # clock arithmetic, no stat portability, and one invariant worth having —
+    # if refresh is running, a valid token exists.
+    do_exchange
+    echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ') refreshed access token for $EX_PROJECT (expires $EX_EXPIRES)"
 
     while :; do
         grant_expires=$(jq -r '.grant_expires_at // ""' < "$GRANT_FILE")
@@ -651,7 +706,8 @@ shift
 
 case "$subcommand" in
     request) cmd_request "$@" ;;
-    refresh) cmd_refresh ;;
+    renew) cmd_renew ;;
+    refresh) cmd_refresh "$@" ;;
     status) cmd_status ;;
     release) cmd_release ;;
     revoke) cmd_revoke ;;

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -121,6 +121,38 @@ feed it from the file in the same command and never echo it:
 GOOGLE_OAUTH_ACCESS_TOKEN="$(cat ~/.config/claude/credential-broker/access_token)" terraform plan
 ```
 
+## After a container restart or a resumed session
+
+**Check this before anything else in a resumed cloud session.** Sandboxes
+restart container processes across an idle gap: the filesystem survives — your
+installed tools, the token file, the log — but the background refresh loop does
+not. Nothing restarts it, so the token ages out and dies while the grant is
+still perfectly valid.
+
+Symptoms, in the order you meet them:
+
+- `gcloud` fails with `Request had invalid authentication credentials`
+- `~/.claude/bin/gcp-credentials status` shows a live grant, `token : present`
+  (but stale), and `refresh : not running`
+- the refresh log's last entry is hours old
+
+The fix needs **no human approval** — the grant is what a human approved, and it
+has not expired:
+
+```sh
+~/.claude/bin/gcp-credentials refresh --background
+```
+
+That mints a token immediately and resumes the loop.
+
+**Do not run `request` for this.** It pings a human for an approval that is not
+needed, spending the one genuinely scarce resource in this design to fix a local
+process problem. Requesting again is for an expired *grant*, not a dead loop —
+`status` tells you which you have.
+
+`renew` mints once and exits, without touching the loop, when that is all you
+want.
+
 ## Grant expired
 
 The grant, not the token, is what runs out. Symptoms:


### PR DESCRIPTION
Closes #159.

A cloud sandbox restarted its container processes across a nine-hour idle gap. The filesystem survived — installed tools, token file, log all intact — but the refresh loop didn't, and nothing restarts it. The token aged out and died while the grant stayed valid for another twenty-three hours. `status` reported it accurately; nothing was listening.

Recovery should have been one exchange. Instead every route was wrong for the situation:

| Route | Why it's wrong here |
|---|---|
| `request` | Pings a human for an approval that isn't needed |
| `refresh` | Slept a full interval before its first exchange — 45 minutes credentialless |
| Actual escape used | `CREDENTIAL_BROKER_REFRESH_INTERVAL=5`, kill that loop, then hand-roll `refresh_start` with `nohup` + `echo $!` so the pidfile matches |

## Three changes

**`renew`** — mints one token from an existing grant and exits. Needs the broker URL but *not* the request key, since `/exchange` authenticates with the session token from the grant file.

**`refresh --background`** — starts the tracked loop from a public subcommand, instead of reimplementing an internal one by hand. Recovery is now one line:

```sh
gcp-credentials refresh --background
```

**`refresh` exchanges before entering its rhythm.** The old order was written for the steady state — a token just installed, the next due in an interval — and was exactly wrong for the case that needs the loop restarted.

## The trade in that last one

It costs a redundant mint when `request` starts the loop moments after its own exchange: a superseded 1-hour token and a duplicate audit-log line.

I took that over a freshness heuristic deliberately. Checking "is the token still fresh" means either clock arithmetic against a stored expiry or `stat` (which differs between macOS and Linux), and it buys nothing except avoiding one mint. The unconditional version has no branches to get wrong and buys an invariant worth having: **if refresh is running, a valid token exists.**

## Skill doc

Gains an *After a container restart or a resumed session* section, placed **before** *Grant expired* — the two look identical from a failing gcloud call, and only one of them should wake a human. It says explicitly not to run `request` for this.

## Checks

`shellcheck` clean, `sh -n` clean, `markdownlint-cli2` clean. Both new paths smoke-tested against an empty `CREDENTIAL_BROKER_HOME`: each exits 2 with the "no grant on this machine" message rather than reaching the network.

Branched from `main`. Touches `home/bin/gcp-credentials` like #151 and #156, but in different functions — merges in any order.

Found during gcp-org-management#269. Diagnosis credit to the sandbox session that traced it: container PID 569→510 across the gap, loop PID 3729 gone, pidfile still holding the dead one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t76AgXyrrP9BvKPN9efdi