### PR TITLE
Refuse to spend a second approval when a grant is already live

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -126,6 +126,9 @@ request options:
   --no-refresh     install one token and do not start background refresh
   --no-gcloud      write the token file but do not touch any gcloud config
   --no-activate    configure the agent-broker gcloud config without activating
+  --force          request even when a live grant already exists. Costs a
+                   human approval; `renew` or `refresh --background` usually
+                   does what you actually want
 USAGE
     exit 2
 }
@@ -418,6 +421,7 @@ cmd_request() {
     OPT_GCLOUD=1
     OPT_ACTIVATE=1
     OPT_WAIT=0
+    OPT_FORCE=0
 
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -431,10 +435,34 @@ cmd_request() {
             --no-gcloud) OPT_GCLOUD=0; shift ;;
             --no-activate) OPT_ACTIVATE=0; shift ;;
             --wait) OPT_WAIT=1; shift ;;
+            --force) OPT_FORCE=1; shift ;;
             -h | --help) usage ;;
             *) echo "$PROG: unknown option: $1" >&2; usage ;;
         esac
     done
+
+    # Refuse to spend a second approval on access that is already granted.
+    #
+    # A human approval is the scarcest resource in this design -- roughly one
+    # per repo per 1-7 days is what the grant window is *for*. A habit-driven
+    # `request` while a live grant sits on disk burns one to obtain something
+    # `renew` (mint now) or `refresh --background` (mint now, resume the loop)
+    # would have produced silently, and the broker will happily open a second
+    # request against a project that already has a live grant from the same key.
+    #
+    # Checked before load_key/load_url and before any HTTP, so the wasteful case
+    # costs one stat and this message. Nothing about the security model changes:
+    # the grant being reused is one a human already approved.
+    if [ "$OPT_FORCE" -eq 0 ] && [ -f "$GRANT_FILE" ]; then
+        rq_exp=$(jq -r '.grant_expires_at // ""' < "$GRANT_FILE" 2> /dev/null || true)
+        rq_epoch=$(rfc3339_to_epoch "$rq_exp")
+        rq_now=$(date -u '+%s')
+        if [ -n "$rq_epoch" ] && [ "$rq_epoch" -gt "$rq_now" ]; then
+            rq_project=$(jq -r '.project // "?"' < "$GRANT_FILE" 2> /dev/null || echo "?")
+            rq_left=$((rq_epoch - rq_now))
+            die 2 "a live grant already exists for $rq_project, valid for another $(humanise_remaining "$rq_left") (until $rq_exp). Requesting again would ask a human to approve access they have already approved. Run '$PROG renew' to mint a token now, or '$PROG refresh --background' if the refresh loop has died; '$PROG status' shows which. Pass --force to request a new approval anyway."
+        fi
+    fi
 
     # The human reads this on the approval card and has nothing else to go on.
     # A request with no stated purpose is one they cannot sensibly approve.

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -66,6 +66,27 @@ non-zero and the table below says to.
 Useful options: `--ttl 72h` (1–7 days, default 24h), `--timeout 900`,
 `--no-gcloud` if you only want the token file.
 
+### If a grant is already live, `request` refuses
+
+`request` checks for an unexpired grant on disk before it opens anything, and
+exits 2 rather than asking a human to approve access they have already approved:
+
+```text
+gcp-credentials: a live grant already exists for example-project-sbx, valid for
+another 19h 40m (until 2026-08-16T11:33Z). ... Run 'gcp-credentials renew' to
+mint a token now, or 'gcp-credentials refresh --background' if the refresh loop
+has died; 'gcp-credentials status' shows which. Pass --force to request a new
+approval anyway.
+```
+
+This is not an error to work around. Do what it says — `renew` and
+`refresh --background` need no human and take one HTTP call. `--force` exists
+for the case where the existing grant is genuinely the wrong one (wrong project,
+wrong tier, too little time left for the work); spending an approval to get back
+something you already hold is not that case.
+
+Nothing was sent to the broker when you see this, so no approval was consumed.
+
 Write a **specific purpose**. It is the only thing the human has to judge the
 request by, and it is rendered on the card as untrusted, agent-written text.
 "deploy the Apigee bootstrap module to the sandbox" is approvable;
@@ -147,7 +168,7 @@ channel by the service that built it.
 | Exit | Meaning | What to do |
 | --- | --- | --- |
 | 0 | Installed | Carry on. Say which project and when the grant expires. |
-| 2 | Usage error | Fix the arguments. |
+| 2 | Usage error, **or a live grant already exists** | Fix the arguments. If it names a live grant, use `renew` / `refresh --background` instead — see [above](#if-a-grant-is-already-live-request-refuses). |
 | 3 | **Denied** or revoked | Stop. A human said no. Do not re-request without asking them why. |
 | 4 | Timed out / expired | Nobody answered, which the broker treats as a deny. Ask the user before retrying. |
 | 5 | Rate limited | Wait. Do not loop. |


### PR DESCRIPTION
## What

`cmd_request` now reads `GRANT_FILE` before doing anything else. If `grant_expires_at` is in the future it exits 2 instead of opening a request and paging a human:

```text
gcp-credentials: a live grant already exists for example-project-sbx, valid for another
19h 40m (until 2026-08-16T11:33Z). Requesting again would ask a human to approve access
they have already approved. Run 'gcp-credentials renew' to mint a token now, or
'gcp-credentials refresh --background' if the refresh loop has died; 'gcp-credentials
status' shows which. Pass --force to request a new approval anyway.
```

`--force` is added for the case where the live grant is genuinely the wrong one.

## Design notes

- **Checked before `load_key`/`load_url` and before any HTTP**, so the wasteful case costs one stat and a message — and no approval is consumed by the run that gets refused.
- **Fails open.** An unparseable or missing `grant_expires_at` falls through to the normal request path. A corrupt grant file must not be able to lock a session out of requesting.
- **No security-model change.** The grant being reused is one a human already approved.
- Reuses the existing `rfc3339_to_epoch` and `humanise_remaining` helpers rather than adding date handling.

## Skill doc

`home/commands/gcp-credentials.md` gains a short section explaining the refusal and that it is not an error to work around, and the exit-2 row now points at it.

## Verification

`shellcheck home/bin/gcp-credentials` clean; `markdownlint-cli2` clean.

Behavioural tests against a stubbed `CREDENTIAL_BROKER_HOME`, with no broker configured so exit 6 proves a run got *past* the guard — 10 assertions, all passing:

| Case | Expected | Result |
| --- | --- | --- |
| live grant | refused, rc=2 | ok |
| message names project / remaining / `renew` / `--force` | present | ok (4 assertions) |
| `--force` with live grant | falls through, rc=6 | ok |
| expired grant | falls through, rc=6 | ok |
| no grant file | falls through, rc=6 | ok |
| unparseable expiry | falls through, rc=6 | ok |
| missing expiry field | falls through, rc=6 | ok |

These are ad-hoc for this PR; #196 turns this shape into a committed harness.

## Conflict note

Touches `home/bin/gcp-credentials`, as do the PRs for #190 and #154. All three branch from `main` and edit different functions (`cmd_request` here, `cmd_status` there), so they should merge in any order.

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_