### PR TITLE
Surface deployed-config drift at session start

### DIFF
--- a/home/bin/start-session-claude-drift
+++ b/home/bin/start-session-claude-drift
@@ -1,0 +1,136 @@
+#!/bin/sh
+# start-session-claude-drift — report whether the deployed ~/.claude tree still
+# matches the agentic-coding-config source.
+#
+# A chezmoi-managed file can be fixed in the repo and keep running the old
+# version on a machine for as long as nobody applies there, and nothing says
+# so. On 2026-08-13 that produced a two-commit gap on `bin/gcp-credentials`:
+# the repo had the request/wait split, the Mac had a helper from the day
+# before, and local and cloud had silently diverged in behaviour on a security
+# control. It was only found by comparing line counts on a hunch.
+#
+# The failure is not forgetting to apply. It is that nothing distinguishes
+# "this machine is current" from "this machine is a day behind", so there is
+# nothing to forget about. This makes that difference visible at session start.
+#
+# It never applies anything. Applying config changes under an agent, without
+# the human seeing them, is its own hazard -- and this repo deploys the harness
+# the agent is running inside.
+#
+# Output protocol (stdout, one key=value or list line per row):
+#   state=absent          no deployed tree (a sandbox) -- nothing to compare
+#   state=no-source       not in an agentic-coding-config checkout
+#   state=compared        a file-by-file comparison ran
+#   behind=<n>            deployed file differs and the repo copy is newer
+#   modified=<n>          deployed file differs and the deployed copy is newer
+#   behind: <path>        one per file, capped
+#   modified: <path>      one per file, capped
+#
+# Exit status is 0 whenever the check ran, whatever it found: this is a
+# reporting step, not a gate.
+
+set -u
+
+CLAUDE_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+MAX_LIST=10
+
+# A cloud sandbox has no deployed tree and no chezmoi. Say so and stop, rather
+# than reporting a scary-looking zero.
+if [ ! -d "$CLAUDE_DIR" ]; then
+    echo "state=absent"
+    echo "note=no ~/.claude on this surface (sandbox); nothing is deployed to drift"
+    exit 0
+fi
+
+# The comparison needs the source. Being *in* the agentic-coding-config
+# checkout is the case that matters: it is where this drift is both most likely
+# (the file being actively fixed is the one most likely to be stale) and most
+# consequential.
+ROOT=""
+if git rev-parse --show-toplevel > /dev/null 2>&1; then
+    candidate=$(git rev-parse --show-toplevel)
+    if git -C "$candidate" remote get-url origin 2> /dev/null | grep -q 'agentic-coding-config' &&
+        [ -d "$candidate/home" ]; then
+        ROOT="$candidate"
+    fi
+fi
+
+if [ -z "$ROOT" ]; then
+    # Outside the checkout there is nothing to diff against without a network
+    # fetch, which is too expensive for every session start. Fall back to how
+    # old the deployed tree is: the archive external carries a 168h refresh
+    # period, so anything older than that is due a refresh regardless.
+    newest=$(find "$CLAUDE_DIR" -maxdepth 2 \
+        \( -name projects -o -name todos -o -name plugins -o -name statsig \) -prune -o \
+        -type f -print 2> /dev/null |
+        while IFS= read -r f; do
+            stat -c %Y "$f" 2> /dev/null || stat -f %m "$f" 2> /dev/null
+        done | sort -n | tail -1)
+    echo "state=no-source"
+    if [ -n "$newest" ]; then
+        age_days=$((($(date -u '+%s') - newest) / 86400))
+        echo "applied_days_ago=$age_days"
+        if [ "$age_days" -ge 7 ]; then
+            echo "note=deployed tree last changed ${age_days}d ago, past the 168h refresh period — 'chezmoi apply --refresh-externals' if a recent a-c-c merge matters here"
+        fi
+    fi
+    exit 0
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+: > "$TMP/behind"
+: > "$TMP/modified"
+
+# Walk the source rather than the target: ~/.claude also holds Claude Code's
+# own runtime state (projects/, todos/, history.jsonl) and files retired from
+# the repo but never pruned, and neither is drift of the kind meant here.
+# (Retired-but-present is #125, and /end-session step 11 already covers it.)
+cd "$ROOT/home" || exit 0
+find . -type f -print 2> /dev/null | sed 's|^\./||' | while IFS= read -r rel; do
+    deployed="$CLAUDE_DIR/$rel"
+
+    if [ ! -e "$deployed" ]; then
+        echo "$rel (never deployed)" >> "$TMP/behind"
+        continue
+    fi
+
+    # The common case by far, and the only one that costs anything per file.
+    cmp -s "$rel" "$deployed" && continue
+
+    # They differ. Which direction? The repo copy's last commit time against
+    # the deployed copy's mtime separates "this machine has not applied yet"
+    # from "somebody edited the generated tree in place" -- different problems
+    # with different fixes, and conflating them makes the message ignorable.
+    src_epoch=$(git -C "$ROOT" log -1 --format=%ct -- "home/$rel" 2> /dev/null || echo 0)
+    [ -n "$src_epoch" ] || src_epoch=0
+    dep_epoch=$(stat -c %Y "$deployed" 2> /dev/null || stat -f %m "$deployed" 2> /dev/null || echo 0)
+
+    if [ "$dep_epoch" -gt "$src_epoch" ]; then
+        echo "$rel" >> "$TMP/modified"
+    else
+        echo "$rel" >> "$TMP/behind"
+    fi
+done
+
+n_behind=$(wc -l < "$TMP/behind" | tr -d ' ')
+n_modified=$(wc -l < "$TMP/modified" | tr -d ' ')
+
+echo "state=compared"
+echo "source=$ROOT/home"
+echo "behind=$n_behind"
+echo "modified=$n_modified"
+
+if [ "$n_behind" -gt 0 ]; then
+    head -n "$MAX_LIST" "$TMP/behind" | sed 's/^/behind: /'
+    [ "$n_behind" -gt "$MAX_LIST" ] && echo "behind: ... and $((n_behind - MAX_LIST)) more"
+    echo "remedy_behind=chezmoi apply --refresh-externals"
+fi
+
+if [ "$n_modified" -gt 0 ]; then
+    head -n "$MAX_LIST" "$TMP/modified" | sed 's/^/modified: /'
+    [ "$n_modified" -gt "$MAX_LIST" ] && echo "modified: ... and $((n_modified - MAX_LIST)) more"
+    echo "remedy_modified=hand-edits to ~/.claude are lost on the next apply — move the change into the repo"
+fi
+
+exit 0

