### PR TITLE
Use a fictional project ID in the skill's worked examples

### DIFF
--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -92,7 +92,7 @@ collect the answer separately.
 Relay it **verbatim, as the first thing you say** — not buried in tool output.
 Say what they are approving:
 
-> Requesting GCP credentials for `pmgledhill-apix-sbx` (sandbox tier, 24h).
+> Requesting GCP credentials for `example-project-sbx` (sandbox tier, 24h).
 > **Verification phrase: `mint-copper-falcon`** — approve the Discord card only
 > if it shows exactly that.
 
@@ -175,7 +175,7 @@ exists to prevent.
 
 Report only what the helper printed:
 
-> Credentials installed for `pmgledhill-apix-sbx`, grant expires 2026-08-13T11:33Z.
+> Credentials installed for `example-project-sbx`, grant expires 2026-08-13T11:33Z.
 > Background refresh is running.
 
 `gcloud` is pointed at the token through a dedicated `agent-broker`


### PR DESCRIPTION
## What

`home/commands/gcp-credentials.md` used a real project ID from the private estate in both relay templates. Replaced with `example-project-sbx` in both places.

## Why it matters more than it looks

This file is re-published into every cloud sandbox as the skill body by `cloud/bootstrap.sh`, so the example travels further than the repo does.

It was also a *misleading* example independently of the disclosure: it revealed a project-naming convention, and the ID shape shown no longer matches the current scheme.

## Deliberately not in this PR

The issue raises a broader question — whether the two private repo names referenced across the README, the helper header, this skill doc, and `cloud/README.md` are sanctioned exceptions or accumulated drift, and recording the answer in `home/CLAUDE.md`. That's a decision, not a mechanical fix, so it's left for you rather than guessed at here.

## Verification

`markdownlint-cli2` — 0 issues. `grep` confirms no remaining occurrences of the old ID anywhere in the repo.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_