### PR TITLE
Report token age in status, and flag a stale one

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -233,6 +233,28 @@ rfc3339_to_epoch() {
         echo ""
 }
 
+# file_mtime prints a file's modification time as an epoch, or nothing.
+#
+# GNU form first, BSD second — the same order and the same two spellings the
+# cloud bootstrap's gcloud wrapper uses to decide whether to renew before a
+# call. Unlike that one this prints nothing on failure rather than substituting
+# "now", because a caller reporting *age* must be able to tell "0 seconds old"
+# from "could not tell".
+file_mtime() { # path
+    stat -c %Y "$1" 2> /dev/null || stat -f %m "$1" 2> /dev/null || true
+}
+
+# humanise_elapsed renders an age. humanise_remaining renders a countdown, and
+# its "0m" reads oddly for something that just happened.
+humanise_elapsed() { # seconds
+    he_s=$1
+    if [ "$he_s" -lt 60 ]; then
+        echo "just now"
+        return 0
+    fi
+    humanise_remaining "$he_s"
+}
+
 humanise_remaining() { # seconds
     hr_s=$1
     if [ "$hr_s" -le 0 ]; then
@@ -875,8 +897,26 @@ cmd_status() {
         [ -n "$st_card" ] && echo "          card expires $st_card; '$PROG wait' collects it"
     fi
 
+    # Age, not just presence. The most common failure in practice is a reaped
+    # refresh loop leaving a stale token on disk: the grant is live, the file is
+    # there, and every call fails. "present" alone reports that state as healthy
+    # and sends whoever is debugging into IAM -- which is the worst place for an
+    # agent holding roles/owner to go looking. mtime is when the token was
+    # written, so age past a token lifetime means no successful mint since.
     if [ -f "$TOKEN_FILE" ]; then
-        echo "token   : present at $TOKEN_FILE"
+        st_mtime=$(file_mtime "$TOKEN_FILE")
+        if [ -n "$st_mtime" ]; then
+            st_age=$(($(date -u '+%s') - st_mtime))
+            if [ "$st_age" -ge "$TOKEN_LIFETIME" ]; then
+                echo "token   : present at $TOKEN_FILE (minted $(humanise_elapsed "$st_age") ago — STALE, past its ${TOKEN_LIFETIME}s lifetime)"
+                echo "          nothing has minted since, so the refresh loop is probably dead:"
+                echo "          '$PROG refresh --background' mints now and restarts it"
+            else
+                echo "token   : present at $TOKEN_FILE (minted $(humanise_elapsed "$st_age") ago)"
+            fi
+        else
+            echo "token   : present at $TOKEN_FILE (age unknown — stat unavailable)"
+        fi
     else
         echo "token   : none installed"
     fi

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -277,9 +277,19 @@ still perfectly valid.
 Symptoms, in the order you meet them:
 
 - `gcloud` fails with `Request had invalid authentication credentials`
-- `~/.claude/bin/gcp-credentials status` shows a live grant, `token : present`
-  (but stale), and `refresh : not running`
-- the refresh log's last entry is hours old
+- `~/.claude/bin/gcp-credentials status` shows a live grant, `refresh : not
+  running`, and a token flagged stale:
+
+  ```text
+  token   : present at ~/.config/claude/credential-broker/access_token (minted 2h 11m ago — STALE, past its 3600s lifetime)
+            nothing has minted since, so the refresh loop is probably dead:
+            'gcp-credentials refresh --background' mints now and restarts it
+  ```
+
+`status` derives that age from the token file's mtime, so it is reporting when a
+token was last successfully minted — not merely that a file exists. A `STALE`
+line is the answer on its own; there is no need to read the refresh log to
+confirm it, and no reason to go looking at IAM.
 
 The fix needs **no human approval** — the grant is what a human approved, and it
 has not expired:


### PR DESCRIPTION
## Before

```text
token   : present at /Users/…/access_token
```

Which is what it says when the refresh loop was reaped an hour ago and every GCP call is failing.

## After

```text
token   : present at /Users/…/access_token (minted 43m ago)
```

```text
token   : present at /Users/…/access_token (minted 2h 11m ago — STALE, past its 3600s lifetime)
          nothing has minted since, so the refresh loop is probably dead:
          'gcp-credentials refresh --background' mints now and restarts it
```

## Notes

- The path is **kept**, not replaced — the skill doc's "feed a tool from the token file" pattern refers to it, and losing it to make room for the age would trade one useful thing for another.
- `file_mtime` uses the same GNU-then-BSD `stat` pair the cloud bootstrap's gcloud wrapper already uses. It differs in one way on purpose: it prints *nothing* on failure rather than substituting "now", because a caller reporting age must be able to tell "0 seconds old" from "couldn't tell". That case reports `(age unknown — stat unavailable)`.
- `humanise_elapsed` wraps the existing `humanise_remaining`, which renders `0m` for anything under a minute — fine for a countdown, odd for "when was this written". Under 60s now reads `just now`.
- Threshold is `TOKEN_LIFETIME` (3600s), the existing constant: past that, no successful mint has happened, which is a fact rather than a heuristic.

## Verification

`shellcheck` clean, `markdownlint-cli2` clean, 11 behavioural assertions passing against a stubbed `CREDENTIAL_BROKER_HOME` with `touch -d`-aged token files:

fresh → age shown, no marker · sub-minute → `just now` · 2h11m → `STALE` + cause + remedy · boundary 3600 stale / 3599 not · absent → `none installed`.

The last assertion is the one that matters most: with a recognisable fake secret in the token file, **the value never appears in `status` output**. #196 turns that into a permanent check rather than one I ran once.

## Conflict note

Touches `home/bin/gcp-credentials`, as do the PRs for #186 and #154. All branch from `main`; this one edits `cmd_status` and the time helpers, #186 edits `cmd_request`. #154 also adds a line to `cmd_status`, so that one may need a trivial rebase depending on merge order.

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_