--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -189,6 +189,11 @@ run_sh gh_assigned '
         '\''
 '
 
+# Deployed-config drift. Cheap (a cmp per file, and nothing else unless one
+# differs), and silent when everything is current. Lives in its own script
+# because the direction-of-drift logic does not belong inline in a `sh -c`.
+run_section claude_drift "$(dirname "$0")/start-session-claude-drift"
+
 export PRE_FETCH_DEFAULT_SHA
 
 # shellcheck disable=SC2016
@@ -241,6 +246,6 @@ if [ "$FETCH_EXIT" -ne 0 ]; then
 fi
 printf '\n'
 
-for s in local_state main_ci recent_main_commits gh_ready gh_assigned; do
+for s in local_state main_ci recent_main_commits gh_ready gh_assigned claude_drift; do
     [ -f "$TMP/$s.exit" ] && emit "$s"
 done

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -71,6 +71,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |
 | `gh_ready` | 7 | Content `not-github` / `gh-unavailable` / `jq-unavailable` = silent skip. Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
 | `gh_assigned` | 7 | Same skip convention as `gh_ready`. Empty content = nothing in flight. Otherwise pipe-separated rows: `#<n>\|P<pri>\|<title>` for open issues assigned to me (usually 0-3). Same row shape as `gh_ready`. |
+| `claude_drift` | 6b, 7 | `state=absent` (sandbox, no `~/.claude`) or `state=no-source` (not in an a-c-c checkout) = silent skip. `state=compared` gives `behind=<n>` and `modified=<n>`, then one `behind: <path>` / `modified: <path>` line each, plus `remedy_behind=` / `remedy_modified=` when non-zero. Both zero = silent. |
 
 Rules for interpreting exit codes:
 
@@ -125,6 +126,39 @@ From gather section `recent_main_commits`. The first line is `count=<N>` — com
 
 This is informational only — no action prompts. The section adds a few lines on busy days and zero on quiet ones.
 
