### PR TITLE
Add cloud/bootstrap.sh, and lint it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           globs: "**/*.md"
 
   shellcheck:
-    name: ShellCheck (home/bin/)
+    name: ShellCheck (home/bin/, cloud/)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
@@ -36,6 +36,12 @@ jobs:
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
         with:
           scandir: './home/bin'
+      # cloud/ is fetched over the network and piped to a shell in every
+      # sandbox, so it is the code most in need of linting, not the least.
+      - name: Run ShellCheck (cloud/)
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
+        with:
+          scandir: './cloud'
 
   actionlint:
     name: Action Lint

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -57,6 +57,17 @@ head -1 "$TMP/gcp-credentials" | grep -q '^#!' ||
 install -m 0755 "$TMP/gcp-credentials" "$BIN_DIR/gcp-credentials"
 log "helper  -> $BIN_DIR/gcp-credentials"
 
+# The skill still spells its invocations ~/.claude/bin/gcp-credentials, because
+# that is where chezmoi puts the helper on a laptop. Nothing here creates that
+# path, so an agent following the documented command would hit "no such file"
+# next to a perfectly good helper on PATH — or worse, find a stale vendored copy
+# there and run that instead. Symlink until the skill stops naming a path at
+# all, which is the real fix and is the corollary in ADR-0016 principle 3:
+# delivery assumptions do not belong in portable text.
+mkdir -p "$HOME/.claude/bin"
+ln -sf "$BIN_DIR/gcp-credentials" "$HOME/.claude/bin/gcp-credentials"
+log "compat  -> $HOME/.claude/bin/gcp-credentials -> $BIN_DIR/gcp-credentials"
+
 # --- the skill, in both shapes -----------------------------------------------
 #
 # Placed under the container's own ~/.claude. Whether Claude Code reads a

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# bootstrap.sh — install this repo's agent toolkit into a cloud sandbox.
+#
+# The one line a Claude Code cloud environment's setup script holds, so that
+# everything of substance stays here, versioned, instead of being pasted into a
+# vendor configuration field (ADR-0016, principle 5):
+#
+#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF>
+#
+# Pass the same <REF> twice on purpose: the first fetches this script, the
+# second is what it fetches everything else from, so a run cannot straddle two
+# versions. Pin <REF> to a tag or commit in anything durable — a branch means
+# any compromise of this repo reaches every sandbox that starts afterwards.
+#
+# This script fails loudly: a half-installed toolkit is worse than none, and the
+# caller is better placed to decide tolerance. A cloud setup script, which fails
+# the whole session on a non-zero exit, should append `|| true`.
+#
+# It installs no credentials and reads none. What it places is public content
+# from a public repo.
+
+set -eu
+
+REF="${1:-main}"
+RAW="https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/${REF}"
+
+log() { echo "[bootstrap] $*"; }
+die() { echo "[bootstrap] error: $*" >&2; exit 1; }
+
+command -v curl > /dev/null 2>&1 || die "curl is required"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+log "installing from ${REF}"
+
+# --- the helper --------------------------------------------------------------
+#
+# /usr/local/bin when writable, which is the case in a sandbox running as root,
+# so the helper is on PATH for every shell without touching a profile. Falling
+# back to ~/.local/bin keeps this usable unprivileged, where PATH may need help.
+
+if [ -w /usr/local/bin ] 2> /dev/null; then
+    BIN_DIR=/usr/local/bin
+else
+    BIN_DIR="$HOME/.local/bin"
+    mkdir -p "$BIN_DIR"
+fi
+
+curl -sSfL "$RAW/home/bin/gcp-credentials" -o "$TMP/gcp-credentials" ||
+    die "could not fetch the helper from $REF"
+# Refuse an error page rendered as a script. A 404 from a bad ref is HTML, and
+# `sh` would run it and report something baffling.
+head -1 "$TMP/gcp-credentials" | grep -q '^#!' ||
+    die "fetched helper is not a script — check that $REF exists"
+
+install -m 0755 "$TMP/gcp-credentials" "$BIN_DIR/gcp-credentials"
+log "helper  -> $BIN_DIR/gcp-credentials"
+
+# --- the skill, in both shapes -----------------------------------------------
+#
+# Placed under the container's own ~/.claude. Whether Claude Code reads a
+# ~/.claude it did not create is the open question behind ADR-0016 principle 3:
+# the documentation says user-scope config does not reach cloud sessions, but it
+# means the developer's laptop does not transfer, which is a different claim
+# from a directory that exists in the VM. Both shapes go down so one run answers
+# both — commands/ is the current format, skills/ the direction of ADR-0014.
+#
+# Either way the content is provider-neutral; only the placement knows about
+# Claude. That is the principle being tested, not a shortcut around it.
+
+curl -sSfL "$RAW/home/commands/gcp-credentials.md" -o "$TMP/gcp-credentials.md" ||
+    die "could not fetch the skill from $REF"
+
+mkdir -p "$HOME/.claude/commands"
+cp "$TMP/gcp-credentials.md" "$HOME/.claude/commands/gcp-credentials.md"
+log "command -> $HOME/.claude/commands/gcp-credentials.md"
+
+# SKILL.md wants frontmatter the command format does not carry. The first line
+# of the command file is its description by convention, so lift it — single
+# quoted, with any internal quote doubled, because that description contains a
+# colon and would otherwise be read as a YAML mapping.
+SKILL_DIR="$HOME/.claude/skills/gcp-credentials"
+mkdir -p "$SKILL_DIR"
+DESC=$(head -1 "$TMP/gcp-credentials.md" | sed "s/'/''/g")
+{
+    echo "---"
+    echo "name: gcp-credentials"
+    echo "description: '${DESC}'"
+    echo "---"
+    echo ""
+    tail -n +2 "$TMP/gcp-credentials.md"
+} > "$SKILL_DIR/SKILL.md"
+log "skill   -> $SKILL_DIR/SKILL.md"
+
+# --- report -------------------------------------------------------------------
+#
+# The pinned ref is logged because a cached cloud environment can serve an older
+# bootstrap than the one in main, and nothing else in a session says which
+# vintage it is running.
+
+log "done, from ${REF}"
+log "note: commands and skills are read when Claude Code starts, so a session"
+log "      already running will not see them until it restarts or resumes."


