### PR TITLE
Add the client-side credential runbook: ending access and incident response

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -111,6 +111,11 @@ Fill this section in from that run rather than from the documentation.
 Not this. `~/.claude` is chezmoi-managed from `home/`; the bootstrap is for
 containers that start empty.
 
+## Ending access, and incident response
+
+Revocation levels and what to do about a possibly-exposed token or request key:
+[`docs/runbooks/sandbox-gcp-credentials.md`](../docs/runbooks/sandbox-gcp-credentials.md).
+
 ## What lands where
 
 | Path | What |

--- a/docs/runbooks/sandbox-gcp-credentials.md
+++ b/docs/runbooks/sandbox-gcp-credentials.md
@@ -1,0 +1,155 @@
+# Runbook: sandbox GCP credentials
+
+Operating the credential broker from the **client side** — the half that lives
+in this repo, plus the procedures for ending access when something looks wrong.
+
+Design and trust model: ADR 021 (broker) and ADR 022 (sandbox provisioning), in
+`pmgledhill102/gcp-org-management`.
+
+## Scope, and what is deliberately elsewhere
+
+This repo is public. Anything naming a project, a hostname, or an identity in
+the estate lives in the private `sandbox-gcp-credentials` runbook in
+`gcp-org-management`, and is **linked, not copied** — a copy drifts, and this
+one would drift into a public repo.
+
+| Concern | Where |
+| --- | --- |
+| Deploying the broker; onboarding a project; Terraform for the agent SAs | Private runbook, `gcp-org-management` |
+| Broker hostname, project IDs, region | Private runbook |
+| Per-environment setup: setup script, allowed domains, environment variables | [`cloud/README.md`](../../cloud/README.md) |
+| Using it in a session: request, phrase, wait, renew, release | [`home/commands/gcp-credentials.md`](../../home/commands/gcp-credentials.md) |
+| The client itself | [`home/bin/gcp-credentials`](../../home/bin/gcp-credentials) |
+| Ending access; incident response | **This file** |
+
+## The model in one paragraph
+
+One human approval creates a **grant** of 1–7 days. Inside that window the
+helper silently re-mints **1-hour** GCP access tokens with no further approvals.
+The token is written straight from the HTTP response to a 0600 file and never
+passes through a shell variable, so it never reaches the transcript or the
+model's context. What a stolen token buys is therefore one project, a limited
+role set, and at most an hour — the broker's job is to make token theft boring.
+
+## Ending access
+
+Three levels. Pick by what you are actually worried about, because they differ
+in blast radius and in how fast they take effect.
+
+### 1. `release` — this machine stops using the credentials
+
+```sh
+~/.claude/bin/gcp-credentials release
+```
+
+Stops the refresh loop, removes the local token, restores the gcloud
+configuration that was active before. **The grant stays live at the broker**, so
+`renew` would bring it straight back.
+
+Use at the end of a session on a shared or local machine. Not an incident
+response.
+
+### 2. `revoke` — the grant ends
+
+```sh
+~/.claude/bin/gcp-credentials revoke
+```
+
+Deletes the grant at the broker, so no further tokens can be minted, then does
+everything `release` does. **Residual exposure: up to one hour** — an
+already-minted token stays valid until it expires. There is no un-minting.
+
+Use when access should end outright: work finished early, or anything about the
+session looks off.
+
+If the broker is unreachable, `revoke` cleans up locally and says so — the grant
+may still be live. Retry, or escalate to level 3.
+
+### 3. Disable the service account — everything stops now
+
+The hard kill, for when a live token is believed to be in the wrong hands and an
+hour is too long to wait:
+
+```sh
+gcloud iam service-accounts disable agent-sandbox@<project>.iam.gserviceaccount.com
+```
+
+This invalidates tokens already issued, which levels 1 and 2 cannot. It needs
+admin credentials — that is, **not** an agent session's credentials, by design.
+Re-enable with `enable` once the grant is revoked and the incident is closed.
+
+## Incident response
+
+### A token may have been exposed
+
+Most likely cause: something printed or copied the token file — a `cat`, a
+debug dump, a tool that echoes its environment. The skill forbids reading that
+file for exactly this reason.
+
+1. **`revoke`** (level 2). Do this first; it costs nothing and stops the bleeding.
+2. If the exposure reached anywhere durable — a transcript, a log, a pasted
+   snippet, a CI job's output — **disable the service account** (level 3) rather
+   than waiting out the hour.
+3. Check what the identity could reach: the agent SA holds a limited role set on
+   **one** project. Confirm which from the grant, then review that project's
+   audit log for the exposure window. Agent activity is attributable, because
+   every call from a session carries the per-project SA rather than the human's
+   identity — that separation is what makes this step possible at all.
+4. Request fresh credentials normally afterwards. A new grant is a new approval
+   and a new phrase; nothing carries over.
+
+### The request key may have leaked
+
+The request key only gates *opening* a request. It cannot approve one — the
+human approval is the real control, and a stranger with the key gets a card the
+owner did not expect and should deny.
+
+Still worth rotating, because the key is what stops approval spam:
+
+1. Rotate the key at the broker (private runbook).
+2. Update it everywhere it is configured: `CREDENTIAL_BROKER_REQUEST_KEY` in each
+   cloud environment, and `~/.config/claude/credential-broker/request-key` (mode
+   0600) on each machine.
+3. Cloud environments have no secrets store, so the key sits in environment
+   variables readable by anyone who can use the environment. That is a knowing
+   exception, documented in `cloud/README.md` — rotation is the compensating
+   control, so actually do it.
+
+### An approval card arrived that nobody expected
+
+**Deny it.** A card with no session running is grounds to deny, always — this is
+the case the whole phrase mechanism exists for.
+
+The phrase is generated by the broker and returned only to the requesting
+session, so a card whose phrase does not match what is on your screen is not
+your session's card. Approving it would hand credentials to whoever made the
+request.
+
+After denying: the card names which request key was used, which tells you
+whether to rotate (above). A deny costs nothing and a wrong approval costs a
+project, so the asymmetry is not close.
+
+### A session is behaving oddly while holding a grant
+
+Sessions on one repo share a project and an identity at `roles/owner`, so a
+second live grant means someone else's work shares your blast radius. `status`
+reports this as a `sharing :` line, and `request` warns at install time.
+
+`revoke` ends only *your* grant. If the concern is another session, level 3 is
+the one that covers both.
+
+## Routine checks
+
+- `~/.claude/bin/gcp-credentials status` — grant, identity, token age, refresh
+  state, and whether an environment variable is overriding the token file. No
+  secrets in its output, by construction; it is safe to run and safe to paste.
+- A `STALE` token with a live grant means the refresh loop died, not that
+  anything is wrong with the access — `refresh --background` fixes it and needs
+  no human. Do not respond to it by requesting again; that spends an approval on
+  a local process problem.
+
+## Verified end to end
+
+The flow has been exercised for real work from a cloud sandbox (2026-08-12) and
+from a local session. Findings from those runs are folded into the skill doc's
+troubleshooting rather than kept here.


