### PR TITLE
Send a client version, and fail loudly when the broker says it is too old

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -48,6 +48,14 @@ DEFAULT_TIER=sandbox
 DEFAULT_TIMEOUT=900 # the broker expires an unanswered card after 15 minutes
 HTTP_TIMEOUT=30
 TOKEN_LIFETIME=3600
+# The wire-contract version this helper implements, sent on every broker call.
+# The broker refuses anything below its minimum (HTTP 426) BEFORE pinging a
+# human, so a stale helper fails with an instruction instead of dying mid-flow
+# on a state it does not understand -- which happened three releases running
+# (warming, failed, provisioning). Bump this in the same commit as any change
+# that follows a broker contract change; the broker's clientversion.go keeps
+# the authoritative history.
+CLIENT_VERSION=4
 
 # Everything the broker client owns lives here. Deliberately not ~/.claude/:
 # that tree is chezmoi-managed from a public repo, and nothing but distance
@@ -171,8 +179,13 @@ load_url() {
 
 # write_header_cfg writes a curl --config file carrying the request key. Passing
 # it as -H would put it in argv, which every process on the machine can read.
+# The version rides along; it is no secret, but every authed call needs it and
+# this is the one place they all pass through.
 write_header_cfg() {
-    printf 'header = "X-Request-Key: %s"\n' "$CB_KEY" > "$1"
+    {
+        printf 'header = "X-Request-Key: %s"\n' "$CB_KEY"
+        printf 'header = "X-Client-Version: %s"\n' "$CLIENT_VERSION"
+    } > "$1"
 }
 
 # --- HTTP --------------------------------------------------------------------
@@ -182,6 +195,7 @@ write_header_cfg() {
 
 http_post_json() { # path bodyfile outfile
     curl -sS -X POST -H 'Content-Type: application/json' \
+        -H "X-Client-Version: $CLIENT_VERSION" \
         --max-time "$HTTP_TIMEOUT" --data-binary "@$2" \
         -o "$3" -w '%{http_code}' "$BROKER_URL$1"
 }
@@ -449,6 +463,7 @@ cmd_request() {
         401) die 1 "broker rejected the request key. Check \$CREDENTIAL_BROKER_REQUEST_KEY or $KEY_FILE (a trailing newline is trimmed here, so this is a genuine mismatch)." ;;
         404) die 1 "$(broker_error "$req_resp")" ;;
         409) die 1 "$(broker_error "$req_resp")" ;;
+        426) die 8 "this helper (v$CLIENT_VERSION) is too old for the broker. $(broker_error "$req_resp")" ;;
         429) die 5 "rate limited by the broker — wait before requesting again" ;;
         502) die 1 "the broker could not reach the approval channel, so nobody was asked. Do not retry blindly; check the broker." ;;
         *) die 1 "request failed (HTTP $code): $(broker_error "$req_resp")" ;;
@@ -549,6 +564,13 @@ poll_and_install() {
                 ;;
             401) die 1 "broker rejected the request key while polling" ;;
             404) die 1 "the broker no longer knows this request" ;;
+            426)
+                # A broker redeploy underneath this session raised the minimum.
+                # The pending file is deliberately left in place: the request may
+                # still be live, and `wait` resumes it once the helper is
+                # updated. Nothing was lost, only the ability to speak.
+                die 8 "this helper (v$CLIENT_VERSION) is too old for the broker. $(broker_error "$poll_resp") Then run '$PROG wait' to resume this request."
+                ;;
             *)
                 # A cold-starting or briefly wobbly broker should not read as a
                 # denial. Persistent failure still has to fail.
@@ -778,6 +800,11 @@ cmd_refresh() {
 }
 
 cmd_status() {
+    # First, so a support conversation starts from which client this even is.
+    # The broker logs the same number as client=N on the request's audit line,
+    # which is how the two ends of a session get paired up afterwards.
+    echo "client  : v$CLIENT_VERSION"
+
     if [ ! -f "$GRANT_FILE" ]; then
         echo "grant   : none on this machine"
     else

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -153,11 +153,19 @@ channel by the service that built it.
 | 5 | Rate limited | Wait. Do not loop. |
 | 6 | Not configured | No request key or no broker URL — see [Setup](#setup-not-per-session). |
 | 7 | Approved, but the identity never became usable | **Not a deny** — nobody refused. Report the reason the helper printed. Requesting again is legitimate; if it recurs, say so, because the sandbox's agent identity needs attention. |
+| 8 | This helper is too old for the broker | Relay the remedy the helper printed and **stop**. Retrying cannot help — nothing is wrong with the request, the client simply cannot speak the current contract. |
 | 1 | Broker unreachable or mint failed | Report it. Do not proceed as if credentials exist. |
 
 Exit 7 is worth distinguishing from exit 3 in what you tell the user. A deny is a
 decision and asking again without checking is rude; a failure is a fault, and
 retrying is the reasonable response.
+
+Exit 8 is neither. Nothing is wrong with the request and nobody decided
+anything — this helper predates a change to the broker's contract and cannot
+speak it. The broker refuses **before** posting a card, so no approval was spent
+and none will be until the helper is updated. Relay the remedy it printed
+(`chezmoi apply` locally, or bump `Rev:` in the cloud setup script) and stop;
+retrying is the one thing that certainly will not help.
 
 Never carry on without credentials after a non-zero exit. Silently falling back
 to whatever identity happens to be lying around is the exact failure the broker


### PR DESCRIPTION
Client half of the handshake in [`gcp-org-management`#313](https://github.com/pmgledhill102/gcp-org-management/pull/313). **Merge and `chezmoi apply` this before that one** — see ordering below.

## What it does

The helper sends `X-Client-Version: 4` on every broker call, and treats **426** as its own outcome: **exit 8**, distinct from a deny and from a generic failure, relaying the broker's hint verbatim.

Verbatim matters. The broker knows which remedies exist — `chezmoi apply` locally, bump `Rev:` in the cloud setup script — and the helper does not, and shouldn't have to learn them to stay correct.

## Why it exists

Three releases running, a new poll state killed a live session with `broker reported an unexpected state`: `warming`, then `failed`, then `provisioning`. Each time the client and broker deploy through separate paths, and nothing tied them together.

The version is what lets the broker refuse **before it posts a card**. That's the point: a stale client should not be able to spend a human approval it cannot complete — the readiness gate's principle (#293), one step earlier in the flow.

## The `/poll` case is deliberately different

If the broker is redeployed underneath a waiting session, the pending file is **left in place**. The request has not been lost — only the ability to talk about it. Once the helper is updated, `gcp-credentials wait` resumes the same request, and no re-approval is needed.

## Verified against a stub broker

Not just linted:

- `request` refused → exit **8**, hint relayed
- `wait` refused → exit **8**, hint relayed, plus the resume instruction
- the version header genuinely on the wire for both `POST` and `GET` (`{"versions": ["4", "4"]}`)
- pending file survives for resume

## Ordering

The broker's `MinClientVersion` is **4**, matching this. So the moment that broker deploys, any helper without this change gets 426 — which is the intended behaviour (a clear instruction instead of a mid-flow death), but it does mean:

1. Merge this, and `chezmoi apply` on any machine that uses the helper.
2. Then merge the broker PR.

Cloud sandboxes pick up the current helper on rebuild; local machines need the `apply`. Getting it the other way round isn't dangerous — nothing is lost and no approval is spent — it just means the next request fails with an instruction until the helper catches up.

Part of #177.
