### PR TITLE
Make the session lifecycle commands surface-aware

### DIFF
--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -22,6 +22,30 @@ git rev-parse --is-inside-work-tree
 
 If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `/end-session` requires a git-backed repo — nothing to tidy, stopping. ``) and stop. Do not run any further checks, do not proceed to Phase 2.
 
+## Surface
+
+This command runs on a workstation and in a cloud sandbox. Two facts settle
+every step that only makes sense on one of them:
+
+**Where the helper scripts are.** Prefer the plugin-relative path and fall back
+to the chezmoi one — `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/<script>`. Both
+spellings are auto-approved in `settings.json`. Under chezmoi the variable is
+unset and this resolves to `~/.claude/bin/`; under a plugin install it resolves
+inside the plugin. Do not hard-code either.
+
+**Which surface this is.** `command -v chezmoi` is the test. A workstation has
+chezmoi and a `~/.claude/` it manages; a sandbox has neither.
+
+Machine-specific steps **detect and skip** — they never error, and they report
+`n/a (sandbox)` in the summary rather than vanishing, so a missing line is never
+ambiguous between "clean" and "could not check". Step 11 already works this way
+via the gather's `chezmoi-unavailable` sentinel; anything added later that
+touches `~/.claude/`, chezmoi, or a workstation path must do the same.
+
+Stash hygiene (step 9) is worth calling out: stashes exist in a sandbox but mean
+something different — the container is disposable, so a stash left behind is
+lost rather than waiting. Surface it as usual, and say so.
+
 ## Repo-level policy (`.agent-policy`)
 
 **Optional.** A POSIX shell `KEY=VALUE` file at the repo root that opts specific Tier 2 prompts into Tier 1 (auto-run, no prompt) on a per-repo basis. The file is shared with `/start-session` (which has its own keys); each command consults the keys it cares about. Defaults (file absent or key unset) preserve every prompt — adding the file never makes any repo behave more aggressively than before.
@@ -64,7 +88,7 @@ This loads any opt-in keys consulted by Tier 2 steps. The file is optional; if a
 Run the parallel gather script. It does `git fetch --all --prune --tags` first, then fans out all read-only queries (status/branch/log, stashes, worktrees, merged branches, `main` CI, open PRs, assigned GitHub issues) in parallel.
 
 ```sh
-~/.claude/bin/end-session-gather-state
+${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/end-session-gather-state
 ```
 
 Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`. The sections are:
@@ -160,7 +184,7 @@ Take the list from gather section `merged_brs`.
 **Batch B — Squash-merged branches** — branches whose upstream was deleted (`[upstream: gone]`, typical after GitHub squash-merge + branch delete) AND whose work is provably on `main`. These won't show up in Batch A because squash-merging rewrites history; `-d` would refuse them. The script accepts either of two "work is delivered" signals as the safety net — empty diff vs `main`, or GitHub records a merged PR with the branch as `headRefName` (fallback for cases where main has subtle post-squash drift that fails the diff but the PR clearly merged):
 
 ```sh
