### PR TITLE
Split the user policy into portable core, Claude adapter, and machine-local fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ restructure that introduced `home/` is on top of that history.
 ├── docs/                      # repo-meta: workflow docs and runbooks
 ├── .github/, .pre-commit-config.yaml, .markdownlint.yaml, .gitignore
 └── home/                      # ← THIS subdirectory mounts at ~/.claude/
-    ├── CLAUDE.md              → ~/.claude/CLAUDE.md  (universal policy)
+    ├── AGENTS.md              → ~/.claude/AGENTS.md  (portable policy core — every provider)
+    ├── CLAUDE.md              → ~/.claude/CLAUDE.md  (Claude adapter; imports the other two)
+    ├── local-machine.md       → ~/.claude/local-machine.md  (workstation-only guidance)
     ├── settings.json          → ~/.claude/settings.json
     ├── settings.json.md       → ~/.claude/settings.json.md  (annotated companion, kept alongside)
     ├── commands/              → ~/.claude/commands/

--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent policy
+
+Portable working policy, in AGENTS.md format. Everything here holds for any
+agent on any surface — Claude Code, Codex, OpenCode, local machine or cloud
+sandbox.
+
+Two companions carry what does *not* belong here:
+
+- `CLAUDE.md` — the Claude Code adapter: tool-name mappings and anything
+  meaningless to another provider. It imports this file.
+- `local-machine.md` — guidance that is only true on a workstation:
+  chezmoi, the interactive shell, macOS paths.
+
+Keep a statement in exactly one of the three. If a rule is portable it
+belongs here, and the adapter should reference it rather than restate it.
+
+## Git Workflow
+
+- Always create feature branches for changes — never commit directly to main
+- Open a pull request for every change; delete the branch on merge
+- **Merge method: `merge` by default, `squash` only to clean up a messy branch, never `rebase`.** Squash replaces a branch's commits with a new SHA, so anything built on that branch still carries the originals and re-applies work `main` already has — conflicts resolved against a change that already landed. Rebase-merge has the same defect for the same reason. A merge commit puts the branch's actual commits in `main`, so a dependent branch rebases to a no-op. Agentic PRs arrive as one or two already-written commits, so squash's benefit — collapsing WIP noise — is usually nothing, while its cost is paid every time. Reach for `squash` when the branch genuinely has fixup/WIP commits or several that aren't individually meaningful. The known trade-off: `git bisect` can descend into a commit that never passed CI on its own — use `git bisect --first-parent`, and `git log --first-parent` for the PR-level view
+- Watch the CI checks and ensure they pass
+- Don't merge your own PRs — let them be reviewed by someone else
+- Before pushing follow-up commits to a PR branch, always check the PR is still open. The user often reviews and merges PRs via the web UI while work continues — if already merged, create a new branch and PR instead
+- When multiple related changes span different concerns, ask the user whether to use one branch or separate branches before committing
+
+## Work Tracking
+
+- **All repos use GitHub Issues**, per the conventions in `agentic-coding-config` `docs/github-issues-workflow.md`:
+  - Create an issue before starting work; close it via `Closes #<n>` in the PR body
+  - Hierarchy via sub-issues; dependencies via blocked-by
+  - Priority labels `P0`–`P4`; type labels `type: epic|feature|task|bug` (issue types are org-only — labels ARE the convention on personal repos)
+  - Some repos (e.g. `lifeos`) declare their own label taxonomy in their repo CLAUDE.md — that wins over the defaults above
+  - **Use issue listing or direct reads for anything time-sensitive — never issue search**: the search API is eventually consistent, so a just-created issue can be invisible to it for seconds to minutes. Deduplicate against a full list including closed issues, not search
+
+## Cross-Repo Work
+
+- **Never edit files in a repo other than the one this session is working in.** Any direction, any repo pair: a project session editing `agentic-coding-config`, an `agentic-coding-config` session editing `dotfiles`, a `dotfiles` session editing `paul-context`. Cross-repo edits bypass the issue queue, skip that repo's review/PR flow, and pollute the current session's context with unrelated work. This holds even when the other repo is already cloned and writable, and even when the change is one line
+- **File a detailed issue in the target repo instead.** This is encouraged, not a consolation prize — it's the sanctioned route. "Detailed" means implementable without rediscovering anything: exact file paths, the full snippet to add, the rationale, every gotcha already ruled out, and acceptance criteria. Write it so the fix is a mechanical edit for whoever picks it up
+- **Reading another repo is fine, and verifying beats assuming.** Cloning a repo read-only to check the real state of a file before writing the issue is good practice — a-c-c's README carried a copy of dotfiles' `.chezmoiexternal.toml.tmpl`, and the issue quoted the live file instead
+- **Say what you filed.** Report the issue number back in the session summary so the cross-repo thread isn't lost
+
+## Changing agent config
+
+- **To request a change to agent configuration, open a GitHub issue against `pmgledhill102/agentic-coding-config`.** Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the source actually lives
+- This is the route from **any** surface. A cloud sandbox has no agent config on disk to edit, and a local machine's copy is generated (see `local-machine.md`), so in both cases the issue is the change
+
+## Commit & PR Style
+
+- Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
+- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in shell commands — heredocs create multi-line commands that defeat prefix-matched permission rules, and ANSI-C quoting gets flagged for hiding characters
+- Prefer a tool's `--*-file` flag over inline content for anything multi-line: `--body-file=PATH` for issues and PRs, `--input` for API JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — the positive form of the heredoc ban above
+
+## Process Guidelines
+
+- **3 strikes rule**: After 3 failed attempts debugging the same issue, stop and question the entire approach before trying again
+- **Check release notes before upgrading CLI tools**: check the changelog or releases before upgrading. Breaking changes (e.g. dropped backends, renamed flags) waste significant time when discovered mid-migration
+- **Lint before pushing**: Always run the relevant linter/test suite locally before `git push`. Only push if everything passes — avoids CI round-trips
+- **Use native binaries over package runners**: When a linter/formatter is installed on PATH (`command -v <tool>`), invoke it directly (e.g. `markdownlint-cli2 "path"`) rather than wrapping it in `npx`/`pipx`/`uvx`. Wrappers introduce version drift from what CI and pre-commit use, are slower, and may trigger permission prompts
+- **Single-concern PRs**: Each PR should contain a single logical change. If multiple tasks are completed in a session, create separate PRs for each rather than bundling unrelated changes
+- **PR-stacking discipline**: only claim "stacked on" when the second branch literally has the first as parent (`git log --oneline first..second` shows just the second's commits). Branching both off `main` and writing "stacked on PR #N" in the body is misleading — reviewers can merge in any order, and the second PR's diff includes the first's changes. If they're truly independent, branch each from `main` and don't say stacked
+- **Batch reads before edits**: When modifying multiple files, read all target files first, then make all edits — avoids "file not read yet" errors on parallel edit calls
+- **Always create a tracking issue**: Even for quick single-file fixes, create a GitHub Issue in the repo before starting work — maintains the audit trail and keeps the habit consistent
+- **Web fetch blocked by a 403? Fall back to curl + pandoc**: Some sites (UESP, other MediaWiki / Cloudflare-fronted wikis) reject an agent fetcher's User-Agent before serving content. On HTTP 403, don't burn time on alternative URLs — go straight to:
+
+  ```sh
+  curl -sS -L -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15" "$URL" -o /tmp/page.html
+  pandoc -f html -t gfm --wrap=none /tmp/page.html -o /tmp/page.md
+  ```
+
+  Then read the markdown (or `grep` it for structured extraction). If the same site will be hit repeatedly, save the fetcher as a per-project script
+
+## Shell Scripts
+
+- **Target POSIX sh**: Avoid bash-only builtins (`mapfile`, `readarray`, `declare -A`). Be aware that `$(( expr ))` returns exit code 1 when the result is 0, which breaks `set -e`
+- **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your own call or in the user's terminal after you suggest them
+- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on this workstation
+- **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use a surgical edit tool for source changes

--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -1,4 +1,16 @@
-# CLAUDE.md
+# CLAUDE.md — Claude Code adapter
+
+Claude-specific guidance only. The portable policy is maintained once, in
+AGENTS.md format, and imported here; machine-local guidance is imported from
+`local-machine.md`.
+
+@AGENTS.md
+
+@local-machine.md
+
+Anything portable belongs in `AGENTS.md`, not here. This file is for what
+would be meaningless to Codex or OpenCode: Claude Code tool names, and the
+MCP servers configured on this surface.
 
 ## GitHub MCP
 
@@ -6,69 +18,23 @@
 - Common mappings: PRs (`create_pull_request`, `pull_request_read`, `update_pull_request`, `merge_pull_request`, `list_pull_requests`, `search_pull_requests`), reviews (`pull_request_review_write`, `add_comment_to_pending_review`, `add_reply_to_pull_request_comment`), issues (`issue_read`, `issue_write`, `list_issues`, `search_issues`, `add_issue_comment`), releases (`get_latest_release`, `list_releases`, `get_release_by_tag`), repo content (`get_file_contents`, `list_commits`, `get_commit`, `list_branches`, `create_branch`), search (`search_code`, `search_repositories`)
 - PR review workflow: create a pending review with `pull_request_review_write` (method: "create"), add line comments with `add_comment_to_pending_review`, then submit with `pull_request_review_write` (method: "submit_pending")
 
-## Git Workflow
+### How the portable rules map to these tools
 
-- Always create feature branches for changes -- never commit directly to main
-- Create PRs with `mcp__github__create_pull_request` and merge via `mcp__github__merge_pull_request` (`delete_branch: true`)
-- **Merge method: `merge` by default, `squash` only to clean up a messy branch, never `rebase`.** Squash replaces a branch's commits with a new SHA, so anything built on that branch still carries the originals and re-applies work `main` already has — conflicts resolved against a change that already landed. Rebase-merge has the same defect for the same reason. A merge commit puts the branch's actual commits in `main`, so a dependent branch rebases to a no-op. Agentic PRs arrive as one or two already-written commits, so squash's benefit — collapsing WIP noise — is usually nothing, while its cost is paid every time. Reach for `squash` when the branch genuinely has fixup/WIP commits or several that aren't individually meaningful. The known trade-off: `git bisect` can descend into a commit that never passed CI on its own — use `git bisect --first-parent`, and `git log --first-parent` for the PR-level view
-- Watch the CI checks and ensure they pass
-- Don't merge your own PRs - let them be reviewed by someone else
-- Before pushing follow-up commits to a PR branch, always check the PR is still open via `mcp__github__pull_request_read` (method: "get"). The user often reviews and merges PRs via the GitHub UI while work continues — if already merged, create a new branch and PR instead
-- When multiple related changes span different concerns, ask the user whether to use one branch or separate branches before committing
+`AGENTS.md` states the policy; these are the calls that carry it out here.
 
-## Agent Config (`~/.claude/` files)
+| Policy (AGENTS.md) | Claude Code |
+| --- | --- |
+| Open a PR, delete the branch on merge | `create_pull_request`; `merge_pull_request` with `delete_branch: true` |
+| Check the PR is still open before pushing follow-ups | `pull_request_read` (method: `get`) |
+| Create an issue before starting work | `issue_write` |
+| Sub-issue hierarchy and blocked-by dependencies | `sub_issue_write` |
+| Never use issue *search* for anything time-sensitive | `list_issues` or `issue_read`, never `search_issues` |
+| Check release notes before upgrading a CLI tool | `get_latest_release` / `list_releases` |
 
-- **`~/.claude/` is chezmoi-managed from `pmgledhill102/agentic-coding-config`.** Do not edit these files directly — chezmoi will overwrite on the next apply and the change is lost. This includes `~/.claude/CLAUDE.md` itself, `~/.claude/settings.json`, slash commands under `~/.claude/commands/`, hooks, scripts under `~/.claude/bin/`, everything sourced from the `home/` directory of that repo.
-- **To request a change, open a GitHub issue against `pmgledhill102/agentic-coding-config`** (auto-approved via `gh issue create --repo pmgledhill102/*` — keep `--repo` as the first flag for the allow rule to match). Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the chezmoi source actually lives.
-- The same applies in reverse — see Cross-Repo Work below. An `agentic-coding-config` session doesn't get to edit `dotfiles` either.
+- `gh` equivalents remain correct when the MCP server is unavailable: `gh issue create --repo pmgledhill102/*` is auto-approved, and keeping `--repo` as the first flag is what makes the allow rule match
 
-## Cross-Repo Work
+## Other MCP servers
 
-- **Never edit files in a repo other than the one this session is working in.** Any direction, any repo pair: a project session editing `agentic-coding-config`, an `agentic-coding-config` session editing `dotfiles`, a `dotfiles` session editing `paul-context`. Cross-repo edits bypass the issue queue, skip that repo's review/PR flow, and pollute the current session's context with unrelated work. This holds even when the other repo is already cloned and writable, and even when the change is one line
-- **File a detailed issue in the target repo instead.** This is encouraged, not a consolation prize — it's the sanctioned route. "Detailed" means implementable without rediscovering anything: exact file paths, the full snippet to add, the rationale, every gotcha already ruled out, and acceptance criteria. Write it so the fix is a mechanical edit for whoever picks it up
-- **Reading another repo is fine, and verifying beats assuming.** Cloning a repo read-only to check the real state of a file before writing the issue is good practice — a-c-c's README carried a copy of dotfiles' `.chezmoiexternal.toml.tmpl`, and the issue quoted the live file instead
-- **Say what you filed.** Report the issue number back in the session summary so the cross-repo thread isn't lost
-
-## Work Tracking
-
-- **All repos use GitHub Issues**, per the conventions in `agentic-coding-config` `docs/github-issues-workflow.md`:
-  - Create an issue before starting work; close it via `Closes #<n>` in the PR body
-  - Hierarchy via sub-issues (`gh issue create --parent <n>`); dependencies via `--blocked-by`
-  - Priority labels `P0`–`P4`; type labels `type: epic|feature|task|bug` (issue types are org-only — labels ARE the convention on personal repos)
-  - Some repos (e.g. `lifeos`) declare their own label taxonomy in their repo CLAUDE.md — that wins over the defaults above
-  - **Use `gh issue list` or direct reads (`gh issue view <n>`) for anything time-sensitive — never `gh search issues`**: the search API is eventually consistent, so a just-created issue can be invisible to it for seconds to minutes. Deduplicate against `gh issue list --state all`, not search
-
-## Commit & PR Style
-
-- Use multiple `-m` flags for multi-paragraph commit messages: `git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`
-- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in bash commands — heredocs create multi-line bash that doesn't match permission rules, and ANSI-C quoting gets flagged for hiding characters
-
-## Process Guidelines
-
-- **3 strikes rule**: After 3 failed attempts debugging the same issue, stop and question the entire approach before trying again
-- **Check release notes before upgrading CLI tools**: Use `mcp__github__get_latest_release` / `mcp__github__list_releases` or check the changelog before upgrading. Breaking changes (e.g., dropped backends, renamed flags) waste significant time when discovered mid-migration
-- **Test chezmoi template changes locally before pushing**: Use `HOME=/tmp/test chezmoi init --source <path> --dry-run` to verify behaviour in a clean environment before relying on CI
-- **Lint before pushing**: Always run the relevant linter/test suite locally before `git push`. Only push if everything passes — avoids CI round-trips
-- **Use native binaries over package runners**: When a linter/formatter is installed on PATH (`which <tool>`), invoke it directly (e.g. `markdownlint-cli2 "path"`) rather than wrapping it in `npx`/`pipx`/`uvx`. Wrappers introduce version drift from what CI and pre-commit use, are slower, and may trigger permission prompts
-- **Single-concern PRs**: Each PR should contain a single logical change. If multiple tasks are completed in a session, create separate PRs for each rather than bundling unrelated changes
-- **PR-stacking discipline**: only claim "stacked on" when the second branch literally has the first as parent (`git log --oneline first..second` shows just the second's commits). Branching both off `main` and writing "stacked on PR #N" in the body is misleading — reviewers can merge in any order, and the second PR's diff includes the first's changes. If they're truly independent, branch each from `main` and don't say stacked
-- **Batch reads before edits**: When modifying multiple files, read all target files first, then make all edits — avoids "file not read yet" errors on parallel Edit calls
-- **Always create a tracking issue**: Even for quick single-file fixes, create a GitHub Issue in the repo before starting work — maintains the audit trail and keeps the habit consistent
-- **WebFetch 403? Fall back to curl + pandoc**: Some sites (UESP, other MediaWiki / Cloudflare-fronted wikis) reject WebFetch's User-Agent before serving content. On HTTP 403, don't burn time on alternative URLs — go straight to:
-
-  ```sh
-  curl -sS -L -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15" "$URL" -o /tmp/page.html
-  pandoc -f html -t gfm --wrap=none /tmp/page.html -o /tmp/page.md
-  ```
-
-  Then `Read` the markdown (or `grep` it for structured extraction). If the same site will be hit repeatedly, save the fetcher as a per-project script
-
-## Shell Scripts
-
-- **Target POSIX sh or ensure macOS/zsh compatibility**: Avoid bash-only builtins (`mapfile`, `readarray`, `declare -A`). Be aware that `$(( expr ))` returns exit code 1 when result is 0 (breaks `set -e`), and empty arrays behave differently in zsh with `set -u`
-- **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your bash call or in the user's terminal after you suggest them
-- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, `Write` a script to the scratchpad and run `bash script.sh` rather than composing the loop in the Bash call. The interactive shell is **zsh**, which differs from bash in two ways that fail silently:
-  - **No word-splitting on unquoted variables.** `set -- $TWO_WORDS` splits into two arguments in bash and stays one argument in zsh, so the loop runs once with a joined value and downstream parsing fails somewhere unrelated. zsh needs `${=VAR}` or a real array
-  - **`:` is a modifier.** `"$MODEL:generateContent"` flirts with zsh's `:g`-style parameter-modifier parsing; write `${MODEL}:generateContent`. Bare `$VAR:` in a URL is a trap
-- **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use the `Edit` tool for surgical source changes
-- **Prefer a tool's `--*-file` flag over inline content**: `gh issue create --body-file=PATH`, `gh pr create --body-file=PATH`, `--input` for `gh api` JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — this is the positive form of the heredoc ban above
+Configured per-machine via `claude mcp add` and stored in `~/.claude.json`,
+not in this repo. `home/settings.json.md` records which of their tools are
+auto-approved and why.

--- a/home/commands/retrospective.md
+++ b/home/commands/retrospective.md
@@ -101,7 +101,7 @@ Permissions, hooks, env vars and everything else in `~/.claude/settings.json` ar
 When a finding clearly mentions a target, route there. Otherwise apply this default split:
 
 - **Brewfile / package lists / shell config / OS bootstrap / chezmoi machinery** → `dotfiles`
-- **Slash commands / hooks / `~/.claude/settings.json` / MCP server config / `home/CLAUDE.md`** → `agentic-coding-config`
+- **Slash commands / hooks / `~/.claude/settings.json` / MCP server config / the policy files (`home/AGENTS.md` portable, `home/CLAUDE.md` Claude-specific, `home/local-machine.md` workstation-only)** → `agentic-coding-config`
 - **Engineering principles / personal direction / repo registry / archive list / decisions** → `paul-context`
 - **Genuinely unsorted / "I had a thought"** → `paul-context` (default fallback)
 

--- a/home/commands/setup-common.md
+++ b/home/commands/setup-common.md
@@ -320,7 +320,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-`--squash` here is deliberate and is the one place it stays. The global default is merge-commit (see the Git Workflow section of `~/.claude/CLAUDE.md`), because squash's SHA rewrite punishes stacked branches — but a Dependabot PR is a single-commit version bump that nothing is ever stacked on, and one commit per bump keeps `main` readable. Don't "fix" this to match the default.
+`--squash` here is deliberate and is the one place it stays. The global default is merge-commit (see the Git Workflow section of `~/.claude/AGENTS.md`), because squash's SHA rewrite punishes stacked branches — but a Dependabot PR is a single-commit version bump that nothing is ever stacked on, and one commit per bump keeps `main` readable. Don't "fix" this to match the default.
 
 Also ensure `.github/dependabot.yml` exists with the base structure. If it doesn't exist, create it:
 

--- a/home/local-machine.md
+++ b/home/local-machine.md
@@ -1,0 +1,56 @@
+# Machine-local guidance
+
+True only on a workstation. Nothing here applies in a cloud sandbox, and
+this file is deliberately not part of the portable core: a sandbox has no
+chezmoi, no `~/.claude/` to be overwritten, and a different shell.
+
+Imported by `CLAUDE.md`. Portable policy lives in `AGENTS.md`.
+
+## `~/.claude/` is generated — do not edit it here
+
+**`~/.claude/` is chezmoi-managed from `pmgledhill102/agentic-coding-config`.**
+Do not edit these files directly — chezmoi will overwrite them on the next
+apply and the change is lost. This includes `~/.claude/CLAUDE.md` itself,
+`~/.claude/AGENTS.md`, this file, `~/.claude/settings.json`, slash commands
+under `~/.claude/commands/`, hooks, and scripts under `~/.claude/bin/` —
+everything sourced from the `home/` directory of that repo.
+
+To change any of it, open an issue against `agentic-coding-config`; see
+"Changing agent config" in `AGENTS.md`. The same applies in reverse — an
+`agentic-coding-config` session doesn't get to edit `dotfiles` either.
+
+A merge to that repo does **not** reach this machine immediately. The
+external carries a `refreshPeriod` of 168h, so a plain `chezmoi apply` can
+re-apply the cached archive: use `chezmoi apply --refresh-externals` (or
+`chezmoi update --refresh-externals`) when you specifically need a change
+that just merged.
+
+## The interactive shell is zsh
+
+Two differences from bash bite silently, which is why loops belong in a
+script file run with `sh` or `bash` rather than composed inline:
+
+- **No word-splitting on unquoted variables.** `set -- $TWO_WORDS` splits
+  into two arguments in bash and stays one argument in zsh, so the loop runs
+  once with a joined value and downstream parsing fails somewhere unrelated.
+  zsh needs `${=VAR}` or a real array
+- **`:` is a modifier.** `"$MODEL:generateContent"` flirts with zsh's
+  `:g`-style parameter-modifier parsing; write `${MODEL}:generateContent`.
+  A bare `$VAR:` in a URL is a trap
+
+Empty arrays also behave differently in zsh under `set -u`.
+
+## Testing chezmoi template changes
+
+Verify behaviour in a clean environment before relying on CI:
+
+```sh
+HOME=/tmp/chezmoi-test chezmoi init --source <path> --dry-run
+```
+
+## Local scratch space
+
+`/tmp` on macOS is per-user and ephemeral, and is the standard place for
+staging multi-line content (issue bodies, PR bodies) before passing it to a
+tool via `--body-file`. Note that macOS resolves `/tmp` to `/private/tmp`,
+which is why permission rules carry both spellings.


### PR DESCRIPTION
Implements ADR-0014 decision 2. `home/CLAUDE.md` mixed three audiences; this separates them.

| File | Audience | Contents |
| --- | --- | --- |
| `home/AGENTS.md` (new, 78 lines) | every agent, every surface | Git Workflow, Work Tracking, Cross-Repo Work, Changing agent config, Commit & PR Style, Process Guidelines, portable half of Shell Scripts |
| `home/CLAUDE.md` (40 lines) | Claude Code only | GitHub MCP section + the policy→tool mapping table |
| `home/local-machine.md` (new, 56 lines) | workstation only | chezmoi ownership of `~/.claude/`, zsh traps, template testing, macOS `/tmp` |

`CLAUDE.md` imports the other two via the `CLAUDE.md` → `@AGENTS.md` bridge that ADR-0014 names.

## On "no policy statement exists in two places"

The core states each rule provider-neutrally. Where the old text had Claude tool names welded into the policy — *"Create PRs with `mcp__github__create_pull_request` and merge via `mcp__github__merge_pull_request` (`delete_branch: true`)"* — the core now states what the rule requires ("open a PR for every change; delete the branch on merge") and the adapter carries a mapping table:

| Policy (AGENTS.md) | Claude Code |
| --- | --- |
| Open a PR, delete the branch on merge | `create_pull_request`; `merge_pull_request` with `delete_branch: true` |
| Check the PR is still open before pushing follow-ups | `pull_request_read` (method: `get`) |
| Never use issue *search* for anything time-sensitive | `list_issues` or `issue_read`, never `search_issues` |

That's a reference, not a restatement — the table would be wrong to read as policy on its own.

## Sandbox-sense for the sections the issue flagged

- **Agent Config** split in two. "Open an issue against `agentic-coding-config` to request a change" is portable and moved to the core as *Changing agent config*, with a line making it explicit that this is the route from **any** surface — a sandbox has no config on disk to edit, and a laptop's copy is generated. "chezmoi will overwrite" stayed in `local-machine.md`, where it is true.
- **Cross-Repo Work** was already surface-neutral and moved intact.
- The `WebFetch` guidance is now "web fetch blocked by a 403", since the tool is named differently on each provider.

## Also updated

The three places that pointed at the old single file: the README layout tree, `setup-common`'s cross-reference to the Git Workflow section, and `retrospective`'s config-routing rule.

`home/settings.json.md` mentions "user-level CLAUDE.md forbids heredocs" — still true, since `CLAUDE.md` imports the rule, and left alone deliberately: touching it would trip the settings-sync CI job, which requires `settings.json` to change alongside it.

## What this does *not* do

**Delivery.** A cloud session still doesn't receive the core — nothing reads `~/.claude/` there. Getting it to a sandbox is the plugin cutover (#48) and the skills conversion (#137); this PR makes the core exist in the right format so those have something to ship. The second half of the acceptance criterion ("a cloud session receives exactly the sections that apply to it") is therefore only half met here, and I'd rather say so than imply otherwise.

## Verification

`markdownlint-cli2 "**/*.md"` — 0 issues across 38 files.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_