### PR TITLE
Handle the broker's warming and failed poll states

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -536,6 +536,7 @@ poll_and_install() {
     elapsed=0
     since_progress=0
     transient=0
+    warming=0
 
     while :; do
         code=$(http_get_authed "/requests/$req_id" "$poll_resp" "$hdr_cfg") || code=000
@@ -560,9 +561,29 @@ poll_and_install() {
         # and the next `wait` polling a request the broker has finished with.
         case "$state" in
             approved) break ;;
+            warming)
+                # Approved already: what is outstanding is GCP propagation of the
+                # agent identity, not the human. Worth saying out loud, because
+                # the two waits need different things from whoever is watching --
+                # one may want a nudge in Discord, the other only patience.
+                if [ "$warming" -eq 0 ]; then
+                    warming=1
+                    since_progress=0
+                    echo "  approved — waiting for the agent identity to become usable (GCP propagation, usually under a minute)"
+                fi
+                ;;
             denied) rm -f "$PENDING_FILE"; die 3 "the request was DENIED. No credentials were issued; do not retry without asking the human first." ;;
             revoked) rm -f "$PENDING_FILE"; die 3 "the grant was revoked before it could be used" ;;
             expired) rm -f "$PENDING_FILE"; die 4 "nobody answered in time, which the broker treats as a deny. No credentials were issued." ;;
+            failed)
+                # Distinct from a deny, and deliberately not exit 3: nobody
+                # refused. The approval was given and then the identity never
+                # became usable, so asking again is legitimate rather than
+                # something to check with the human first.
+                rm -f "$PENDING_FILE"
+                cb_reason=$(jq -r '.failure_reason // ""' < "$poll_resp")
+                die 7 "approved, but the agent identity never became usable, so no credentials were issued${cb_reason:+ ($cb_reason)}. Nobody refused — this is a fault, not a denial. Requesting again is legitimate; if it recurs, the sandbox's agent identity needs looking at."
+                ;;
             pending | "") ;;
             *) die 1 "broker reported an unexpected state: $state" ;;
         esac
@@ -577,7 +598,14 @@ poll_and_install() {
         elapsed=$((elapsed + POLL_INTERVAL))
         since_progress=$((since_progress + POLL_INTERVAL))
         if [ "$since_progress" -ge "$PROGRESS_EVERY" ]; then
-            echo "  ... still waiting for approval (${elapsed}s elapsed, phrase $phrase)"
+            if [ "$warming" -eq 1 ]; then
+                # No phrase here: it has already served its purpose, and
+                # repeating it past the decision invites a second match against
+                # a card that is no longer open.
+                echo "  ... still waiting for the identity to become usable (${elapsed}s elapsed)"
+            else
+                echo "  ... still waiting for approval (${elapsed}s elapsed, phrase $phrase)"
+            fi
             since_progress=0
         fi
     done

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -87,6 +87,21 @@ them as two turns, with your message carrying the phrase in between.
 If the session scrolls or you lose track, `status` reports the outstanding
 request and its phrase.
 
+### Waiting on a human, then waiting on GCP
+
+`wait` distinguishes two waits, and it is worth relaying which one you are in.
+Before the decision it reports waiting for approval — that is the one a nudge in
+Discord can help with. After approval it may report:
+
+```text
+  approved — waiting for the agent identity to become usable (GCP propagation, usually under a minute)
+```
+
+Nothing is wrong there and nobody needs chasing. The broker refuses to hand over
+a grant it cannot actually mint a token for, so it waits for the identity to
+propagate rather than issuing something that would fail on first use. It
+resolves on its own, without a second approval. Say so if asked, and wait.
+
 ## Reading the outcome
 
 | Exit | Meaning | What to do |
@@ -97,7 +112,12 @@ request and its phrase.
 | 4 | Timed out / expired | Nobody answered, which the broker treats as a deny. Ask the user before retrying. |
 | 5 | Rate limited | Wait. Do not loop. |
 | 6 | Not configured | No request key or no broker URL — see [Setup](#setup-not-per-session). |
+| 7 | Approved, but the identity never became usable | **Not a deny** — nobody refused. Report the reason the helper printed. Requesting again is legitimate; if it recurs, say so, because the sandbox's agent identity needs attention. |
 | 1 | Broker unreachable or mint failed | Report it. Do not proceed as if credentials exist. |
+
+Exit 7 is worth distinguishing from exit 3 in what you tell the user. A deny is a
+decision and asking again without checking is rude; a failure is a fault, and
+retrying is the reasonable response.
 
 Never carry on without credentials after a non-zero exit. Silently falling back
 to whatever identity happens to be lying around is the exact failure the broker


### PR DESCRIPTION
The client slice that unblocks [`gcp-org-management`#301](https://github.com/pmgledhill102/gcp-org-management/pull/301) (the readiness gate). Deliberately minimal — the rest of #177 stays as scoped.

## Why it is needed

#301 makes the broker refuse to hand over a grant it cannot actually mint a token for. It reports `warming` while the agent identity propagates, and `failed` if it never becomes usable. The poll loop ended its state switch with:

```sh
*) die 1 "broker reported an unexpected state: $state" ;;
```

So either new state would have killed the session outright — losing exactly the benefit the gate adds. **This has to land before #301 deploys.**

## `warming` joins the keep-polling branch, and says which wait it is

The distinction is worth surfacing: before the decision the wait is on a **human**, and a nudge in Discord may help. After approval the wait is on **GCP propagation**, and only patience does. Reporting them identically invites chasing an approval that already happened.

```text
  approved — waiting for the agent identity to become usable (GCP propagation, usually under a minute)
```

The periodic progress line also stops repeating the phrase once approved. Past the decision the phrase has served its purpose, and continuing to print it invites a match against a card that is no longer open.

## `failed` gets exit 7, not exit 3

Exit 3 is documented as *"a human said no. Do not re-request without asking them why"*. That guidance is actively wrong for this case: nobody refused, the identity broke, and asking again is legitimate. Reusing it would train exactly the wrong response.

The broker's `failure_reason` is surfaced alongside it, so the session can say what actually went wrong instead of reporting a bare failure. The skill doc gains the row plus a note on why 7 and 3 warrant different things being said to the user.

## Verified against a stub broker

Not just linted — both paths run end to end:

- `warming` → `failed`: prints the warming line, exits **7** carrying `PERMISSION_DENIED: caller lacks serviceAccountTokenCreator`, and clears the pending file.
- `warming` → `approved`: prints the warming line, then installs normally, exit **0**, token file at `0600`. Confirms warming does not leave the poll loop in a state that breaks recovery.

`shellcheck` clean, `sh -n` clean, `markdownlint-cli2` clean.

## Still open in #177

The propagation warning and its do-not-touch-IAM instruction, the timeout message, `status` reporting other live grants, and the skill copy that currently tells the agent to ask for a manual `/sandbox create`. All of those depend on #291 landing; none is needed here.

Part of #177.
