### PR TITLE
Detect credential environment variables that silently outrank the token file

### DIFF
--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -313,6 +313,65 @@ do_exchange() {
     fi
 }
 
+# --- environment conflicts ---------------------------------------------------
+#
+# gcloud resolves every property in the order environment variable ->
+# configuration -> default, so a preset CLOUDSDK_* variable silently outranks
+# everything gcloud_install writes.
+#
+# Observed in a cloud sandbox on 2026-08-12: the image presets
+# CLOUDSDK_AUTH_ACCESS_TOKEN, which is both higher precedence *and* a different
+# property (auth/access_token) than the auth/access_token_file this helper sets.
+# Every API call failed ACCESS_TOKEN_TYPE_UNSUPPORTED while the broker token on
+# disk was perfectly good -- and the helper reported "credentials installed",
+# and `status` reported a healthy grant with a token present, throughout. That
+# is the worst shape a failure can take: every diagnostic says healthy and the
+# error names neither the broker nor the variable. It cost most of a session.
+#
+# A child process cannot unset a variable in its parent's environment, so the
+# only fix available here is to stop looking healthy.
+#
+# ONLY THE NAMES ARE EVER PRINTED. CLOUDSDK_AUTH_ACCESS_TOKEN holds a bearer
+# token; echoing its value to explain the problem would put a live credential
+# in the transcript, which is the thing this whole helper exists to avoid.
+
+# Variables that hijack gcloud itself.
+gcloud_env_conflicts() {
+    if [ -n "${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" ]; then echo "CLOUDSDK_AUTH_ACCESS_TOKEN"; fi
+    if [ -n "${CLOUDSDK_AUTH_ACCESS_TOKEN_FILE:-}" ]; then echo "CLOUDSDK_AUTH_ACCESS_TOKEN_FILE"; fi
+    if [ -n "${CLOUDSDK_CORE_PROJECT:-}" ]; then echo "CLOUDSDK_CORE_PROJECT"; fi
+}
+
+# Variables that hijack client libraries and Terraform rather than gcloud.
+# They matter because the skill tells agents to feed both from the token file,
+# and a preset value there fails the same silent way.
+client_env_conflicts() {
+    if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then echo "GOOGLE_APPLICATION_CREDENTIALS"; fi
+    if [ -n "${GOOGLE_OAUTH_ACCESS_TOKEN:-}" ]; then echo "GOOGLE_OAUTH_ACCESS_TOKEN"; fi
+}
+
+# warn_env_conflicts is called after a successful install, where the message has
+# to do one more job than naming the problem: say that the grant is *fine*, so
+# nobody responds to it by spending another human approval on a new request.
+warn_env_conflicts() {
+    wec_gcloud=$(gcloud_env_conflicts | tr '\n' ' ')
+    wec_client=$(client_env_conflicts | tr '\n' ' ')
+    [ -n "$wec_gcloud$wec_client" ] || return 0
+
+    echo ""
+    echo "  WARNING: the environment overrides what was just installed."
+    if [ -n "$wec_gcloud" ]; then
+        echo "  gcloud reads these before any configuration: ${wec_gcloud% }"
+        echo "  Symptom: calls fail ACCESS_TOKEN_TYPE_UNSUPPORTED, or hit the wrong project."
+    fi
+    if [ -n "$wec_client" ]; then
+        echo "  Client libraries and Terraform read these first: ${wec_client% }"
+    fi
+    echo "  Remedy: unset them, or invoke the tool through a wrapper that does."
+    echo "  The grant and the token file are correct — this is gcloud plumbing,"
+    echo "  not a credential problem. Do NOT request again."
+}
+
 gcloud_active_config() {
     command -v gcloud > /dev/null 2>&1 || return 0
     gcloud config configurations list --filter='is_active=true' \
@@ -718,6 +777,10 @@ poll_and_install() {
         echo "  refresh   : running in the background until the grant expires (log: $LOG_FILE)"
     fi
 
+    # After the install lines, not before: the install did succeed, and the
+    # warning is about the environment defeating it downstream.
+    warn_env_conflicts
+
     # Only when this very flow built the project. A brand-new project's API
     # enablement and IAM bindings are still propagating when the token arrives,
     # and the dangerous part is not the 403 -- it is what an agent holding
@@ -891,6 +954,19 @@ cmd_status() {
         st_active=$(gcloud config configurations list --filter='is_active=true' \
             --format='value(name)' 2> /dev/null | head -1 || true)
         echo "gcloud  : active configuration '$st_active'"
+    fi
+
+    # The line that stops this command lying. Everything above can report a
+    # healthy grant, a present token and a running refresh loop while every API
+    # call fails, because an environment variable outranks the configuration.
+    st_env_gcloud=$(gcloud_env_conflicts | tr '\n' ' ')
+    st_env_client=$(client_env_conflicts | tr '\n' ' ')
+    if [ -n "$st_env_gcloud" ]; then
+        echo "gcloud  : OVERRIDDEN by ${st_env_gcloud% } — gcloud ignores the broker token; calls will fail"
+        echo "          unset it, or run gcloud through a wrapper that does. The grant is fine."
+    fi
+    if [ -n "$st_env_client" ]; then
+        echo "clients : OVERRIDDEN by ${st_env_client% } — client libraries and Terraform ignore the token file"
     fi
 }
 

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -266,6 +266,51 @@ Escalate only if `renew` itself fails:
 - exit 2 — no grant on this machine at all; request one
 - exit 1 — the broker is unreachable, which is a real fault worth reporting
 
+### `ACCESS_TOKEN_TYPE_UNSUPPORTED` — the one `renew` cannot fix
+
+This error reads like a broker fault or an IAM problem and is neither. It means
+**an environment variable is outranking the token file**, so gcloud never looks
+at what the helper installed.
+
+gcloud resolves every property in the order environment variable →
+configuration → default. `CLOUDSDK_AUTH_ACCESS_TOKEN` is both higher precedence
+*and* a different property (`auth/access_token`) than the
+`auth/access_token_file` the helper sets, so a preset value wins over everything
+the helper does — silently. It was preset in a sandbox image, and cost most of a
+debugging session because every diagnostic said healthy.
+
+`status` now says so directly:
+
+```text
+gcloud  : OVERRIDDEN by CLOUDSDK_AUTH_ACCESS_TOKEN — gcloud ignores the broker token; calls will fail
+          unset it, or run gcloud through a wrapper that does. The grant is fine.
+```
+
+The variables that do this:
+
+| Variable | Overrides |
+| --- | --- |
+| `CLOUDSDK_AUTH_ACCESS_TOKEN` | `auth/access_token_file` — the observed case |
+| `CLOUDSDK_AUTH_ACCESS_TOKEN_FILE` | the same property the helper sets |
+| `CLOUDSDK_CORE_PROJECT` | the project the helper sets — calls go elsewhere |
+| `GOOGLE_APPLICATION_CREDENTIALS` | client libraries and Terraform, not gcloud |
+| `GOOGLE_OAUTH_ACCESS_TOKEN` | client libraries and Terraform, not gcloud |
+
+**The remedy is `unset`, not `renew` and not `request`.** The grant is valid and
+the token file is correct; this is gcloud plumbing. `renew` will cheerfully
+succeed and change nothing, and `request` spends a human approval on a problem
+no approval can solve.
+
+```sh
+unset CLOUDSDK_AUTH_ACCESS_TOKEN
+```
+
+If the variable is preset by the environment image rather than by something in
+the session, it will come back in the next session: say so, so it gets reported
+to whoever owns the image. A general-purpose dev container presetting
+`CLOUDSDK_AUTH_ACCESS_TOKEN` hijacks gcloud auth for anything that brings its
+own credentials.
+
 ## After a container restart or a resumed session
 
 **Check this before anything else in a resumed cloud session.** Sandboxes


### PR DESCRIPTION
Addresses the four acceptance criteria in #154.

## The problem

gcloud resolves every property **environment variable → configuration → default**. `CLOUDSDK_AUTH_ACCESS_TOKEN` is both higher precedence *and* a different property (`auth/access_token`) than the `auth/access_token_file` the helper sets, so a preset value wins over everything `gcloud_install` does — silently.

Every diagnostic said healthy. `request` printed "credentials installed", `status` reported a live grant with a token present, and every call failed `ACCESS_TOKEN_TYPE_UNSUPPORTED` — an error naming neither the broker nor the variable.

## What changed

The helper can't unset a variable in its parent's environment, so it stops looking healthy instead.

**`request`**, after install:

```text
  WARNING: the environment overrides what was just installed.
  gcloud reads these before any configuration: CLOUDSDK_AUTH_ACCESS_TOKEN
  Symptom: calls fail ACCESS_TOKEN_TYPE_UNSUPPORTED, or hit the wrong project.
  Remedy: unset them, or invoke the tool through a wrapper that does.
  The grant and the token file are correct — this is gcloud plumbing,
  not a credential problem. Do NOT request again.
```

**`status`**:

```text
gcloud  : OVERRIDDEN by CLOUDSDK_AUTH_ACCESS_TOKEN — gcloud ignores the broker token; calls will fail
          unset it, or run gcloud through a wrapper that does. The grant is fine.
```

All five variables from the issue's table are checked, split into the ones that hijack **gcloud** and the ones that hijack **client libraries and Terraform** — the latter matter because the skill tells agents to feed both from the token file.

## The detail that mattered most

**Only variable names are ever printed, never values.** `CLOUDSDK_AUTH_ACCESS_TOKEN` holds a bearer token; echoing its value to explain the problem would put a live credential in the transcript — precisely what this helper exists to prevent. There's a test asserting it with a recognisable fake secret in each variable in turn.

## Skill doc

New troubleshooting section naming `ACCESS_TOKEN_TYPE_UNSUPPORTED`, placed next to the "run `renew` first" advice because **this is the failure `renew` cannot fix**: it succeeds and changes nothing, while `request` spends a human approval on a problem no approval can solve. The remedy is `unset`.

It also says that if the variable is image-preset it will return next session, so it gets reported upstream — the issue's "flag it to whoever owns the sandbox image" point, put where an agent will actually hit it.

## Verification

`shellcheck` clean, `markdownlint-cli2` clean, **21 assertions passing**: clean env produces no line; each of the five variables detected in isolation and categorised correctly; multiple variables render as one space-separated list without a doubled separator; an empty value is not a conflict; and the value never appears in output, checked per-variable.

Not verified: **the fourth acceptance criterion — "verified in a sandbox where the variable is preset"** — needs a real sandbox and is left for you. The tests simulate the preset variable, which covers the logic but not the image.

## Conflict note

Adds lines to `cmd_status`, as does #190. Both branch from `main`; whichever merges second may want a trivial rebase.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_