### PR TITLE
Split request from wait, so the phrase can be relayed before it is needed

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -6,8 +6,9 @@
 # approval into a *grant* of 1-7 days. Inside that window this helper silently
 # re-mints 1-hour GCP access tokens with no further approvals.
 #
-#   request  ask for credentials, show the verification phrase, wait for the
-#            decision, install the token, and start background refresh
+#   request  ask for credentials and show the verification phrase, then return
+#            so the phrase can be relayed before anyone answers the card
+#   wait     collect the decision on that request and install the token
 #   refresh  the refresh loop itself (started automatically by `request`;
 #            runnable in the foreground for debugging)
 #   status   report grant, refresh and gcloud state — never any secret
@@ -55,6 +56,10 @@ CB_HOME="${CREDENTIAL_BROKER_HOME:-$HOME/.config/claude/credential-broker}"
 KEY_FILE="$CB_HOME/request-key"
 URL_FILE="$CB_HOME/url"
 GRANT_FILE="$CB_HOME/grant.json"
+# An outstanding request, between `request` and `wait`. Holds no secret: a
+# request id, the phrase the human is matching, and the install options `wait`
+# needs to finish the job the same way `request --wait` would have.
+PENDING_FILE="$CB_HOME/pending.json"
 TOKEN_FILE="$CB_HOME/access_token"
 PID_FILE="$CB_HOME/refresh.pid"
 LOG_FILE="$CB_HOME/refresh.log"
@@ -88,7 +93,8 @@ die() {
 usage() {
     cat >&2 <<'USAGE'
 usage:
-  gcp-credentials request [options]   ask for credentials and install them
+  gcp-credentials request [options]   ask, print the phrase, and return
+  gcp-credentials wait                wait for the decision and install
   gcp-credentials renew               mint one token from an existing grant
   gcp-credentials refresh [--background]
                                       run the refresh loop (default: foreground)
@@ -106,6 +112,9 @@ request options:
   --ttl DURATION   grant length, 24h-168h (default: 24h)
   --tier NAME      role set (default: sandbox)
   --timeout SECS   how long to wait for a decision (default: 900)
+  --wait           block until the decision instead of returning after the
+                   phrase. Interactive terminals only: an agent that blocks
+                   here cannot relay the phrase, which is the point of it
   --no-refresh     install one token and do not start background refresh
   --no-gcloud      write the token file but do not touch any gcloud config
   --no-activate    configure the agent-broker gcloud config without activating
@@ -365,6 +374,7 @@ cmd_request() {
     OPT_REFRESH=1
     OPT_GCLOUD=1
     OPT_ACTIVATE=1
+    OPT_WAIT=0
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -377,6 +387,7 @@ cmd_request() {
             --no-refresh) OPT_REFRESH=0; shift ;;
             --no-gcloud) OPT_GCLOUD=0; shift ;;
             --no-activate) OPT_ACTIVATE=0; shift ;;
+            --wait) OPT_WAIT=1; shift ;;
             -h | --help) usage ;;
             *) echo "$PROG: unknown option: $1" >&2; usage ;;
         esac
