### PR TITLE
Pin and verify the actionlint download instead of piping from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,27 @@ jobs:
     name: Action Lint
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Pinned release + checksum, rather than piping an install script from a
+    # mutable `main` ref into bash. ADR-0016 principle 6 forbids exactly that
+    # pattern for this repo's own bootstrap, on the grounds that a mutable ref
+    # hands a third party reach into the environment; CI is not an exception.
+    # The upstream download script performs no verification of its own.
+    #
+    # Bump VERSION and SHA256 together. The checksum is the publisher's, from
+    # actionlint_<version>_checksums.txt in the same release.
+    env:
+      ACTIONLINT_VERSION: 1.7.12
+      ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Download actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Download and verify actionlint
+        run: |
+          set -euo pipefail
+          file="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL -o "$file" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${file}"
+          echo "${ACTIONLINT_SHA256}  ${file}" | sha256sum --check --strict -
+          tar -xzf "$file" actionlint
       - name: Run actionlint
         run: ./actionlint -color
 


### PR DESCRIPTION
## Before

```yaml
run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
```

A fetch from a mutable `main` ref, executed. ADR-0016 principle 6 forbids exactly this pattern for the repo's own bootstrap — a mutable ref hands a third party reach into the environment — and CI isn't an exception. The bare `curl` also had no `-f`, so an HTTP error page would have been piped to bash.

## After

A pinned release tarball, verified against the publisher's own SHA256 before extraction:

```yaml
env:
  ACTIONLINT_VERSION: 1.7.12
  ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
```

## Why the binary, not just a pinned script ref

The issue offered either. I went with the release binary because **the upstream download script performs no verification of its own** — I read it; there's no `sha256sum` anywhere in it. Pinning the script to a tag would have made *the script* immutable while leaving the thing it downloads unverified. Pinning the artifact and checking its digest closes both.

`1.7.12` is current: it's the version the upstream script itself defaults to, and `v1.7.13` doesn't exist yet.

## Verification

Ran the exact step sequence locally on linux/amd64:

- checksum check: `actionlint_1.7.12_linux_amd64.tar.gz: OK`
- the digest matches the publisher's `actionlint_1.7.12_checksums.txt` entry, fetched separately
- `./actionlint -version` → `1.7.12`
- `./actionlint -color` against this repo's workflows → clean, including the edited file

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_