### PR TITLE
Write down the ephemeral-first engineering principles

### DIFF
--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -1,5 +1,10 @@
 # CLAUDE.md
 
+Ephemeral-first engineering principles are maintained separately, because
+they are portable policy rather than Claude-specific:
+
+@ephemeral-first.md
+
 ## GitHub MCP
 
 - **Prefer `mcp__github__*` tools over the `gh` CLI for all GitHub operations** when the GitHub MCP server is connected. Only fall back to `gh` if the MCP server is unavailable or a specific capability is missing

--- a/home/ephemeral-first.md
+++ b/home/ephemeral-first.md
@@ -1,0 +1,72 @@
+# Ephemeral-first engineering
+
+Portable policy. Applies to any agent session, on any surface.
+
+Agent sandboxes are disposable, and their lifetime is becoming a tunable
+rather than a fixed assumption. The governing principle is **decoupling: how
+agents work must not depend on how long the environment lives.** At a long
+TTL, in-place continuity is a convenience; at a short one, nothing about the
+workflow should change.
+
+The same forcing function ephemeral CI runners applied to builds applies
+here. When the environment dies regularly, reproducibility stops being
+discipline and becomes physics.
+
+## 1. Environment-as-script
+
+Setup is **committed, idempotent, and identical for a fresh environment and
+a resume.** The contents of a sandbox must be reconstructible from the repo.
+
+- Anything installed by hand is lost, and worse, invisible: the next session
+  starts subtly different from this one and nobody knows why
+- "Idempotent" is not optional. The same script runs on a cold start and on
+  a resume, so every step has to tolerate already having been done
+- If you install something mid-session to get unblocked, the work is not
+  finished until that install is in the setup script — or in an issue asking
+  for it. A session that only works because of what you typed into it is a
+  session that cannot be repeated
+
+## 2. The repo is the default durable output channel — for what repos are for
+
+Docs, scripts, code, configuration. Commit early rather than at the end: an
+uncommitted change is one reclaimed container away from never having existed.
+
+It is **not** the channel for testing datasets, fixtures, generated
+artifacts, or bulk output. A repo used as a filesystem stops being reviewable
+and starts being a place things go to be forgotten. If the thing is large,
+binary, regenerable, or uninteresting to a reviewer, it does not belong in
+git — see principle 3.
+
+## 3. Durable storage is a separate, explicitly granted capability
+
+Anything that must outlive the sandbox goes somewhere granted for the
+purpose. **Never assumed.**
+
+- Do not invent a location. A bucket, a volume, or a database that a session
+  decided on unilaterally is one nobody else knows to look in, nobody is
+  paying attention to, and nobody has scoped access for
+- If a task needs durable storage and none has been granted, say so and stop,
+  the same way a task needing credentials says so and stops. "I put it
+  somewhere" is not an answer
+- Absence of a granted store is a finding worth reporting, not an obstacle to
+  route around
+
+## 4. Agent-built infrastructure checkpoints its state externally
+
+Terraform state written inside a disposable environment means every
+re-provision starts with archaeology — reconciling real cloud resources
+against a state file that died with its container.
+
+- Remote state from the first `terraform init`, not once it hurts
+- The same holds for anything else that records what exists: migration
+  version tables, deployment ledgers, resource inventories
+- State that lives only in the sandbox converts a routine re-provision into
+  an incident
+
+## What this means in practice
+
+Before ending a session, ask: **if this environment were destroyed right
+now, what would be lost?** Every answer is either something that should have
+been committed, something that needs a granted durable store, or something
+that was never worth keeping. There is no fourth category, and "it is fine,
+the sandbox will still be here" is not one of the three.


### PR DESCRIPTION
Adds `home/ephemeral-first.md` — the four principles from #197, written as portable policy, imported from `home/CLAUDE.md`.

## The framing

Decoupling: **how agents work must not depend on how long the environment lives.** At a long TTL, in-place continuity is a convenience; at a short one, nothing about the workflow should change. Same forcing function ephemeral CI runners applied to builds.

## The four

1. **Environment-as-script** — committed, idempotent, identical for a fresh environment and a resume. With the consequence spelled out: if you install something mid-session to get unblocked, the work isn't finished until that install is in the setup script or in an issue asking for it.
2. **The repo is the default durable output channel — for what repos are for.** Docs, scripts, code. Explicitly *not* datasets, fixtures, or bulk artifacts, with the test for which is which (large, binary, regenerable, uninteresting to a reviewer → not git).
3. **Durable storage is a separate, explicitly granted capability.** The operative rule is *don't invent a location* — a bucket a session chose unilaterally is one nobody looks in and nobody scoped access for. Modelled on how the credential skill handles missing credentials: say so and stop, and treat the absence as a finding worth reporting rather than an obstacle to route around.
4. **Agent-built infrastructure checkpoints state externally.** Remote state from the first `terraform init`, not once it hurts; extends to migration tables, deployment ledgers, resource inventories.

It closes with the question that makes the principles operational at session end: *if this environment were destroyed right now, what would be lost?* — every answer is something that should have been committed, something needing a granted store, or something not worth keeping.

## Placement

Its own file rather than a section of `home/CLAUDE.md`, because none of it is Claude-specific. The issue offered "the AGENTS.md core or a skill"; the core doesn't exist on `main` yet (#138), so this is written to drop into it unchanged.

## Conflict note

The one-line import in `home/CLAUDE.md` will conflict with **#138**, which rewrites that file. Resolution is small and worth stating: if #138 merges first, move `@ephemeral-first.md` out of `CLAUDE.md` and into `AGENTS.md`'s companion list, where it belongs — the file itself needs no edit either way.

## Related

Principle 3 has a companion capability being designed in the estate repo; this states the client-side rule, not the mechanism.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_