### PR TITLE
ADR-0016: the symlinked skill layout is confirmed

### DIFF
--- a/adrs/0016-capability-delivery-principles.md
+++ b/adrs/0016-capability-delivery-principles.md
@@ -248,14 +248,23 @@ are all `POST`. Setup-script `export`s do not survive into the agent
 phase either, so variables belong in the environment's own settings. All
 of it is recorded in [`cloud/README.md`](../cloud/README.md).
 
-### Still unverified
+### The symlinked layout, also confirmed
 
-Whether Claude Code follows a **symlinked** skill directory. The Claude
-result above was obtained with a real directory; the canonical layout now
-places the file at `~/.agents/skills` with `~/.claude/skills` pointing at
-it. If Claude stops listing the skill, that is why, and the fallback is a
-real copy in both locations. This does not affect the principles: it is
-an implementation detail of one delivery mechanism.
+The first Claude result was obtained with a real directory, which left
+open whether Claude Code would follow a **symlink** — the layout the
+canonical form depends on, with the file at `~/.agents/skills` and
+`~/.claude/skills` pointing at it.
+
+It does. A sandbox on 2026-08-13 reported `~/.agents/skills/gcp-credentials`
+as a real directory and `~/.claude/skills/gcp-credentials` as a symlink to
+it, with the skill listed and invocable as `/gcp-credentials`. Both paths
+were created when the container came up, so this was the current bootstrap
+and not a cached older one.
+
+That matters beyond the implementation detail: one file can serve every
+provider that scans a user-level skills directory, with each vendor path
+a link rather than a copy. Adding a provider costs a symlink. Nothing can
+drift, because there is only ever one file.
 
 ## Alternatives considered
 


### PR DESCRIPTION
Closes #174.

ADR-0016 was accepted carrying one caveat: whether Claude Code follows a **symlinked** skill directory. The Claude evidence at the time came from a real directory, while #171's canonical layout puts the file at `~/.agents/skills` and makes `~/.claude/skills` a link to it.

A sandbox settled it on 2026-08-13:

```
/root/.agents/skills/gcp-credentials    real directory
/root/.claude/skills/gcp-credentials    symlink -> the above
```

…with the skill listed and invocable as `/gcp-credentials`. **Both created when the container came up**, which is the part that makes it evidence — an environment snapshot can otherwise serve a pre-#171 install and appear to prove something it hasn't.

I recorded the consequence alongside the fact, because it's larger than the implementation detail: **one file can serve every provider that scans a user-level skills directory**, each vendor path being a link rather than a copy. Adding a provider costs a symlink, and nothing can drift because there is only ever one file.

A resolved caveat left standing in an accepted ADR is worse than never having written it — the next reader treats it as still open.

`markdownlint-cli2` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t76AgXyrrP9BvKPN9efdi