+### 5b. Deployed-config drift (Tier 1 — surface, never act)
+
+From gather section `claude_drift`. Answers a question nothing else asks: does
+`~/.claude/` on this machine still match what the repo says it should be?
+
+A chezmoi-managed file can be fixed in the repo and go on running the old
+version here for as long as nobody applies. The failure is not forgetting to
+apply — it is that nothing distinguishes "this machine is current" from "this
+machine is a day behind", so there is nothing to forget about. It has already
+cost a session: two merged commits to `bin/gcp-credentials` were undeployed
+while the cloud surface had them, so local and cloud disagreed on the behaviour
+of a security control and an issue was filed against a defect already fixed.
+
+- **`state=absent` or `state=no-source`**: silent skip. A sandbox has nothing
+  deployed; outside an a-c-c checkout there is nothing to compare against
+  without a network fetch, which is not worth every session start.
+- **`behind=0 modified=0`**: silent. This is the normal case and should stay
+  invisible.
+- **`behind >= 1`**: surface under **Needs attention** in the brief, naming the
+  count and the files, with the remedy verbatim from `remedy_behind`. The
+  command is `chezmoi apply --refresh-externals`, **not** a plain `chezmoi
+  apply` — the archive external's 168h refresh period means a plain apply can
+  re-serve the cached copy.
+- **`modified >= 1`**: surface separately, and do not conflate it with the
+  above. A hand-edited file in `~/.claude/` is a different problem with a
+  different fix — the edit is lost on the next apply, so it needs moving into
+  the repo. Reporting both as one number makes the message ignorable.
+
+**Never apply anything, and never offer to.** This is Tier 1 surface-only by
+design: applying config changes under an agent without the human reading them
+is its own hazard, and this repo deploys the harness the agent is running
+inside.
+
 ### 6. Paul-context inbox surface (Tier 2 — prompt, paul-context only; Tier 1 with policy opt-in)
 
 **Only fires when the current working tree is `paul-context`** (`basename "$(git rev-parse --show-toplevel)" = "paul-context"`). Otherwise skip silently. This is a runtime filesystem check, not part of the gather output — `/start-session` runs in many repos and a generic gather section would always be empty for the rest.
@@ -178,6 +212,10 @@ Needs attention:
   • <main CI red on workflow X>    (omit when green)
   • <feature branch behind main by N>          (omit when on default, even, or auto-switched)
   • <branch upstream gone but tree dirty>      (omit unless that case fires)
+  • ~/.claude is behind the repo on N file(s): <paths> — run `chezmoi apply --refresh-externals`
+                                               (omit when behind=0 / skipped)
+  • ~/.claude has N hand-edited file(s): <paths> — the edits are lost on the next
+    apply; move them into the repo    (omit when modified=0 / skipped)
 ───────────────────────────────────────────────
 ```
 


### PR DESCRIPTION
All four acceptance criteria in #178.

## What

`home/bin/start-session-claude-drift` compares `~/.claude/` against the checkout file by file; `start-session-gather-state` runs it as a parallel section; `/start-session` reports it under **Needs attention**.

## Behind vs locally modified

The issue was explicit that conflating these makes the message ignorable, and they genuinely differ:

| Case | How it's told apart | Remedy reported |
| --- | --- | --- |
| **behind** | file differs, repo copy's last commit is newer than the deployed mtime | `chezmoi apply --refresh-externals` |
| **modified** | file differs, deployed mtime is newer | edits are lost on the next apply — move them into the repo |
| **never deployed** | absent from `~/.claude/` | counted as behind, tagged `(never deployed)` |

The remedy for *behind* is `--refresh-externals` deliberately: the 168h `refreshPeriod` means a plain `chezmoi apply` can re-serve the cached archive. (Same root cause as #187, other end of the system.)

## Cost when everything is current

One `cmp` per file and nothing else — the `git log` lookup that decides direction only runs for files that actually differ. Silent when `behind=0 modified=0`, which is the normal case.

It walks the **source**, not the target, so Claude Code's own runtime state (`projects/`, `todos/`, `history.jsonl`) and files retired from the repo but never pruned (#125, already covered by `/end-session` step 11) aren't mistaken for drift.

## Nothing is applied

Tier 1 surface-only, and the command doc says not to offer either. Applying config changes under an agent without the human reading them is its own hazard, and this repo deploys the harness the agent is running inside. There's a test asserting the deployed tree is untouched.

## Degradation

- `state=absent` — no `~/.claude` (a sandbox). Silent skip with a note, rather than a scary-looking zero.
- `state=no-source` — not in an a-c-c checkout. Falls back to reporting how long ago the tree was last applied, flagged only past the 168h period. Comparing properly from another repo would need a network fetch, which isn't worth every session start.

## Verification

`shellcheck` clean on both scripts, `markdownlint-cli2` clean, **18 assertions passing** against a synthetic deployed tree — including a reproduction of the original incident (an old `bin/gcp-credentials` with an old mtime → `behind=1`, named, correct remedy, *not* miscalled modified) and its mirror image (same divergence, fresh mtime → `modified=1`, different remedy, not miscalled behind).

## Conflict note

Touches `start-session-gather-state` and `start-session.md`, which **#139** also reworks. Expect a conflict; the new script itself is standalone.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_