-~/.claude/bin/end-session-squash-merged
+${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/end-session-squash-merged
 ```
 
 For each batch:

--- a/home/commands/retrospective.md
+++ b/home/commands/retrospective.md
@@ -9,6 +9,11 @@ Run a retrospective on this session: draft a per-session journal entry into `pau
 - **Issue state**: `gh issue list --assignee @me --state open` (so the retro knows what was already in flight).
 - **Memory dir**: list `~/.claude/projects/<project>/memory/` (path matches the cwd-derived project key) and read `MEMORY.md` so you know what's already captured and don't propose duplicates.
 - **Settings**: read `~/.claude/settings.json` for permission-related observations.
+- **Surface**: `command -v chezmoi`. Present = workstation; absent = cloud sandbox. This decides which dimensions run in step 2.
+
+**The last two reads are workstation-only.** A cloud sandbox has no `~/.claude/settings.json` and no `projects/<project>/memory/` — nothing is wrong, that state simply lives on the machine the session is not running on.
+
+**Degrade explicitly, don't skip silently.** When either is absent, say so in the retro output — `settings: n/a (sandbox)`, `memory: n/a (sandbox)` — and carry on. A retro that quietly omits a dimension reads identically to one that ran it and found nothing, and the difference matters: the first means "not checked here", the second means "checked, all good".
 
 If we're not inside a git repo, treat the retro as cross-repo by default — every action becomes an Issue against `pmgledhill102/paul-context`.
 
@@ -16,7 +21,19 @@ If we're not inside a git repo, treat the retro as cross-repo by default — eve
 
 Review the full conversation history and evaluate each of these dimensions. Skip any that aren't relevant.
 
-- **Approval friction**: Which tool calls required manual approval? Were any repeatedly approved and should be added to `allowedTools` in settings? Note the specific tool patterns.
+**Two dimensions are surface-specific** — run whichever matches the surface detected in step 1, not both:
+
+- **Approval friction** — *workstation only*. Skip in a sandbox: the permission model there is the environment's, `~/.claude/settings.json` is not readable, and a recommendation to add an allow rule has nowhere to land.
+- **Missing sandbox config** — *sandbox only*. See below.
+
+- **Approval friction** (workstation only): Which tool calls required manual approval? Were any repeatedly approved and should be added to `allowedTools` in settings? Note the specific tool patterns.
+- **Missing sandbox config** (sandbox only): **what config, context or credentials were missing from this sandbox session?** This is the feedback loop that catches capability gaps, and it is the dimension most worth getting right, because a sandbox is the surface where a gap is invisible until it blocks something. Look for:
+  - **Tools absent** that the work needed — was `gcloud`, a linter, a language runtime missing because the environment's setup script does not install it? Name the tool and the setup-script change.
+  - **Credentials unavailable** — was GCP access needed and absent? The answer is the credential broker (`/gcp-credentials`), so the finding is usually "the broker was not configured for this environment", naming which of the request key, broker URL or allowed-domains entry was missing.
+  - **Context that only exists on a workstation** — did the session need a runbook, a decision record, or a policy statement that lives in `~/.claude/` or a private repo and is therefore unreachable from here? That is a portability gap, and the fix is usually to move the content into a public, fetched, or repo-committed home.
+  - **Guidance a local session would have had** — anything you had to work out that a `CLAUDE.md`/`AGENTS.md` on a laptop would simply have told you.
+
+  Route every finding as an Issue against `pmgledhill102/agentic-coding-config` — that is where the environment definition, the bootstrap and the policy core all live. Be specific enough to action without re-running the session: name the tool or setting, what failed without it, and where it should be configured.
 - **Shell-friction patterns**: Did Bash tool calls use shell shapes that a file-import alternative would replace? These shapes hide multi-line content on the rendered command line, can trigger the harness's re-prompt heuristic even with the bare command allow-listed, and break on quoting edge cases. Scan the transcript for these patterns:
   - `--description="$(cat PATH)"` / `--body="$(cat PATH)"` / `--message="$(cat PATH)"` — propose the tool's file flag (e.g. `gh issue create --body-file=PATH`, `gh pr create --body-file=PATH`).
   - Heredocs (`tool <<'EOF' … EOF`) — already banned in the user's CLAUDE.md, but spot any that leaked in. Propose `Write` to `/tmp/<slug>.md` followed by the tool's file flag.

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -22,6 +22,31 @@ git rev-parse --is-inside-work-tree
 
 If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `/start-session` requires a git-backed repo — nothing to sync, stopping. ``) and stop.
 
+## Surface
+
+This command runs on a workstation and in a cloud sandbox, and some steps only
+make sense on one of them. Two facts settle every such case:
+
+**Where the helper scripts are.** Prefer the plugin-relative path and fall back
+to the chezmoi one:
+
+```sh
+${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/<script>
+```
+
+Both spellings are auto-approved in `settings.json`. Under chezmoi the variable
+is unset and this resolves to `~/.claude/bin/`; under a plugin install it
+resolves inside the plugin. Do not hard-code either.
+
+**Which surface this is.** `command -v chezmoi` is the test. A workstation has
+chezmoi and a `~/.claude/` it manages; a sandbox has neither, having been built
+by `cloud/bootstrap.sh` from scratch.
+
+Machine-specific steps **detect and skip** — they never error. A skipped step
+reports `n/a (sandbox)` in the summary rather than vanishing, so the brief means
+the same thing everywhere and a missing line is never ambiguous between "clean"
+and "could not check".
+
 ## Repo-level policy (`.agent-policy`)
 
 **Optional.** A POSIX shell `KEY=VALUE` file at the repo root that opts specific Tier 2 prompts into Tier 1 (auto-run, no prompt) on a per-repo basis. Defaults (file absent or key unset) preserve the prompt — adding the file never makes any repo behave more aggressively than before.
