### PR TITLE
Document the client-version handshake on the cloud surface

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -135,3 +135,49 @@ the branch that installs the gcloud wrapper.
 
 Skills are read when the agent starts, so a newly installed skill appears after
 the session restarts or resumes. The helper is usable immediately.
+
+## When the broker says the helper is too old (exit 8)
+
+The helper sends a `X-Client-Version` header on `/request` and `/poll`, and the
+broker refuses anything below its minimum with HTTP 426 — **before** posting an
+approval card, so a stale client never spends a human approval it cannot
+complete. The helper exits 8 and renders the broker's hint.
+
+This exists because a client too old to understand a new broker state is also
+too old to know that the state exists: three broker releases in a row
+(`warming`, `failed`, `provisioning`) each broke running sessions with
+`unexpected state: <name>`. Self-checking asks the stale component to detect its
+own staleness, which only works for cases it already anticipated. The broker
+always knows what it needs, so the check belongs there.
+
+**Why this bites cloud sessions specifically.** The environment snapshots the
+setup script's result and re-runs it only when the script *text* changes, the
+allowed domains change, or roughly seven days pass. Because `main` never changes
+as a string, **pushing to `main` does not reach new sessions** — they keep
+restoring a snapshot built with whatever helper was current then. A cloud
+session can be running a week-old client with nothing to indicate it.
+
+Two remedies, in the order you want them:
+
+| Situation | Do this |
+| --- | --- |
+| The session in front of you | Re-run the bootstrap (above). Takes effect immediately for the helper |
+| Every session from now on | Bump `Rev:` in the setup script, forcing a rebuild |
+
+Do both. The re-run unblocks the task at hand; the `Rev:` bump is what stops the
+next session hitting the same wall. On a local machine the equivalent is
+`chezmoi apply --refresh-externals` — see the skill doc.
+
+**The version constant is bumped in the same commit as the wire change that
+needs it**, on both sides. That is the whole value of the mechanism: the bump is
+the moment someone notices a client change is required, rather than a session
+discovering it mid-task. The helper's `CLIENT_VERSION` carries a comment saying
+so; the broker's `clientversion.go` keeps the authoritative history.
+
+Do **not** make the skill fetch and install a newer helper before running. The
+helper is what displays the verification phrase, which makes it the one
+client-side component that is security-relevant — a compromised helper could
+show a phrase that does not match the request it made and walk a human into
+approving something else. Updating that component *inside* the credential flow
+means the code implementing the phrase check can change during the request it is
+checking. Detect and instruct; do not self-modify.


### PR DESCRIPTION
**Refs #182** — deliberately not `Closes`. Most of that issue is already done or lives in another repo; see the audit below.

## State of #182's acceptance criteria

| Criterion | Where it stands |
| --- | --- |
| Helper sends its version on `/request` and `/poll` | ✅ Done in `5ae8c5f` — `CLIENT_VERSION=4`, sent on both. Asserted by the #196 tests |
| Helper renders the hint verbatim rather than a generic failure | ✅ Done — `broker_error()` renders `.error` + `.hint` |
| Skill doc covers both remedies | ✅ Covered by **#187**, which also corrects the local one to `--refresh-externals` |
| Broker refuses below-minimum before posting a card | ⛔ **Broker-side** — private repo, not reachable from this session |
| Missing version header treated as too old | ⛔ Broker-side |
| Broker README records the same-commit bump rule | ⛔ Broker-side (the helper's own comment already states it) |
| Tests for too old / exactly minimum / newer / absent | ⛔ Broker-side. The client's 426 handling is tested in #196, both at request time and mid-poll |

## What this PR actually adds

The one genuine in-repo gap: `cloud/README.md` — the document a cloud operator reads — **never mentioned exit 8**, on the surface where staleness is least visible.

New section covering:

- **Why the broker owns the check.** A client too old to understand a new state is also too old to know the state exists. Self-checking asks the stale component to detect its own staleness; three releases running (`warming`, `failed`, `provisioning`) proved that doesn't work.
- **Why cloud sessions are hit hardest.** The environment re-runs its setup script only when the text changes, the domains change, or ~7 days pass — so *pushing to `main` does not reach new sessions*. A cloud session can run a week-old client with nothing to indicate it. This is the fact the section exists for; it's stated elsewhere in the file about setup generally, but never connected to exit 8.
- **Both remedies, in order**: re-run the bootstrap for the session in front of you (immediate), *and* bump `Rev:` so the next session isn't stuck too. Do both — the first unblocks the task, the second stops the recurrence.
- **The same-commit bump rule**, since the bump being the reminder is the entire value of the mechanism.
- **Why the skill must not self-update**: the helper is what displays the verification phrase, so updating it inside the credential flow means the code implementing the phrase check can change during the request it's checking. Detect and instruct; do not self-modify.

## Verification

`markdownlint-cli2` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_