### PR TITLE
Implement the tiered-ADR conventions from ADR-0015

### DIFF
--- a/adrs/0012-claude-code-config-via-dotfiles.md
+++ b/adrs/0012-claude-code-config-via-dotfiles.md
@@ -3,6 +3,7 @@
 - **Status**: Superseded — see note at end. Original status: Accepted (2026-04-26).
 - **Date**: 2026-04-26
 - **Tags**: claude-code, tooling
+- **Scope**: user (applies to all personal repos and agent surfaces)
 
 ## Context
 

--- a/adrs/0013-github-issues-for-work-tracking.md
+++ b/adrs/0013-github-issues-for-work-tracking.md
@@ -3,6 +3,7 @@
 - **Status**: Accepted (2026-07-14)
 - **Date**: 2026-07-14
 - **Tags**: workflow, tooling, issue-tracking
+- **Scope**: user (applies to all personal repos)
 
 ## Context
 

--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -6,6 +6,31 @@
 - Common mappings: PRs (`create_pull_request`, `pull_request_read`, `update_pull_request`, `merge_pull_request`, `list_pull_requests`, `search_pull_requests`), reviews (`pull_request_review_write`, `add_comment_to_pending_review`, `add_reply_to_pull_request_comment`), issues (`issue_read`, `issue_write`, `list_issues`, `search_issues`, `add_issue_comment`), releases (`get_latest_release`, `list_releases`, `get_release_by_tag`), repo content (`get_file_contents`, `list_commits`, `get_commit`, `list_branches`, `create_branch`), search (`search_code`, `search_repositories`)
 - PR review workflow: create a pending review with `pull_request_review_write` (method: "create"), add line comments with `add_comment_to_pending_review`, then submit with `pull_request_review_write` (method: "submit_pending")
 