### PR DESCRIPTION
**Refs #140** — not `Closes`, because most of that epic's deliverables are built and live in another repo. Audit below.

## Where #140's deliverables stand

| Deliverable | Status |
| --- | --- |
| Terraform: agent SAs + broker IAM | ✅ Built — `gcp-org-management` |
| Broker service (Cloud Run + Firestore) | ✅ Built — request/poll/exchange/revoke, phrases, rate limiting all exercised |
| Discord approval bot | ✅ Built |
| Plugin helper + skill | ✅ Shipped here — `home/bin/gcp-credentials`, `home/commands/gcp-credentials.md` |
| Executed end to end from cloud + local | ✅ Done — the 2026-08-12 sandbox run is what produced #154 |
| Runbook | ⚠️ **Partially** — the deploy/onboard runbook exists privately; this adds the public-safe half |
| Retro dimension points at this | ⛔ #139 |

## Why this isn't just a copy of the private runbook

`cloud/README.md` already establishes that the broker hostname is deliberately not written here — this repo is public. Deploy and onboarding steps are full of project IDs, hostnames and identities, and #189 just cleaned one such leak out of the skill doc. So the runbook is split by what's safe to publish, and the two halves are **linked, not copied** — a copy drifts, and this one would drift into a public repo.

What was genuinely missing *anywhere* is the operational half a session needs when something looks wrong.

## What the new runbook covers

**Three revocation levels**, distinguished by what they actually achieve:

| Level | Effect | Residual exposure |
| --- | --- | --- |
| `release` | this machine stops using the credentials; grant stays live | n/a — `renew` brings it straight back |
| `revoke` | grant ends, no further tokens mintable | **up to 1 hour** — an issued token can't be un-minted |
| disable the SA | invalidates tokens already issued | none |

That middle row is the one worth writing down: `revoke` reads like "access is off now" and isn't. Level 3 deliberately requires admin credentials an agent session doesn't have.

**Incident procedures** for the three realistic cases:

- **Token possibly exposed** — revoke first, escalate to level 3 if it reached anywhere durable, then read the project audit log. That last step works *because* agent calls carry the per-project SA rather than the human's identity — the identity separation earning its keep.
- **Request key leaked** — rotate; with the reassurance that the key only gates *opening* a request while the human approval is the real control, and the note that cloud environments have no secrets store, so rotation is the compensating control for a knowing exception.
- **Unexpected approval card** — deny. A card with no session running is exactly what the phrase mechanism exists for, and the asymmetry (a deny costs nothing, a wrong approval costs a project) is worth stating.

Plus a pointer from `cloud/README.md`, so an operator reading about environment setup can find it.

## Verification

`markdownlint-cli2 "**/*.md"` — 0 issues across 37 files. All relative links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_