### PR DESCRIPTION
Closes #162. ADR-0016 principle 5 (PR #158) made real.

A cloud environment's setup script had nowhere to defer to, so anything a sandbox needed was either pasted into a vendor configuration field or copied into the consuming repo — and the copy route has already been shown to drift, within a day of being made.

## Shape

```sh
curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF>
```

The ref is passed **twice on purpose** — once to fetch the script, once for the script to fetch everything else from — so a run cannot straddle two versions.

It installs the helper to `/usr/local/bin` when writable (a sandbox running as root, so it's on PATH without touching a profile), falling back to `~/.local/bin`.

## Three decisions worth flagging

**It fails loudly rather than exiting zero.** A half-installed toolkit is worse than none, and the caller knows better than the script whether it can tolerate that — so a cloud setup script, which fails the session on a non-zero exit, appends its own `|| true`.

**The 404-is-HTML check.** A mistyped ref returns a web page, not an error; without a shebang test the installer would write that to a file named after a shell script and leave the failure to surface somewhere unrelated. Verified: a bad ref exits 1 with a clear message.

**CI now shellchecks `cloud/` too.** Code fetched over the network and piped to a shell in every sandbox is the code *most* in need of linting, not the least — and it would otherwise have shipped unchecked, since the existing job scans only `home/bin`.

## It also runs the ADR-0016 experiment

The script writes the skill in **both** shapes — `~/.claude/commands/gcp-credentials.md` and `~/.claude/skills/gcp-credentials/SKILL.md` (frontmatter synthesised from the command file's description line, single-quoted because that description contains a colon).

That answers the question blocking ADR-0016 ratification: does Claude Code read a `~/.claude` that exists in the container but that it didn't create? One run, both shapes, and a discriminating result either way.

## Checks

`shellcheck` clean, `sh -n` clean, `actionlint` clean. Run end-to-end against `main` into a throwaway `HOME`: all three files land, the helper executes, and the generated frontmatter parses with both keys present and the description correctly quoted. Bad-ref path exits 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t76AgXyrrP9BvKPN9efdi