### PR TITLE
Stop pre-approving the token-printing commands the skill forbids

### DIFF
--- a/home/settings.json
+++ b/home/settings.json
@@ -65,8 +65,6 @@
       "Bash(gcloud artifacts repositories describe *)",
       "Bash(gcloud artifacts repositories list *)",
       "Bash(gcloud auth list *)",
-      "Bash(gcloud auth print-access-token *)",
-      "Bash(gcloud auth print-identity-token *)",
       "Bash(gcloud beta logging tail *)",
       "Bash(gcloud builds *)",
       "Bash(gcloud compute backend-services describe *)",

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -95,9 +95,11 @@ its own heading — currently just `gcloud builds` (see below).
 
 #### Auth and config
 
+`gcloud auth list` reports which accounts are configured; it prints no
+credential material. The two `print-*-token` forms do, and are in the
+Never Allow list below.
+
 - `Bash(gcloud auth list *)`
-- `Bash(gcloud auth print-access-token *)`
-- `Bash(gcloud auth print-identity-token *)`
 - `Bash(gcloud config *)`
 - `Bash(gcloud info *)`
 
@@ -677,6 +679,7 @@ the user revisits it.
 | `Bash(gcloud storage cp *)` | Write operation — uploads to GCS |
 | `Bash(gcloud run services update-traffic *)` | Mutates production Cloud Run traffic |
 | `Bash(gcloud secrets versions access *)` | Reads secret values — credential-exfiltration risk |
+| `Bash(gcloud auth print-access-token *)` / `Bash(gcloud auth print-identity-token *)` | Prints a live credential to stdout, i.e. into the transcript and therefore into model context — the exact exfiltration path the credential broker exists to close. `home/commands/gcp-credentials.md` forbids running these in bold ("Never run `gcloud auth print-access-token`"), so auto-approving them made the forbidden action the frictionless one on every local machine. Removed 2026-08; do not re-add |
 | `Bash(gcloud monitoring *)` / `Bash(gcloud beta monitoring *)` / `Bash(gcloud alpha monitoring *)` | Can modify alerts and dashboards, not read-only |
 | `Bash(gh api *)` / `Bash(gh api repos/*)` | Full GitHub API including POST/PATCH/DELETE — prefer `mcp__github__*` |
 | `Bash(gh repo create *)` | Creates repositories — infrequent, should always prompt |


### PR DESCRIPTION
## What

Removes two allowlist entries from `home/settings.json`:

- `Bash(gcloud auth print-access-token *)`
- `Bash(gcloud auth print-identity-token *)`

and their companion lines in `home/settings.json.md` (CI enforces that the two change together).

## Why

`home/commands/gcp-credentials.md` says, in bold, never to run `gcloud auth print-access-token` — it prints a live credential to stdout, which puts it in the transcript and therefore in model context. That is the exact exfiltration path the credential-broker design exists to close.

Allowlisting it made the forbidden action the prompt-free one on every local machine.

## Also

Both patterns are added to the **Never Allow** table with the rationale, so a future retrospective doesn't reinstate them. ADR-0014's "frozen allowlist" posture is about not *investing* in the allowlist — it shouldn't preserve a rule the repo's own security guidance bans.

`gcloud auth list` stays: it reports which accounts are configured and prints no credential material. A short note above the group now says why the split exists.

## Verification

- `jq empty home/settings.json` — valid
- `markdownlint-cli2 "**/*.md"` — 0 issues
- settings-sync CI job should pass: both files changed

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_