### PR TITLE
Meet the baseline this repo prescribes for every other repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  # The workflow actions here are SHA-pinned, which is correct and also means
+  # nothing will ever bump them without this file. /setup-common installs this
+  # in every repo it touches; this one had been missing it.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+    # Load-bearing, not a lint nit: a cooldown gives upstream time to yank a
+    # bad or malicious release before it can land here.
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,26 @@ jobs:
       - name: Run actionlint
         run: ./actionlint -color
 
+  gitleaks:
+    name: Gitleaks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    # The default GITHUB_TOKEN no longer grants pull-requests: read, and
+    # gitleaks-action needs it in PR context to fetch the PR's commit list —
+    # without it the first PR run fails 403. Job-level to stay least-privilege.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      # Full history: a secret is only interesting if it was ever committed,
+      # and a shallow clone cannot see that.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   retired-paths:
     name: retired-paths validity
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,32 @@
 repos:
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.21.0
+    rev: v0.23.2
     hooks:
       - id: markdownlint-cli2
+
+  # shellcheck and actionlint as `repo: local` / system hooks rather than a
+  # mirror or a docker_image hook, per /setup-common's own guidance: prefer the
+  # binary the project already depends on, so the hook and CI cannot silently
+  # run different versions. The docker_image variants would also need a Docker
+  # daemon, which a podman machine does not necessarily provide.
+  #
+  # These need shellcheck and actionlint on PATH. Both are already assumed by
+  # this repo (CI runs them, and both are auto-approved in home/settings.json).
+  # If one is genuinely missing, `SKIP=shellcheck git commit ...` gets past it —
+  # CI is the source of truth and still runs both.
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+        description: the repo's payload is shell scripts; CI covered them, this catches them earlier
+        language: system
+        entry: shellcheck
+        types: [shell]
+
+      - id: actionlint
+        name: actionlint
+        description: lint workflow files before they reach CI
+        language: system
+        entry: actionlint
+        files: ^\.github/workflows/
+        types: [yaml]


### PR DESCRIPTION
`/setup-common` installs Dependabot and gitleaks in every project it touches, and the README's tooling matrix lists both under **Common**. Neither was configured here.

## Dependabot

`.github/dependabot.yml`, github-actions ecosystem, in the exact shape `setup-common` prescribes — weekly, `ci(deps)` prefix, labels, limit 5, and the `cooldown` block.

The SHA-pinning of the workflow actions is what made this necessary: correct, and the reason nothing would ever have bumped them.

## Gitleaks

A CI job using `gitleaks/gitleaks-action` **SHA-pinned** to v3.0.0, with:

- `fetch-depth: 0` — a secret is only interesting if it was ever committed, and a shallow clone can't see that;
- the job-level `permissions: pull-requests: read` that `setup-common` documents as required (the default token no longer grants it, and the first PR run 403s without it).

**Pre-checked before shipping it**: ran gitleaks 8.30.0 over all 81 commits of history locally — *no leaks found* — so this job goes green rather than landing red on its own PR.

## Pre-commit

- `markdownlint-cli2` **v0.21.0 → v0.23.2**.
- **shellcheck** and **actionlint** hooks. The repo's payload is shell scripts and CI was the only thing checking them.

Both new hooks are `repo: local` / `language: system` rather than mirrors or `docker_image` variants, for two reasons: `setup-common`'s own guidance says to prefer the binary the project already depends on so the hook and CI can't silently run different versions, and the `docker_image` variants need a Docker daemon, which a podman machine doesn't necessarily provide.

**Trade-off worth knowing**: system hooks hard-fail if the binary is missing, and `precommit-claude-hook` blocks commits on failure. Both tools are already assumed here (CI runs them, both are auto-approved in `home/settings.json`), and `SKIP=shellcheck git commit …` is the escape hatch. A comment in the config says so.

## Verification

- `pre-commit run --all-files` → markdownlint-cli2, shellcheck, actionlint all **Passed**.
- Confirmed the shellcheck hook actually *selects* the extensionless scripts rather than matching nothing: injecting an SC2086 into `home/bin/claude-prune-retired` made it fail on that file, and reverting made it pass. `types: [shell]` resolves them by shebang.
- `actionlint` clean; all three YAML files parse.

## Deliberately not included

`/setup-common` also installs a **Dependabot auto-merge workflow**. I've left it out — it's machinery that merges PRs without a human, it needs branch protection with required checks to be safe, and that's your call rather than something to add in passing.

## Conflict note

Touches `.github/workflows/ci.yml`, as do #194 (actionlint job) and #196 (new test job). Different hunks, but expect a possible trivial conflict depending on merge order.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_