### PR TITLE
Handle the provisioning state, and stop the agent asking which project to use

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -537,6 +537,7 @@ poll_and_install() {
     since_progress=0
     transient=0
     warming=0
+    provisioning=0
 
     while :; do
         code=$(http_get_authed "/requests/$req_id" "$poll_resp" "$hdr_cfg") || code=000
@@ -561,6 +562,18 @@ poll_and_install() {
         # and the next `wait` polling a request the broker has finished with.
         case "$state" in
             approved) break ;;
+            provisioning)
+                # Approved, and the repo had no sandbox, so one is being built
+                # before there is anything to grant against. Two to three minutes.
+                # Said once rather than every poll, and distinguished from warming
+                # because the two waits are different lengths and a human watching
+                # should know which one this is.
+                if [ "$provisioning" -eq 0 ]; then
+                    provisioning=1
+                    since_progress=0
+                    echo "  approved — creating the sandbox project (this takes two to three minutes)"
+                fi
+                ;;
             warming)
                 # Approved already: what is outstanding is GCP propagation of the
                 # agent identity, not the human. Worth saying out loud, because
@@ -603,6 +616,8 @@ poll_and_install() {
                 # repeating it past the decision invites a second match against
                 # a card that is no longer open.
                 echo "  ... still waiting for the identity to become usable (${elapsed}s elapsed)"
+            elif [ "$provisioning" -eq 1 ]; then
+                echo "  ... still creating the sandbox project (${elapsed}s elapsed)"
             else
                 echo "  ... still waiting for approval (${elapsed}s elapsed, phrase $phrase)"
             fi

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -26,6 +26,12 @@ three-word phrase as the session — that match is what binds an approval to
 *this* session rather than to whichever request happened to arrive first. Design
 and trust model: ADR 021 in `pmgledhill102/gcp-org-management`.
 
+If the repo has no sandbox project yet, the same approval **also creates one**,
+so the card may be authorising a project and its monthly spend as well as the
+access. The build takes two to three minutes, during which the helper reports
+`provisioning` — see [Waiting on a human, then waiting on
+GCP](#waiting-on-a-human-then-waiting-on-gcp). Design: ADR 022.
+
 ## Requesting
 
 ```sh
@@ -35,6 +41,27 @@ and trust model: ADR 021 in `pmgledhill102/gcp-org-management`.
 The project is resolved from the repo's `origin` remote, so nothing needs
 configuring per project. Override with `--project <id>` if the broker cannot
 resolve it, or `--repo <remote>` when working outside a checkout.
+
+### Never ask the user which project to use
+
+**The flow supplies the project. You do not choose it, and you must not ask the
+user to.** On success the helper prints it, `gcloud` is already pointed at it,
+and `status` reports it at any time.
+
+This matters because repo scripts often carry a default project ID in a
+`shared/env.sh` or similar, and it is tempting to ask which one to target. Asking
+is wrong twice over: it interrupts the human for something already decided, and
+their answer can send the work to a project the grant does not cover — the token
+is scoped to one project, so a "helpful" override just produces permission
+errors that look like a broken grant.
+
+If the repo has no sandbox yet, the broker does not fail: approving the card
+**creates one**, and the project it creates is the one to use. Wait for the
+helper to report it rather than filling the gap with a guess or a question.
+
+So: read the project from the helper's output, pass it to whatever needs it, and
+say which project you are working in. Ask the user only if the helper exits
+non-zero and the table below says to.
 
 Useful options: `--ttl 72h` (1–7 days, default 24h), `--timeout 900`,
 `--no-gcloud` if you only want the token file.
@@ -101,6 +128,19 @@ Nothing is wrong there and nobody needs chasing. The broker refuses to hand over
 a grant it cannot actually mint a token for, so it waits for the identity to
 propagate rather than issuing something that would fail on first use. It
 resolves on its own, without a second approval. Say so if asked, and wait.
+
+When the repo had no sandbox, there is a longer wait first, while the project is
+built:
+
+```text
+  approved — creating the sandbox project (this takes two to three minutes)
+```
+
+Also normal, also nobody to chase. **Do not fill the time by asking the user
+which project to target** — that is what this wait is deciding. Tell them the
+sandbox is being created and roughly how long it takes, and wait. If it never
+appears the helper exits non-zero and the reason is posted to the operations
+channel by the service that built it.
 
 ## Reading the outcome
 


### PR DESCRIPTION
Both from your first real end-to-end run.

## The urgent one: `provisioning` killed the session

The broker now reports `provisioning` while a sandbox is built for a repo that had none. The poll loop had no case for it, so it fell through to the catch-all `die 1 "broker reported an unexpected state"`.

**This is the same coupling I flagged for `warming` and `failed`, and then walked into again** for a third state I added to the broker without updating the client. The mistake wasn't missing the pattern — it was not treating "new poll state" as automatically meaning "client change required".

The wait is now named, and distinguished from `warming`: two to three minutes for a project build versus under a minute for identity propagation. A human watching should know which one they're in.

Note the pending file survives `die 1`, so a session that hit this can be resumed with `gcp-credentials wait` once the helper is updated — the grant is real and the sandbox is still being built.

## The skill let the agent ask which project to target

Because repo scripts carry a default project in `shared/env.sh` and similar, so "which PROJECT_ID?" looks like a reasonable question. It's wrong twice over:

- It interrupts the human for something already decided.
- Their answer can send work to a project **the grant doesn't cover**. The token is scoped to one project, so an override produces permission errors that look like a broken grant — a confusing failure a long way from its cause.

The doc now states that the flow supplies the project, that a repo without a sandbox gets one created rather than failing, and specifically not to fill the provisioning wait with a question about the very thing that wait is deciding.

## Verified

Against a stub broker, not just linted: `provisioning` → `warming` → `approved` prints both waits and installs normally at exit 0.

Part of #177.