@@ -459,6 +470,55 @@ cmd_request() {
     [ -n "$req_expires" ] && echo "  card expires at $req_expires (no answer means deny)"
     echo ""
 
+    # Record the outstanding request, then hand back control.
+    #
+    # This is the whole point of the split. The phrase binds an approval to
+    # *this* session, and that only works if the human can read it at the
+    # moment they answer the card. Blocking here put the phrase in the stdout
+    # of a still-running command, where a terminal streams it live and a web or
+    # mobile session does not — so the property held on the surface this was
+    # written on and nowhere else. An agent cannot relay what it is blocked
+    # inside. Returning gives it a turn boundary to speak on.
+    jq -n --arg rid "$req_id" --arg phrase "$phrase" --arg exp "$req_expires" \
+        --arg timeout "$OPT_TIMEOUT" --arg refresh "$OPT_REFRESH" \
+        --arg gcloud "$OPT_GCLOUD" --arg activate "$OPT_ACTIVATE" \
+        '{request_id: $rid, phrase: $phrase, card_expires_at: $exp,
+          timeout: ($timeout | tonumber), refresh: ($refresh | tonumber),
+          gcloud: ($gcloud | tonumber), activate: ($activate | tonumber)}' > "$PENDING_FILE"
+    chmod 600 "$PENDING_FILE"
+
+    if [ "$OPT_WAIT" -eq 0 ]; then
+        echo "  Relay the phrase above, then run '$PROG wait' to collect the decision."
+        return 0
+    fi
+
+    poll_and_install
+}
+
+# poll_and_install waits on the outstanding request and, on approval, installs.
+#
+# Shared by `request --wait` and `wait` so the two cannot drift: whichever way a
+# session got here, what happens after approval is the same code.
+#
+# Reads its parameters from the pending file rather than taking arguments,
+# because `wait` runs in a different process from `request` and the options
+# chosen at request time still have to apply.
+poll_and_install() {
+    [ -f "$PENDING_FILE" ] || die 2 "no outstanding request — run '$PROG request' first"
+
+    req_id=$(jq -r '.request_id // ""' < "$PENDING_FILE")
+    phrase=$(jq -r '.phrase // ""' < "$PENDING_FILE")
+    OPT_TIMEOUT=$(jq -r '.timeout // 900' < "$PENDING_FILE")
+    OPT_REFRESH=$(jq -r '.refresh // 1' < "$PENDING_FILE")
+    OPT_GCLOUD=$(jq -r '.gcloud // 1' < "$PENDING_FILE")
+    OPT_ACTIVATE=$(jq -r '.activate // 1' < "$PENDING_FILE")
+    [ -n "$req_id" ] || die 1 "pending file has no request id"
+
+    [ -n "$TMPDIR_CB" ] || TMPDIR_CB=$(mktemp -d)
+    hdr_cfg="$TMPDIR_CB/headers.conf"
+    [ -n "$CB_KEY" ] || load_key
+    [ -n "$BROKER_URL" ] || load_url
+
     write_header_cfg "$hdr_cfg"
     poll_resp="$TMPDIR_CB/poll.json"
     elapsed=0
@@ -483,17 +543,23 @@ cmd_request() {
                 ;;
         esac
 
+        # Every terminal state clears the pending file. A decided request that
+        # lingered would leave `status` reporting a phantom approval to wait on,
+        # and the next `wait` polling a request the broker has finished with.
         case "$state" in
             approved) break ;;
-            denied) die 3 "the request was DENIED. No credentials were issued; do not retry without asking the human first." ;;
-            revoked) die 3 "the grant was revoked before it could be used" ;;
-            expired) die 4 "nobody answered in time, which the broker treats as a deny. No credentials were issued." ;;
+            denied) rm -f "$PENDING_FILE"; die 3 "the request was DENIED. No credentials were issued; do not retry without asking the human first." ;;
+            revoked) rm -f "$PENDING_FILE"; die 3 "the grant was revoked before it could be used" ;;
+            expired) rm -f "$PENDING_FILE"; die 4 "nobody answered in time, which the broker treats as a deny. No credentials were issued." ;;
             pending | "") ;;
             *) die 1 "broker reported an unexpected state: $state" ;;
         esac
 
         if [ "$elapsed" -ge "$OPT_TIMEOUT" ]; then
-            die 4 "gave up waiting after ${OPT_TIMEOUT}s with no decision. Treat this as a deny."
+            # The card outlives this timeout, so the request is left in place: a
+            # human answering late should still be collectable with another
+            # `wait`, rather than the session having thrown the id away.
+            die 4 "gave up waiting after ${OPT_TIMEOUT}s with no decision. Treat this as a deny; '$PROG wait' resumes if the card is still live."
         fi
         sleep "$POLL_INTERVAL"
         elapsed=$((elapsed + POLL_INTERVAL))
