### PR TITLE
Surface sharing, propagation, and mid-provisioning timeouts

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -293,7 +293,24 @@ do_exchange() {
     EX_GRANT_EXPIRES=$(jq -r '.grant_expires_at // ""' < "$ex_resp")
     EX_PROJECT=$(jq -r '.project // ""' < "$ex_resp")
     EX_SA=$(jq -r '.service_account // ""' < "$ex_resp")
+    EX_OTHER_GRANTS=$(jq -r '.other_active_grants // 0' < "$ex_resp")
     rm -f "$ex_resp"
+
+    # Persisted so `status` can report it between exchanges. Sessions on one
+    # repo share a project and an identity at roles/owner, so another live
+    # grant means someone else's work is in the same blast radius as yours --
+    # worth a warning at install, and worth remembering for status.
+    if [ -f "$GRANT_FILE" ]; then
+        # chmod before mv, as with the token file: the grant file carries the
+        # session token, and even a briefly world-readable copy is a copy.
+        jq --argjson n "${EX_OTHER_GRANTS:-0}" '. + {other_active_grants: $n}' \
+            < "$GRANT_FILE" > "$GRANT_FILE.new"
+        chmod 600 "$GRANT_FILE.new"
+        mv "$GRANT_FILE.new" "$GRANT_FILE"
+    fi
+    if [ "${EX_OTHER_GRANTS:-0}" -gt 0 ] 2> /dev/null; then
+        echo "  WARNING: $EX_OTHER_GRANTS other active grant(s) on this project — another session may be working here. Coordinate before destructive changes (terraform destroy, deletes)."
+    fi
 }
 
 gcloud_active_config() {
@@ -627,6 +644,14 @@ poll_and_install() {
             # The card outlives this timeout, so the request is left in place: a
             # human answering late should still be collectable with another
             # `wait`, rather than the session having thrown the id away.
+            #
+            # A timeout mid-provisioning is a different message entirely. The
+            # human already approved; the build continues server-side whether or
+            # not anyone is polling, and reporting it as a deny would send an
+            # agent into re-requesting a sandbox that is minutes from existing.
+            if [ "$provisioning" -eq 1 ]; then
+                die 4 "timed out after ${OPT_TIMEOUT}s, but the sandbox is still being built server-side — nothing is lost. Run '$PROG wait' to keep collecting, or a fresh '$PROG request' later will resolve the finished sandbox."
+            fi
             die 4 "gave up waiting after ${OPT_TIMEOUT}s with no decision. Treat this as a deny; '$PROG wait' resumes if the card is still live."
         fi
         sleep "$POLL_INTERVAL"
@@ -691,6 +716,19 @@ poll_and_install() {
     if [ "$OPT_REFRESH" -eq 1 ]; then
         refresh_start
         echo "  refresh   : running in the background until the grant expires (log: $LOG_FILE)"
+    fi
+
+    # Only when this very flow built the project. A brand-new project's API
+    # enablement and IAM bindings are still propagating when the token arrives,
+    # and the dangerous part is not the 403 -- it is what an agent holding
+    # roles/owner does about one. Debugging IAM it should have waited out is
+    # how an agent starts granting itself things.
+    if [ "$provisioning" -eq 1 ]; then
+        echo ""
+        echo "  NOTE: this project was just created. 403/404 on the first calls is"
+        echo "  propagation, not misconfiguration — wait ~60s and retry once before"
+        echo "  diagnosing anything, and do NOT modify IAM or org policy to work"
+        echo "  around it."
     fi
 }
 
@@ -819,6 +857,15 @@ cmd_status() {
             echo "grant   : $st_project, expires $st_exp"
         fi
         echo "identity: $st_sa"
+
+        # As of the last token exchange, so at most an hour stale while refresh
+        # runs. Sessions on one repo share the project and the identity at
+        # roles/owner, so another live grant means someone else's work shares
+        # your blast radius -- say so before the terraform destroy, not after.
+        st_others=$(jq -r '.other_active_grants // 0' < "$GRANT_FILE")
+        if [ "$st_others" -gt 0 ] 2> /dev/null; then
+            echo "sharing : $st_others other active grant(s) on this project — coordinate before destructive changes"
+        fi
     fi
 
     if [ -f "$PENDING_FILE" ]; then

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -182,6 +182,33 @@ Report only what the helper printed:
 configuration, which is activated. `~/.claude/bin/gcp-credentials release`
 restores the configuration that was active before.
 
+### If the project was just created: early 403s are propagation
+
+When the sandbox was built by this very approval, the helper says so and warns
+that API enablement and IAM bindings are still propagating. **A 403 or 404 on
+your first calls is propagation, not misconfiguration.** Wait ~60 seconds and
+retry once before diagnosing anything — and do **not** modify IAM or org policy
+to work around it. You hold `roles/owner`; "fixing" a propagation delay by
+granting things is how a sandbox's permissions end up unrecognisable.
+
+### The grant may be shorter than you asked for
+
+A grant is clamped to the sandbox's own expiry — a 24h grant against a sandbox
+that is deleted in 12h becomes a 12h grant, and the approval card said so. If
+the helper reports a shorter expiry than requested, that is why; it is not an
+error. A sandbox expiring within the hour is refused at request time with a
+pointer at `/sandbox extend` — relay that to the user rather than retrying.
+
+### Someone else may be working in the same project
+
+Sandboxes are shared per repo. If the helper prints a `WARNING` about other
+active grants — or `status` shows a `sharing :` line — another session holds a
+live grant on the same project, under the same identity, at `roles/owner`.
+Nothing prevents you overwriting each other's work. **Tell the user before any
+destructive operation** (`terraform destroy`, deleting resources, rewriting
+state): they may be running the other session themselves and know what it is
+doing.
+
 ## Things never to do
 
 - **Never print, `cat`, `grep`, `head` or otherwise read the token file.** The


### PR DESCRIPTION
The remainder of #177, consuming what `gcp-org-management`#320 exposes. **Merge #320 first** — without it `other_active_grants` is absent from the exchange response and the sharing features silently show nothing (harmless, but untested).

## Sharing becomes visible

Every exchange returns `other_active_grants`. The helper:

- **warns at install**: `WARNING: 2 other active grant(s) on this project — another session may be working here`
- **persists it** in the grant file (chmod-before-mv, same care as the token file — the grant file carries the session token)
- **reports it in `status`** as a `sharing :` line, at most an hour stale while refresh runs

The skill tells the agent the part that matters: sessions share one identity at `roles/owner`, nothing prevents overwriting each other's work, so **tell the user before destructive operations** — they may be running the other session themselves.

## The propagation note, only when it's true

After an install where *this flow built the project*, the helper prints: 403/404 on the first calls is propagation, wait ~60s and retry once, and **do not modify IAM or org policy to work around it**. The dangerous part of an early 403 isn't the error — it's what an agent holding `roles/owner` does about it.

Printed only on the provisioning path, so the warning stays information rather than wallpaper.

## A timeout mid-provisioning stops reading as a deny

The human already approved; the build continues server-side whether anyone polls or not. The old message ("treat this as a deny") would send an agent into re-requesting a sandbox minutes from existing. It now says nothing is lost, and both ways to resume.

## Skill doc

Gains all three sections, plus the clamp from #320: a grant shorter than requested is the sandbox's own expiry, not an error — and a sandbox dying within the hour refuses at request time pointing at `/sandbox extend`, which the agent should relay rather than retry.

## Verified against a stub broker

All three ran end to end: warning printed and persisted → `status` shows `sharing : 2 other active grant(s)`; the propagation NOTE appears on the provisioning path and only there; the timeout path exits 4 with the build-continues message.

Closes #177.