+## Decision records (ADR tiers)
+
+Decisions are recorded at three tiers, per
+[ADR-0015](https://github.com/pmgledhill102/agentic-coding-config/blob/main/adrs/0015-tiered-adrs.md).
+Every ADR declares which with a `Scope:` header line, so its blast radius is
+stated rather than inferred from where it sits.
+
+| Tier | Home | Holds |
+| --- | --- | --- |
+| **Personal** | `paul-context/decisions/` | Life/estate decisions, private rationale (private repo) |
+| **User** | [`agentic-coding-config/adrs/`](https://github.com/pmgledhill102/agentic-coding-config/tree/main/adrs) | How I work with agents and repos, across the estate |
+| **Repo** | `<repo>/adrs/` | Architecture and technology choices for that repo |
+
+- **User-tier ADRs bind every repo.** They are public, so a sandbox session
+  with no local clone can read them at the URL above. Consult them on demand;
+  never copy them into a repo, because a copy drifts
+- **Placement follows scope, not convenience.** The authoring test: *would
+  this decision still bind if the current repo were archived?* If yes, it is
+  not repo-tier
+- **A repo may deviate from a higher tier, but only explicitly.** The repo
+  ADR must name the ADR it deviates from and why. Silent divergence is the
+  failure this rule exists to prevent
+- Numbering is per-directory; cross-tier references use full URLs, which also
+  work from sandboxes
+
 ## Git Workflow
 
 - Always create feature branches for changes -- never commit directly to main

--- a/home/commands/repo-review.md
+++ b/home/commands/repo-review.md
@@ -123,6 +123,44 @@ For each ADR file (`*.md` in the detected ADR directory):
 
 4. Output a table: ADR file → status → finding → suggested action ("update", "supersede", "delete", "no action").
 
+### Phase A2 — Tier fit
+
+Per [ADR-0015](https://github.com/pmgledhill102/agentic-coding-config/blob/main/adrs/0015-tiered-adrs.md),
+every ADR declares a tier with a `Scope:` header line — `personal`, `user` or
+`repo` — and placement is meant to follow scope rather than convenience. This
+check is the backstop for that; it is a review prompt, not enforcement.
+
+For each ADR, additionally:
+
+1. **Missing scope.** No `Scope:` line → flag it, and suggest one from the
+   authoring test below. Don't guess silently; the point of the header is
+   that the blast radius is stated rather than inferred.
+
+2. **Outgrown its tier.** Apply the authoring test — *would this decision
+   still bind if this repo were archived?* If yes and it is `Scope: repo`,
+   flag it for promotion to the user tier
+   (`agentic-coding-config/adrs/`), leaving a stub behind that links to
+   the new home. Signals worth searching for:
+   - the ADR's own text generalises beyond this repo ("every repo", "all my
+     projects", "across the estate")
+   - another repo is known to depend on the decision, or the ADR is
+     referenced by URL from outside this repo
+
+3. **Undeclared deviation.** A repo-tier ADR that contradicts a user-tier
+   decision must say so — naming the ADR it deviates from and why. A repo ADR
+   that quietly reverses a user-tier decision without referencing it is the
+   failure mode the tier model exists to prevent, so flag it as a finding in
+   its own right rather than as a style nit. The user-tier set is listed at
+   <https://github.com/pmgledhill102/agentic-coding-config/tree/main/adrs>
+   and is readable from a sandbox with no local clones.
+
+Suggested actions for this phase: "add Scope:", "promote to user tier +
+stub", "declare the deviation", "no action".
+
+Note that promotion is a **cross-repo** change: per the cross-repo rule, do
+not edit the other repo. File an issue against `agentic-coding-config`
+containing the ADR's full text and the reason for promotion.
+
 ## Phase B — Dependency currency
 
 Run the per-language scanners. Each scanner is invoked once. **Run synchronously** — do not background. Aggregate the JSON or text output into a structured findings list.
@@ -291,6 +329,7 @@ Print to chat. Use the structure:
 
 ADRs (<N> found)
   - <file>  <STATUS>  <one-line reason>
+  Tier fit: <N> missing Scope:, <N> outgrown their tier, <N> undeclared deviations
 
 Dependencies
   Outdated: <N> (major: <a>, minor: <b>, patch: <c>)


### PR DESCRIPTION
ADR-0015 was ratified in August and never implemented. Three of its four mechanical steps land here.

## 1. `Scope:` headers

Added to **0012** and **0013** (both `user`). 0014, 0015 and 0016 already carried theirs — so the gap was two files, not four as the issue estimated.

## 2. Tier model in the policy file

A new *Decision records (ADR tiers)* section covering:

- the three homes (personal / user / repo) and what each holds;
- **user-tier ADRs bind every repo**, are public, and are readable at their URL from a sandbox with no local clone — consulted on demand, never copied, because a copy drifts (which is the reason for the tier model rather than a duplicated set);
- the authoring test for placement: *would this decision still bind if the current repo were archived?*
- deviation is allowed but only explicitly, naming the ADR deviated from.

## 3. `/repo-review` tier-fit check

New **Phase A2**, with three findings and their suggested actions:

| Finding | Action |
| --- | --- |
| No `Scope:` line | "add Scope:" — suggest one from the authoring test, don't guess silently |
| Repo-tier ADR that outgrew its tier | "promote to user tier + stub" |
| Repo ADR contradicting a user-tier decision without saying so | "declare the deviation" |

The third is flagged as a finding in its own right rather than a style nit, since silent divergence is the failure the tier model exists to prevent. It also gives the promotion path correctly: promotion is a **cross-repo** change, so the action is an issue against `agentic-coding-config`, not an edit — per the repo's own cross-repo rule.

The summary template gains a `Tier fit:` line so the counts show up in the report.

## 4. The `paul-context` note — not done, and can't be

Step 4 asks for a note in `paul-context` that `decisions/` is formally the personal tier. That repo isn't in this session's scope, and the cross-repo rule says to file an issue rather than edit it. **I couldn't file that issue either** — `paul-context` isn't reachable from here. So it's outstanding and needs one of:

- an issue against `paul-context` saying `decisions/` is the personal tier per ADR-0015, or
- a `journal-draft` entry, per the retrospective flow.

Flagging rather than silently dropping it, since the acceptance criteria for #141 don't cover it but the issue body does.

## Placement note

The tier model went into `home/CLAUDE.md`, which is where user policy lives on `main`. #138 splits that file into a portable core, and this section is portable — if #138 merges first, this belongs in `home/AGENTS.md` instead. Expect a small conflict either way; the content moves unchanged.

## Verification

`markdownlint-cli2 "**/*.md"` — 0 issues. All five ADRs now carry a `Scope:` line.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_