@@ -519,6 +585,11 @@ cmd_request() {
           grant_expires_at: .grant_expires_at, session_token: .session_token,
           previous_gcloud_config: $prev}' < "$poll_resp" > "$GRANT_FILE"
     chmod 600 "$GRANT_FILE"
+    # The grant file now carries everything the pending file did, so the
+    # outstanding request is discharged. Cleared after the write, never before:
+    # a crash between the two would otherwise lose the request id with the
+    # approval already spent.
+    rm -f "$PENDING_FILE"
     rm -f "$poll_resp"
 
     # Exchange before touching gcloud: pointing a configuration at a token file
@@ -544,6 +615,19 @@ cmd_request() {
         refresh_start
         echo "  refresh   : running in the background until the grant expires (log: $LOG_FILE)"
     fi
+}
+
+# wait collects the decision on an outstanding request and installs on approval.
+#
+# The half of `request` that used to be welded to it. Separated so the phrase
+# can be spoken in the session before a human is asked to match it — which is
+# the only thing that makes the phrase a session binding rather than decoration.
+cmd_wait() {
+    [ -f "$PENDING_FILE" ] || die 2 "no outstanding request — run '$PROG request' first"
+    load_key
+    load_url
+    TMPDIR_CB=$(mktemp -d)
+    poll_and_install
 }
 
 # renew mints one token from the existing grant and exits.
@@ -655,6 +739,13 @@ cmd_status() {
         echo "identity: $st_sa"
     fi
 
+    if [ -f "$PENDING_FILE" ]; then
+        st_phrase=$(jq -r '.phrase // "?"' < "$PENDING_FILE")
+        st_card=$(jq -r '.card_expires_at // ""' < "$PENDING_FILE")
+        echo "pending : a request is awaiting a decision, phrase '$st_phrase'"
+        [ -n "$st_card" ] && echo "          card expires $st_card; '$PROG wait' collects it"
+    fi
+
     if [ -f "$TOKEN_FILE" ]; then
         echo "token   : present at $TOKEN_FILE"
     else
@@ -725,6 +816,7 @@ shift
 
 case "$subcommand" in
     request) cmd_request "$@" ;;
