### PR TITLE
Make ~/.agents/skills canonical, with the Claude path as a symlink

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -1,0 +1,137 @@
+# Cloud sandbox environments
+
+Everything a vendor's cloud sandbox needs to gain this repo's capabilities,
+without the repo you are working on carrying any of it.
+
+`bootstrap.sh` is the whole mechanism: an environment's setup script fetches it
+by ref and runs it, and it installs the helper and skill into the container.
+See [ADR-0016](../adrs/0016-capability-delivery-principles.md) for why the
+substance lives here rather than in the setup script itself.
+
+## Claude Code
+
+Set these three things once per environment, at
+[claude.ai/code](https://claude.ai/code) → the environment's settings.
+
+### 1. Setup script
+
+```bash
+#!/bin/bash
+# Rev: 1
+curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/main/cloud/bootstrap.sh \
+  | sh -s -- main --with-gcloud || true
+exit 0
+```
+
+Drop `--with-gcloud` for an environment that does no Google Cloud work; it
+saves a ~96 MB download and declares what kind of environment this is.
+
+**The `Rev:` comment is load-bearing.** The environment snapshots the setup
+script's result and re-runs it only when the script text changes, the allowed
+domains change, or roughly seven days pass. Because `main` never changes *as a
+string*, pushing to `main` does not reach new sessions — they keep restoring the
+snapshot built the first time. Bump the number to force a rebuild.
+
+Pin a tag instead of `main` for anything beyond development:
+
+```bash
+  | sh -s -- v0.1.0 --with-gcloud || true
+```
+
+A mutable ref means any compromise of this repo reaches every sandbox that
+starts afterwards. A tag also names, in the session's own log, which version it
+is running.
+
+`|| true` belongs to the caller, not the script: a non-zero exit fails the whole
+session, while `bootstrap.sh` deliberately fails loudly so that a partial
+install is visible rather than silent.
+
+### 2. Allowed domains
+
+Select **Custom**, tick *also include default list*, and add:
+
+```text
+credential-broker-<hash>-nw.a.run.app
+dl.google.com
+```
+
+Obtain the broker hostname with `gcloud run services describe credential-broker`
+against the project it is deployed to — named, with the region, in the
+`sandbox-gcp-credentials` runbook in `gcp-org-management`. It is deliberately
+not written here: this repo is public, and while the URL is not a credential,
+publishing it hands a stranger the rate limit.
+
+Both are needed because neither is on the Trusted default list, and each fails
+in a way that reads as something else:
+
+| Missing | Symptom | Actually |
+| ------- | ------- | -------- |
+| broker host | `could not resolve host` | the environment was never allowed to call it |
+| `dl.google.com` | gcloud install fails | `cloud.google.com` and `gcloud.google.com` are on the default list and neither serves the tarball |
+
+`raw.githubusercontent.com` is already on the default list, so fetching the
+bootstrap itself needs nothing added.
+
+### 3. Environment variables
+
+| Variable | Value |
+| -------- | ----- |
+| `CREDENTIAL_BROKER_URL` | the broker hostname above, with scheme |
+| `CREDENTIAL_BROKER_REQUEST_KEY` | the **`cloud`** key, from the password manager |
+
+Use the `cloud` key, not the `local` one. The approval card names which key was
+used, and "key cloud while I am at my laptop" is information worth keeping
+truthful.
+
+Cloud environments have **no secrets store** — anyone who can use the
+environment can read its variables, and the documentation says not to put
+credentials there. The request key is a deliberate exception: it only gates
+*opening* a request, the human approval is the real control, and rotation is
+documented. Treat that as a knowing decision rather than a default.
+
+## Codex
+
+**Not yet established.** The mechanism should port — cloud sessions on both
+Claude and Codex ignore user-level config from your machine and both run an
+environment setup script, and `bootstrap.sh` writes its canonical skill to
+`~/.agents/skills`, which Codex scans natively.
+
+What a first run needs to answer:
+
+1. Does the sandbox run a setup script, and in what shell?
+2. Can it reach `raw.githubusercontent.com`, or is there an allowlist to extend?
+3. Is the skill discovered from `~/.agents/skills`?
+4. Does the helper work unchanged? It is POSIX `sh` plus `curl` and `jq`, with
+   nothing Claude-specific in it.
+
+Fill this section in from that run rather than from the documentation.
+
+## Local machines
+
+Not this. `~/.claude` is chezmoi-managed from `home/`; the bootstrap is for
+containers that start empty.
+
+## What lands where
+
+| Path | What |
+| ---- | ---- |
+| `~/.agents/skills/gcp-credentials/SKILL.md` | the skill, canonical, vendor-neutral |
+| `~/.claude/skills/gcp-credentials` | symlink to the above, for Claude Code |
+| `/usr/local/bin/gcp-credentials` | the helper (or `~/.local/bin` unprivileged) |
+| `~/.claude/bin/gcp-credentials` | symlink, because the skill still names that path |
+| `/usr/local/bin/gcloud` | wrapper: prefers the broker token, renews it when stale |
+
+## Updating a running session
+
+Re-run the bootstrap directly; no environment edit, no restart:
+
+```sh
+curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/main/cloud/bootstrap.sh \
+  | sh -s -- main --with-gcloud
+```
+
+Keep `--with-gcloud` even where gcloud exists: it skips the download but is also
+the branch that installs the gcloud wrapper.
+
+Skills are read when the agent starts, so a newly installed skill appears after
+the session restarts or resumes. The helper is usable immediately.

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -116,30 +116,34 @@ mkdir -p "$HOME/.claude/bin"
 ln -sf "$BIN_DIR/gcp-credentials" "$HOME/.claude/bin/gcp-credentials"
 log "compat  -> $HOME/.claude/bin/gcp-credentials -> $BIN_DIR/gcp-credentials"
 
-# --- the skill, in both shapes -----------------------------------------------
+# --- the skill: one file, vendor paths as adapters ----------------------------
 #
-# Placed under the container's own ~/.claude. Whether Claude Code reads a
-# ~/.claude it did not create is the open question behind ADR-0016 principle 3:
-# the documentation says user-scope config does not reach cloud sessions, but it
-# means the developer's laptop does not transfer, which is a different claim
-# from a directory that exists in the VM. Both shapes go down so one run answers
-# both — commands/ is the current format, skills/ the direction of ADR-0014.
+# The canonical copy goes to ~/.agents/skills, the vendor-neutral Agent Skills
+# location that Codex, OpenCode and Gemini CLI scan natively. Claude Code does
+# not read it — its documentation names only ~/.claude/skills and
+# .claude/skills — so ~/.claude/skills gets a symlink pointing at the real
+# thing.
 #
-# Either way the content is provider-neutral; only the placement knows about
-# Claude. That is the principle being tested, not a shortcut around it.
+# That direction is deliberate. Copying into each vendor's directory would work
+# and would reintroduce the one failure this repo keeps meeting: two copies of
+# the same content, diverging quietly. A symlink cannot drift, and a fourth
+# provider costs another link rather than another copy. It is also ADR-0016
+# principle 3 in the filesystem — the portable path holds the content, the
+# vendor path is a thin adapter — rather than a paragraph asserting it.
+#
+# That a container-created ~/.claude/skills is read at all is no longer an open
+# question: a sandbox session on 2026-08-13 discovered this skill there and
+# invoked it unprompted. What a symlinked skill directory does is the part still
+# worth watching; if Claude stops listing the skill, that is why.
 
 curl -sSfL "$RAW/home/commands/gcp-credentials.md" -o "$TMP/gcp-credentials.md" ||
     die "could not fetch the skill from $REF"
-
-mkdir -p "$HOME/.claude/commands"
-cp "$TMP/gcp-credentials.md" "$HOME/.claude/commands/gcp-credentials.md"
-log "command -> $HOME/.claude/commands/gcp-credentials.md"
 
 # SKILL.md wants frontmatter the command format does not carry. The first line
 # of the command file is its description by convention, so lift it — single
 # quoted, with any internal quote doubled, because that description contains a
 # colon and would otherwise be read as a YAML mapping.
-SKILL_DIR="$HOME/.claude/skills/gcp-credentials"
+SKILL_DIR="$HOME/.agents/skills/gcp-credentials"
 mkdir -p "$SKILL_DIR"
 DESC=$(head -1 "$TMP/gcp-credentials.md" | sed "s/'/''/g")
 {
@@ -150,7 +154,21 @@ DESC=$(head -1 "$TMP/gcp-credentials.md" | sed "s/'/''/g")
     echo ""
     tail -n +2 "$TMP/gcp-credentials.md"
 } > "$SKILL_DIR/SKILL.md"
-log "skill   -> $SKILL_DIR/SKILL.md"
+log "skill   -> $SKILL_DIR/SKILL.md (canonical)"
+
+# An earlier run left a real directory here, and `ln -s` onto one links *inside*
+# it rather than replacing it. Remove first; the path is fixed and ours.
+rm -rf "$HOME/.claude/skills/gcp-credentials"
+mkdir -p "$HOME/.claude/skills"
+ln -sfn "$SKILL_DIR" "$HOME/.claude/skills/gcp-credentials"
+log "adapter -> $HOME/.claude/skills/gcp-credentials"
+
+# Claude merged custom commands into skills: a commands/*.md and a
+# skills/*/SKILL.md both register the same /name and behave the same way. So an
+# earlier run's commands copy is now a second, Claude-only registration of a
+# skill that already works from the neutral path. Remove it rather than leave
+# two sources for one command.
+rm -f "$HOME/.claude/commands/gcp-credentials.md"
 
 # --- report -------------------------------------------------------------------
 #


### PR DESCRIPTION
Closes #170.

**Renaming wasn't on the table.** Claude Code's skills documentation names only `~/.claude/skills` and `.claude/skills`, and doesn't mention `.agents` anywhere — while Codex, OpenCode and Gemini CLI scan `~/.agents/skills`. Move to the neutral path alone and Claude stops seeing the skill entirely.

## The layout

```
~/.agents/skills/gcp-credentials/SKILL.md      ← the file
~/.claude/skills/gcp-credentials -> ─────────┘  ← adapter
```

Copying into each vendor's directory would also work, and would reintroduce the one failure this repo keeps meeting: two copies of the same content, diverging quietly. **A symlink cannot drift**, and a fourth provider costs another link rather than another copy.

It's also ADR-0016 principle 3 in the filesystem — portable path holds the content, vendor path is a thin adapter — rather than a paragraph asserting it. And it makes the Codex experiment runnable, which is the remaining gate on #158.

## `~/.claude/commands/` is dropped

The docs settled this:

> **Custom commands have been merged into skills.** A file at `.claude/commands/deploy.md` and a skill at `.claude/skills/deploy/SKILL.md` both create `/deploy` and work the same way.

So the commands copy was one skill registered twice, in two formats, from one source. Defensible while the skills path was unproven; not now that a sandbox session has discovered the skill there and invoked it unprompted.

## Migration

An earlier run leaves a *real directory* where the symlink goes, and `ln -s` onto a directory links **inside** it rather than replacing it — so it removes first. Exercised both ways:

- **Fresh install** — canonical file written, symlink resolves, `SKILL.md` readable through it
- **Upgrade from a pre-#170 install** with stale content in both old locations — stale skill directory replaced by a symlink (`type: l`, not nested), stale command file removed, no stale content anywhere

## Still unverified

**Whether Claude Code follows a symlinked skill directory.** Very likely — it's a filesystem read — but it fails *silently* if not: the skill just stops being listed. The next sandbox answers it in the first minute, and the fallback is a real copy in both places, which is what main does today.

`shellcheck` clean, `sh -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t76AgXyrrP9BvKPN9efdi