@@ -58,7 +83,7 @@ This loads any opt-in keys consulted by Tier 2 steps. The file is optional; if a
 Run the parallel gather script. It does `git fetch --all --prune --tags` first, resolves the repo's default branch, then fans out all read-only queries (local branch state, `main` CI, ready/assigned GitHub issues) in parallel. The script compacts each section's output to keep model-visible context cost low: `fetch`'s body is suppressed on success, and `main_ci` is parsed in-script to one line per workflow.
 
 ```sh
-~/.claude/bin/start-session-gather-state
+${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/start-session-gather-state
 ```
 
 Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`. The sections are:

--- a/home/settings.json
+++ b/home/settings.json
@@ -38,6 +38,8 @@
       "Bash(dig *)",
       "Bash(~/.claude/bin/end-session-*)",
       "Bash(~/.claude/bin/start-session-*)",
+      "Bash(${CLAUDE_PLUGIN_ROOT}/bin/end-session-*)",
+      "Bash(${CLAUDE_PLUGIN_ROOT}/bin/start-session-*)",
       "Bash(/Applications/draw.io.app/Contents/MacOS/draw.io *)",
       "Bash(podman build *)",
       "Bash(podman compose *)",

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -41,6 +41,17 @@ prompt.
 
 - `Bash(~/.claude/bin/end-session-*)`
 - `Bash(~/.claude/bin/start-session-*)`
+- `Bash(${CLAUDE_PLUGIN_ROOT}/bin/end-session-*)`
+- `Bash(${CLAUDE_PLUGIN_ROOT}/bin/start-session-*)`
+
+The `${CLAUDE_PLUGIN_ROOT}` pair is the same grant for the plugin delivery
+path (ADR-0014), added ahead of the cutover so the commands can reference
+their helpers plugin-relative wherever that variable is set. The matcher is
+literal-prefix and runs **before** shell expansion, so the variable spelling
+in the rule matches the variable spelling in the command — which is why both
+forms are listed rather than one being made to cover the other. Under chezmoi
+the variable is unset and the `~/.claude/bin/` rules are what match; the
+commands pick the form that exists.
 
 See `docs/end-session-design.md` for the full rationale.
 


### PR DESCRIPTION
## Plugin-relative helper paths

`${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/<script>` replaces the hard-coded `~/.claude/bin/` invocations in both lifecycle commands.

**The part that needed care**: Claude Code's permission matcher is literal-prefix and runs *before* shell expansion, so `Bash(~/.claude/bin/start-session-*)` does not match a command written `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/start-session-gather-state`. Switching the path without touching the allowlist would have silently traded plugin-readiness for a permission prompt on every single session start — the exact friction those rules were added to remove.

So `settings.json` gains the matching pair:

```json
"Bash(${CLAUDE_PLUGIN_ROOT}/bin/end-session-*)",
"Bash(${CLAUDE_PLUGIN_ROOT}/bin/start-session-*)",
```

Both spellings are now granted; under chezmoi the variable is unset and the original rules match, under a plugin install the new ones do. `settings.json.md` carries that reasoning, so the pair doesn't read as redundant.

## Surface detection, stated once

Both commands gain a **Surface** section fixing the two facts every conditional step needs: where the helpers live, and that `command -v chezmoi` distinguishes workstation from sandbox.

The rule for machine-specific steps is **detect and skip, never error** — and report `n/a (sandbox)` rather than omitting the line, because a missing line is otherwise ambiguous between "clean" and "could not check".

Worth noting: **`/end-session` step 11 already did this correctly** via the gather's `chezmoi-unavailable` sentinel. The change is writing the convention down so what gets added next follows it, rather than rediscovering it. Stash hygiene gets an explicit note — stashes exist in a sandbox but mean something different, since a stash left in a disposable container is lost rather than waiting.

## `/retrospective`

- **Step 1 degrades explicitly.** `~/.claude/settings.json` and `projects/<project>/memory/` are workstation-only; when absent the retro says `n/a (sandbox)` instead of quietly omitting them. A retro that silently skips a dimension reads identically to one that ran it and found nothing.
- **Approval friction is now workstation-only.** In a sandbox the permission model is the environment's, settings aren't readable, and a recommendation to add an allow rule has nowhere to land.
- **A missing-sandbox-config dimension replaces it**: what tools, credentials, context or guidance this session lacked — with four concrete things to look for (absent tools → a setup-script change; unavailable credentials → which of the request key / broker URL / allowed domain was missing; context that only exists on a workstation → a portability gap; guidance a local `CLAUDE.md` would have given). All routed as `agentic-coding-config` issues, since that's where the environment definition, the bootstrap and the policy core live.

This is the feedback loop the issue wanted — the one that catches gaps like the missing GCP runbook, on the surface where a gap is invisible until it blocks something.

## Verification

`markdownlint-cli2` clean; `home/settings.json` valid JSON; both settings files changed together so the sync job passes.

## Conflict note

Touches `start-session.md` (also **#178**) and `settings.json`/`.md` (also **#188**). Different hunks in each.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_