+    wait) cmd_wait ;;
     renew) cmd_renew ;;
     refresh) cmd_refresh "$@" ;;
     status) cmd_status ;;

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -58,14 +58,34 @@ The command prints a block like this:
 ==================================================================
 ```
 
-Relay the phrase to the user **verbatim, in your own reply, as the first thing
-you say** — do not leave it buried in tool output. Say what they are approving:
+`request` returns as soon as it has the phrase. It does **not** wait for the
+decision, and that is deliberate: relay the phrase in your own reply, then
+collect the answer separately.
+
+Relay it **verbatim, as the first thing you say** — not buried in tool output.
+Say what they are approving:
 
 > Requesting GCP credentials for `pmgledhill-apix-sbx` (sandbox tier, 24h).
 > **Verification phrase: `mint-copper-falcon`** — approve the Discord card only
 > if it shows exactly that.
 
-Then let the command keep polling. It exits by itself on a decision.
+### Then collect the decision
+
+```sh
+~/.claude/bin/gcp-credentials wait
+```
+
+This blocks until the human answers, then installs the token and starts refresh.
+
+**Never collapse these two steps into one.** `request --wait` exists for a human
+at an interactive terminal and is wrong for you: a blocked command cannot
+produce a reply, so the phrase would sit unread in the output of something still
+running while the human is asked to match it against nothing. The phrase is only
+a session binding if it reaches the person *before* they answer the card. Run
+them as two turns, with your message carrying the phrase in between.
+
+If the session scrolls or you lose track, `status` reports the outstanding
+request and its phrase.
 
 ## Reading the outcome
 
@@ -120,6 +140,36 @@ feed it from the file in the same command and never echo it:
 ```sh
 GOOGLE_OAUTH_ACCESS_TOKEN="$(cat ~/.config/claude/credential-broker/access_token)" terraform plan
 ```
+
+## An authentication failure? Run `renew` first, then think
+
+**Before diagnosing any GCP authentication error, run:**
+
+```sh
+~/.claude/bin/gcp-credentials renew
+```
+
+If it succeeds, the problem is solved and there was nothing to diagnose. It
+costs one HTTP call, needs no human, and is a no-op you can afford to be wrong
+about.
+
+The reason is that the background refresh loop is **not reliable in a sandbox**.
+Detached processes are reaped there — observed twice in one session, once across
+an idle gap and once inside a twenty-minute window of active work. When that
+happens the grant stays valid for days while the token quietly ages out, so the
+first symptom is an authentication error that looks like a broker fault, an IAM
+problem, or a revoked grant, and is none of them.
+
+Applies to `Request had invalid authentication credentials`, a bare 401 or 403
+from a Google API, and `Unable to read file [...access_token]`. The last one
+means the token was *removed*, not rejected — a grant that ended, or a `release`
+— and `renew` will tell you which by failing with an exit code that says so.
+
+Escalate only if `renew` itself fails:
+
+- exit 4 — the grant is genuinely over; request a new one
+- exit 2 — no grant on this machine at all; request one
+- exit 1 — the broker is unreachable, which is a real fault worth reporting
 
 ## After a container restart or a resumed session
 


### PR DESCRIPTION
Closes #152. Also lands the cheap mitigation from #164.

The verification phrase is the whole session binding: a human approves only if the card matches what's on screen, so a request from a prompt-injected session elsewhere produces a *different* phrase and fails the match. **That property never worked outside a terminal.**

`request` printed the phrase and then blocked polling in the same invocation, for up to fifteen minutes. The phrase therefore existed only in the stdout of a still-running command — which a terminal streams live and a web or mobile session does not. Meanwhile the skill instructed the agent to relay it "as the first thing you say", and an agent blocked inside the call has nothing to say it in. The instruction was unfollowable.

## The split

```sh
gcp-credentials request --purpose "..."   # returns with the phrase
#   → agent speaks the phrase — a real turn boundary
gcp-credentials wait                      # blocks, installs, starts refresh
```

`poll_and_install` is shared by `wait` and `request --wait` so the two can't drift — whichever way a session arrives, what happens after approval is the same code. State passes through a `0600` pending file holding the request id, the phrase, and the install options chosen at request time, since `wait` runs in a different process.

`--wait` keeps the old behaviour for a human at an interactive terminal, and the skill documents it as **wrong for an agent**.

## Two judgement calls worth reviewing

**Terminal states clear the pending file; a timeout deliberately doesn't.** Denied, revoked and expired all remove it, or `status` would report a phantom approval to wait on forever. But `--timeout` is the *client's* patience, not the card's — the card outlives it — so a human answering late should still be collectable with another `wait` rather than having the request id thrown away.

**The pending file is cleared after the grant file is written, never before.** A crash between the two would otherwise lose the request id with the approval already spent.

## #164's mitigation

The skill now says: on any authentication failure, run `renew` **before diagnosing anything**. One HTTP call, wakes nobody, and a no-op worth being wrong about — against a failure that otherwise reads as a broker fault, an IAM problem, or a revoked grant, and is none of them. It names the three exit codes that mean "genuinely escalate".

This doesn't close #164 — the daemon-model question stands — but it's the piece that would have turned this session's two loop deaths into one retried command.

## Checks

`shellcheck` clean, `sh -n` clean, `markdownlint-cli2` clean. `wait`, `renew` and `refresh --background` all exit 2 with the right message against an empty `CREDENTIAL_BROKER_HOME`; `status` renders a pending request and its phrase from a fabricated state file.

Not exercised against a live broker — that's the fresh-sandbox run, which this unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t76AgXyrrP9BvKPN9efdi