### PR TITLE
Convert the provider-neutral command library to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ restructure that introduced `home/` is on top of that history.
     ├── CLAUDE.md              → ~/.claude/CLAUDE.md  (universal policy)
     ├── settings.json          → ~/.claude/settings.json
     ├── settings.json.md       → ~/.claude/settings.json.md  (annotated companion, kept alongside)
-    ├── commands/              → ~/.claude/commands/
+    ├── commands/              → ~/.claude/commands/  (Claude slash commands)
+    ├── skills/                → ~/.claude/skills/    (Agent Skills — provider-neutral)
     └── bin/                   → ~/.claude/bin/  (helper executables)
 ```
 
@@ -230,6 +231,32 @@ Each `/setup-*` command contains:
 /setup-common     # Local tooling foundation (depends on branch protection for auto-merge)
 /setup-python     # Language-specific tooling
 ```
+
+### Skills (provider-neutral)
+
+The 16 provider-neutral commands — every `/setup-*` plus `/repo-review` — also
+exist as [Agent Skills](https://agentskills.io) under `home/skills/`, one
+`<name>/SKILL.md` each with `name` + `description` frontmatter. Skills are the
+portable unit: native in Claude Code, and the primary customisation unit in
+Codex, with OpenCode, Gemini CLI, Cursor and Copilot also reading the format
+(ADR-0014).
+
+Skill bodies carry no `$ARGUMENTS` / `$1` / `` !`cmd` `` / `@file` templating —
+Codex's parser rejects those — so arguments arrive as free text ("the user names
+the target language in their request").
+
+**Both forms ship for now.** The commands stay until the plugin cutover
+([#48][issue-48]); retirement is tracked separately. Until then the skill body
+is a copy, so **a change to one needs the same change to the other** — the
+duplication is deliberate and temporary, but it can drift.
+
+The session-lifecycle commands (`/start-session`, `/end-session`,
+`/retrospective`, `/promote-journal-inbox`) and `/gcp-credentials` are **not**
+converted: they carry Claude-specific tool references or are local-only.
+`/gcp-credentials` already ships as a skill to sandboxes by another route —
+`cloud/bootstrap.sh` writes it to `~/.agents/skills/`.
+
+[issue-48]: https://github.com/pmgledhill102/agentic-coding-config/issues/48
 
 **Maintenance and review:**
 

--- a/home/skills/repo-review/SKILL.md
+++ b/home/skills/repo-review/SKILL.md
@@ -128,6 +128,44 @@ For each ADR file (`*.md` in the detected ADR directory):
 
 4. Output a table: ADR file → status → finding → suggested action ("update", "supersede", "delete", "no action").
 
+### Phase A2 — Tier fit
+
+Per [ADR-0015](https://github.com/pmgledhill102/agentic-coding-config/blob/main/adrs/0015-tiered-adrs.md),
+every ADR declares a tier with a `Scope:` header line — `personal`, `user` or
+`repo` — and placement is meant to follow scope rather than convenience. This
+check is the backstop for that; it is a review prompt, not enforcement.
+
+For each ADR, additionally:
+
+1. **Missing scope.** No `Scope:` line → flag it, and suggest one from the
+   authoring test below. Don't guess silently; the point of the header is
+   that the blast radius is stated rather than inferred.
+
+2. **Outgrown its tier.** Apply the authoring test — *would this decision
+   still bind if this repo were archived?* If yes and it is `Scope: repo`,
+   flag it for promotion to the user tier
+   (`agentic-coding-config/adrs/`), leaving a stub behind that links to
+   the new home. Signals worth searching for:
+   - the ADR's own text generalises beyond this repo ("every repo", "all my
+     projects", "across the estate")
+   - another repo is known to depend on the decision, or the ADR is
+     referenced by URL from outside this repo
+
+3. **Undeclared deviation.** A repo-tier ADR that contradicts a user-tier
+   decision must say so — naming the ADR it deviates from and why. A repo ADR
+   that quietly reverses a user-tier decision without referencing it is the
+   failure mode the tier model exists to prevent, so flag it as a finding in
+   its own right rather than as a style nit. The user-tier set is listed at
+   <https://github.com/pmgledhill102/agentic-coding-config/tree/main/adrs>
+   and is readable from a sandbox with no local clones.
+
+Suggested actions for this phase: "add Scope:", "promote to user tier +
+stub", "declare the deviation", "no action".
+
+Note that promotion is a **cross-repo** change: per the cross-repo rule, do
+not edit the other repo. File an issue against `agentic-coding-config`
+containing the ADR's full text and the reason for promotion.
+
 ## Phase B — Dependency currency
 
 Run the per-language scanners. Each scanner is invoked once. **Run synchronously** — do not background. Aggregate the JSON or text output into a structured findings list.
@@ -296,6 +334,7 @@ Print to chat. Use the structure:
 
 ADRs (<N> found)
   - <file>  <STATUS>  <one-line reason>
+  Tier fit: <N> missing Scope:, <N> outgrown their tier, <N> undeclared deviations
 
 Dependencies
   Outdated: <N> (major: <a>, minor: <b>, patch: <c>)

--- a/home/skills/repo-review/SKILL.md
+++ b/home/skills/repo-review/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: repo-review
+description: Audit a repository for accumulated drift and produce actionable findings: validate architecture decision records against the code, surface outdated, deprecated or vulnerable dependencies, and flag stale docs, dead code and old TODOs. Read-only; never modifies code or dependencies.
+---
+
+# Review a repo for currency and drift
+
+## When to use
+
+- Periodically on long-lived projects to surface accumulated drift (deprecated deps, ADRs that no longer match the code, stale docs).
+- Before a refactor sprint, to scope cleanup work as concrete action items.
+- On a project you're returning to after months — get a fast read on what's rotted.
+- After a major dependency or framework migration, to find leftover references to the old stack.
+
+Don't run during ongoing feature work — the action-item output is a sweep-up step, not a continuous-integration check.
+
+## What it doesn't do
+
+- **No fixes.** Read-only diagnostic. Each finding is a suggestion for the user to action separately.
+- **No silent fallback when scanners are missing.** Pre-flight halts with an install list. The user installs the tools and re-runs.
+- **No automatic scanner installation.** The command prints install commands; the user runs them.
+- **No SARIF or CI integration.** Output is markdown for humans. CI integration is out of scope for v1.
+- **No bidirectional sync.** Issues are created in the repo's own GitHub tracker. Nothing is pushed to Jira or other external trackers.
+
+## Operational notes
+
+- **Foreground everything.** Scanners are I/O-bound; running them sequentially in the foreground is fine and keeps output legible.
+- **Expected runtime**: 1–3 min on a small repo, 5–10 min on a large multi-language repo (most of which is `pip-audit` / `cargo-audit` fetching advisory data).
+- **Per-language gating.** A scanner is only required if the corresponding manifest is detected. A pure-Python repo doesn't need `cargo-audit`.
+- **`gh issue create` pacing.** Pace writes ~2s apart when creating a batch — GitHub's secondary rate limits allow at most 80 content-creating requests/min, and bursts trigger 403s. For a typical 5–20 action-item batch, under a minute total.
+
+## Pre-flight: detect, verify, prepare
+
+Run the detection block first as a single shell call so the full state lands in one output:
+
+```sh
+echo "===root==="; git rev-parse --show-toplevel 2>&1
+echo "===project name==="; basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+echo "===origin url==="; git remote get-url origin 2>&1
+echo "===languages detected==="
+[ -f package.json ]    && echo "js"     || true
+[ -f pyproject.toml ] || [ -f setup.py ] || [ -f setup.cfg ] || [ -f requirements.txt ] && echo "python" || true
+[ -f Cargo.toml ]      && echo "rust"   || true
+[ -f go.mod ]          && echo "go"     || true
+[ -f Gemfile ]         && echo "ruby"   || true
+[ -f composer.json ]   && echo "php"    || true
+[ -f pom.xml ] || ls *.csproj 2>/dev/null | head -1 || ls build.gradle* 2>/dev/null | head -1 || true
+echo "===adr search==="
+for d in docs/decisions docs/adr doc/adr architecture/decisions adrs .adr-log; do
+  [ -d "$d" ] && echo "found: $d" && ls "$d" | head -10
+done
+echo "===dependabot==="; [ -f .github/dependabot.yml ] || [ -f .github/dependabot.yaml ] && echo "yes" || echo "no"
+echo "===renovate==="; [ -f renovate.json ] || [ -f .renovaterc ] || [ -f .renovaterc.json ] && echo "yes" || echo "no"
+echo "===pre-commit==="; [ -f .pre-commit-config.yaml ] && echo "yes" || echo "no"
+```
+
+Capture the language list — it drives the required-scanners check next.
+
+### Verify required scanners
+
+Required tools per detected language. **Halt if any are missing**: print the install list, do not proceed.
+
+| Detected | Required | Install hint |
+| --- | --- | --- |
+| any (always) | `lychee` | `brew install lychee` or `cargo install lychee` |
+| `js` | `knip`, `npm-check-updates` (and the package manager's outdated subcommand: `npm`/`pnpm`/`yarn`) | `npm i -g knip npm-check-updates` |
+| `python` | `pip-audit`, `deptry`, `vulture` | `uv tool install pip-audit deptry vulture` |
+| `rust` | `cargo-audit`, `cargo-outdated`, `cargo-udeps` | `cargo install cargo-audit cargo-outdated cargo-udeps` (note: `cargo-udeps` requires nightly) |
+| `go` | `govulncheck`, `go-mod-outdated` | `go install golang.org/x/vuln/cmd/govulncheck@latest && go install github.com/psampaz/go-mod-outdated@latest` |
+
+Verification idiom (one block, run after detection):
+
+```sh
+missing=""
+for tool in lychee; do command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"; done
+# Then, conditionally on detected languages, append more tools to the loop above.
+[ -n "$missing" ] && { echo "Missing required tools:$missing"; echo "Install them and re-run."; exit 1; }
+```
+
+If anything is missing, print:
+
+```text
+Missing required scanners for detected languages: <list>
+
+Install with:
+  <one line per tool>
+
+Re-run /repo-review when installed.
+```
+
+…and stop. Do not proceed.
+
+### Brief the user
+
+Once detection and verification pass, give the user a one-paragraph summary before running phases:
+
+```text
+Reviewing <project>: detected <langs>. Found <N> ADRs in <path> (or "no ADRs").
+GitHub Issues: <yes|no — origin url contains github.com>. Will run phases A–E and output <action-items target>.
+Estimated runtime: <X> min. Proceed? (y/n)
+```
+
+Wait for explicit `yes`. Anything else, abort.
+
+## Phase A — ADR validation
+
+Skip if pre-flight found no ADR directory.
+
+For each ADR file (`*.md` in the detected ADR directory):
+
+1. Parse the file. Extract:
+   - **Title** (first H1 or `# NNNN. ...` heading).
+   - **Status** (look for a `Status:` line or `## Status` section — typical values: `Accepted`, `Proposed`, `Deprecated`, `Superseded by ...`).
+   - **Date** (look for a `Date:` line or front matter; fall back to the file's `git log -1 --format=%ad` if absent).
+   - **Decision claims**: extract every line under a "## Decision" / "## Context" section that names a specific technology, library, framework, service, or pattern. Heuristic: a noun phrase capitalised or in backticks (e.g. `PostgreSQL`, `gRPC`, `redux-toolkit`).
+
+2. For each claim, check whether the named technology appears in the **current** code:
+   - Search manifests first (`package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, etc.) — exact dependency name match.
+   - Then `rg -l '\b<name>\b' --type-add 'src:*.{js,ts,py,rs,go,rb,php,java,cs}' -tsrc` (or equivalent), capped at first 5 matches.
+   - Record: `present` (manifest hit), `referenced` (code hit only), or `missing` (no hit).
+
+3. Classify each ADR:
+   - **OK** — at least one decision claim resolves to `present` or `referenced`.
+   - **STALE** — `Status: Accepted` (or unset) but **all** decision claims are `missing`. Likely the decision was reversed and the ADR wasn't updated.
+   - **CONTRADICTED** — `Status: Accepted` but a *competing* technology (one not mentioned in the ADR) is also present in the manifest. E.g. ADR says "use REST", but `grpc-go` is in `go.mod`.
+   - **STALE-DATE** — date older than 2 years AND status is still `Accepted` AND no edits in `git log` since. Worth re-validating regardless of code state.
+   - **EXPLICITLY DEPRECATED** — `Status: Deprecated` or `Superseded`. Skip; no action needed.
+
+4. Output a table: ADR file → status → finding → suggested action ("update", "supersede", "delete", "no action").
+
+## Phase B — Dependency currency
+
+Run the per-language scanners. Each scanner is invoked once. **Run synchronously** — do not background. Aggregate the JSON or text output into a structured findings list.
+
+### JS / TS
+
+```sh
+# Outdated (whichever package manager is in use)
+[ -f pnpm-lock.yaml ] && pnpm outdated --format=json 2>/dev/null
+[ -f yarn.lock ]      && yarn outdated --json 2>/dev/null
+[ -f package-lock.json ] && npm outdated --json 2>/dev/null
+# Unused / dead code
+knip --reporter json 2>/dev/null
+# Major-version upgrade picture
+npm-check-updates --jsonUpgraded 2>/dev/null
+```
+
+### Python
+
+```sh
+pip list --outdated --format=json 2>/dev/null
+pip-audit --format=json 2>/dev/null
+deptry . --json-output /tmp/deptry-out.json 2>/dev/null && cat /tmp/deptry-out.json
+vulture --min-confidence 80 . 2>/dev/null
+```
+
+### Rust
+
+```sh
+cargo audit --json 2>/dev/null
+cargo outdated --format json 2>/dev/null
+# udeps requires nightly; allow it to fail and surface "skipped" rather than block.
+cargo +nightly udeps --output json 2>/dev/null || echo "(cargo-udeps skipped — nightly toolchain not available)"
+```
+
+### Go
+
+```sh
+govulncheck -json ./... 2>/dev/null
+go list -u -m -json all 2>/dev/null | go-mod-outdated -update -direct -json 2>/dev/null
+```
+
+### Aggregate
+
+Build a `findings.deps` list, each item:
+
+```text
+{language, name, current, latest, kind: outdated|deprecated|cve|unused, severity: P0..P3, source}
+```
+
+Severity rules:
+
+- CVE with CVSS ≥ 7.0 → P0
+- Deprecated (npm `deprecated`, PyPI yanked, RustSec advisory) → P1
+- Major-version behind, current major unsupported → P1
+- Major-version behind, current major still supported → P2
+- Minor/patch-version behind → P3
+- Unused dependency → P2
+
+## Phase C — Deprecated → modern alternative
+
+For each item in `findings.deps` flagged as `deprecated` (Phase B), and additionally for any dependency whose name appears in the curated map below, emit a "consider replacing X with Y" action item. Keep the map in this command file — extend it via PR as new cases come up.
+
+```text
+# JS / TS
+moment           → Temporal (Node 22+) or date-fns / dayjs
+request          → undici (Node 22+ fetch) or node-fetch
+node-uuid        → globalThis.crypto.randomUUID() (Node 19+)
+tslint           → eslint
+node-sass        → sass (Dart Sass)
+true-myth        → neverthrow (more active)
+husky 4.x        → husky 9.x (config format changed)
+yarn 1.x         → pnpm or npm 10+
+
+# Python
+PyCrypto         → cryptography
+nose             → pytest
+black + isort + flake8 → ruff (single tool, faster)
+pylint (alone)   → ruff + mypy
+mock             → unittest.mock (stdlib)
+
+# Rust
+failure          → thiserror + anyhow
+error-chain      → thiserror + anyhow
+
+# Build / CI
+travis-ci        → GitHub Actions
+circleci (small projects) → GitHub Actions
+
+# Generic
+README.rst-only without README.md → README.md (better GitHub rendering)
+```
+
+The replacement is a *suggestion*, not an automatic action. Each becomes an action item with `priority=P2, type=task`.
+
+## Phase D — Doc and code drift
+
+### Broken links
+
+```sh
+lychee --offline --no-progress --format json --include '\.(md|markdown|rst|txt)$' . > /tmp/lychee-offline.json 2>/dev/null
+# Optional online pass — only if user opts in. Surface count from offline pass first.
+```
+
+Only count `error` results (not `cached` or `excluded`). Each broken link becomes an action item, severity P2.
+
+### README claim drift
+
+Spot-check the project README:
+
+1. Extract every fenced code block whose info string is `bash`, `sh`, `shell`, or unset and whose first line looks like a command (e.g. `npm run dev`, `make build`, `./scripts/foo.sh`).
+2. For each, check whether the named entry point exists:
+   - `npm run X` / `pnpm X` / `yarn X` → present in `package.json` `scripts`?
+   - `make X` → present in `Makefile`?
+   - `./scripts/X.sh` → file exists?
+3. Mismatches → action item, P2.
+
+This is best-effort — don't try to validate every code fence. The goal is to catch obvious "README says `npm run dev` but only `pnpm` is configured" drift.
+
+### Dead code
+
+Already covered by Phase B's scanners (`knip`, `deptry`, `vulture`, `cargo-udeps`). Promote each unused-export and unused-file finding into an action item if the count is non-trivial (≥3). Bundle small counts as one action item.
+
+### Old TODOs / FIXMEs
+
+```sh
+rg -n '\b(TODO|FIXME|XXX|HACK)\b' --type-add 'src:*.{js,ts,py,rs,go,rb,php,java,cs,sh}' -tsrc . 2>/dev/null \
+  | head -100
+```
+
+For each match, run `git blame -L <line>,<line> <file> --porcelain | head -5` to extract the commit date. Items older than 12 months become an action item. Group by file in the output to keep it readable.
+
+## Phase E — Repo hygiene
+
+### Stale branches
+
+```sh
+git for-each-ref --sort=-committerdate refs/remotes/origin --format='%(refname:short) %(committerdate:iso8601-strict)' 2>/dev/null \
+  | head -50
+```
+
+Heuristic: any branch with last commit > 90 days ago AND merged into `main` (`git branch -r --merged origin/main`). Surface count + a max-10 list. Action item: P3, suggest `git push origin --delete <branch>`.
+
+### GitHub Actions pinning
+
+```sh
+rg -n 'uses:\s*[A-Za-z0-9_./-]+@(?:v[0-9]+|[a-f0-9]{6,40})' .github/workflows/ 2>/dev/null
+```
+
+For each non-SHA-pinned reference, action item P2 — "pin to commit SHA for supply-chain safety".
+
+### Dependabot / Renovate
+
+If neither `.github/dependabot.yml` / `.yaml` nor `renovate.json` is present: action item P1 — "no automated dependency PRs configured".
+
+### Pre-commit / CI freshness
+
+If `.pre-commit-config.yaml` exists, surface the file's last-modified date (`git log -1 --format=%ad -- .pre-commit-config.yaml`). If older than 12 months, action item P3.
+
+## Output: findings summary (always inline)
+
+Print to chat. Use the structure:
+
+```text
+## Findings
+
+ADRs (<N> found)
+  - <file>  <STATUS>  <one-line reason>
+
+Dependencies
+  Outdated: <N> (major: <a>, minor: <b>, patch: <c>)
+  Deprecated: <list of names>
+  CVEs: <N> (P0: <a>, P1: <b>)
+  Unused: <list of names>
+
+Deprecated → modern alternative
+  - <X> → <Y>
+
+Docs & code drift
+  Broken links: <N> (offline pass)
+  README out-of-date: <list>
+  Dead code: <N> exports across <N> files
+  Old TODOs: <N> (oldest: <date>)
+
+Repo hygiene
+  Stale branches: <N>
+  GitHub Actions pinned to floating tags: <N>
+  Dependabot/Renovate: <yes|no>
+  Pre-commit config last edited: <date>
+```
+
+Sections with zero findings should explicitly say "none" — silence is ambiguous.
+
+## Output: action items
+
+Compile every finding into a single ranked list:
+
+```text
+## Action items
+
+[P0] (bug)     Update lodash >=4.17.21 — CVE-2021-23337 (high)
+[P1] (task)    Replace `request` with `undici` — deprecated since 2020
+[P1] (task)    Update ADR docs/decisions/0007-use-yarn.md — repo migrated to pnpm
+[P2] (task)    Pin .github/workflows/ci.yml actions to commit SHAs (3 entries)
+[P2] (task)    Remove unused exports from src/utils/ (8 across 3 files)
+[P3] (task)    Delete stale branches: feature/foo, refactor/bar (12 total, oldest 2024-01)
+```
+
+Type tags follow the GitHub Issues label conventions (`docs/github-issues-workflow.md` in `agentic-coding-config`): `bug` (CVE / breakage), `feature` (proposed adoption like Renovate), `task` (cleanup, default).
+
+### If the repo has a github.com origin remote
+
+Show the action item list, then ask once:
+
+```text
+<N> action items proposed. Create them as GitHub Issues?
+  - "yes" — create all
+  - "skip <n>,<m>" — create all except listed indices
+  - "cancel" — abort
+```
+
+On confirmation, for each accepted item:
+
+1. Write the description to `/tmp/repo-review-<index>.md` using the `Write` tool (never inline-escape multi-line content).
+2. Run `gh issue create --title "<short>" --body-file /tmp/repo-review-<i>.md --label "type: <type>,P<0..4>"` synchronously (prefer a structured GitHub API tool over the CLI when the client offers one). Pace successive creates ~2s apart to stay under GitHub's secondary rate limits. If the standard labels (`P0`–`P4`, `type: *`) don't exist yet, bootstrap them per `docs/github-issues-workflow.md` (idempotent `gh label create --force` loop) before the batch.
+3. Capture the issue number/URL. Build a mapping table.
+
+Description file template:
+
+```markdown
+Source: /repo-review run on YYYY-MM-DD
+
+<finding details: scanner, severity, location, suggested fix>
+
+---
+Generated by /repo-review.
+```
+
+If any `gh issue create` fails, STOP — do not silently continue. Surface the partial state.
+
+### If the repo has no github.com origin remote
+
+Write the action items to a markdown file:
+
+- Path: `docs/reviews/repo-review-YYYY-MM-DD.md` (create `docs/reviews/` if absent).
+- Use the `Write` tool, not heredocs. Overwrite if a file with today's date already exists.
+
+File structure:
+
+```markdown
+# Repo review — YYYY-MM-DD
+
+Generated by `repo-review`.
+
+## Findings summary
+
+<the same findings block printed inline>
+
+## Action items
+
+- [ ] [P0] (bug)  <one-line title>
+      <2–4 line description: scanner, location, suggested fix>
+
+- [ ] [P1] (task) <one-line title>
+      <description>
+
+...
+```
+
+Print the file path on completion. Suggest the user commit the file so the review history accumulates in the repo.
+
+## Idempotency
+
+Re-running on the same day:
+
+- GitHub Issues path: re-creates duplicate issues. Deduplicate against `gh issue list --state all` (never `gh search issues` — the search API is eventually consistent); surface a warning if any existing issue's title matches an action item title and ask the user to confirm before re-creating.
+- Markdown path: overwrites today's file. Yesterday's review (if committed) is preserved in git history.
+
+The command itself does not maintain a state file — its source of truth is the current state of the repo.
+
+## Known issues / footnotes
+
+- **`cargo-udeps` requires nightly.** If the project's `rust-toolchain.toml` pins to stable, the check is skipped with a warning rather than failing the run.
+- **`lychee` online pass is opt-in.** The default offline pass catches structural broken links (relative paths, anchors). The online pass adds rate-limited HTTP fetches and can take minutes — only run if the user explicitly asks.
+- **README claim drift is a heuristic.** Won't catch every drift case; particularly flaky on repos with multiple READMEs (root + per-package). Treat the output as a starting point.
+- **The deprecated→modern map is hand-curated.** Update via PR when a new "X is dead, use Y" case is encountered. Don't auto-generate from npm `deprecated` flags alone — that catches the obvious cases but misses ecosystem shifts (e.g. `tslint` → `eslint` predates the `deprecated` flag).
+- **Pre-commit framework interaction.** If the repo has `.pre-commit-config.yaml`, the markdown report file (`docs/reviews/repo-review-*.md`) may trip markdownlint depending on configured rules. The report uses standard markdown so this is rare; if it happens, add `exclude: ^docs/reviews/` to the relevant hook rather than rewriting the report format.
+- **GitHub Actions SHA-pinning check uses a regex.** False positives on weird `uses:` syntax; false negatives on actions referenced via composite or local paths. Treat the count as approximate.

--- a/home/skills/setup-common/SKILL.md
+++ b/home/skills/setup-common/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: setup-common
+description: Set up the baseline development tooling for a project — pre-commit framework, gitleaks secret scanning, spell checking, Dependabot and the shared CI workflow. Run this first; the language-specific setup skills build on it.
+---
+
+# Set up common project tooling
+
+## What to install and configure
+
+### 1. EditorConfig
+
+Create `.editorconfig` in the project root (if it doesn't already exist). If one exists, review it and suggest additions for any missing settings.
+
+```ini
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.{go,py}]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+```
+
+### 2. pre-commit framework
+
+Create `.pre-commit-config.yaml` in the project root (if it doesn't already exist). If one exists, review it and suggest adding any missing hooks from below.
+
+```yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: <latest tag>
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: <latest tag>
+    hooks:
+      - id: gitleaks
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+Do **not** run `pre-commit install` — nothing should write to `.git/hooks`. The config file is the source of truth, and it is enforced from two directions: a global pre-tool hook runs pre-commit on every `git commit`/`git push` the agent makes, and CI runs `pre-commit run --all-files` on every push. Manual terminal commits are CI-backed. Mention this model in the closing summary so the user knows why no git hook was installed.
+
+If `pre-commit` is not installed, tell the user to install it (`brew install pre-commit`) and stop.
+
+When adding hooks for a tool that is already a project or system dependency (prettier, eslint, golangci-lint, …), prefer a `repo: local` hook invoking the project's own binary over a `pre-commit/mirrors-*` repo — the mirrors pin their own copy of the tool, so the hook and the project can silently run different versions (and several mirrors are archived).
+
+### 3. cspell (spell checking)
+
+Create `cspell.json` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```json
+{
+  "version": "0.2",
+  "language": "en-GB",
+  "files": "\\.(md|txt|rst|yaml|yml)$",
+  "ignorePaths": [
+    "node_modules",
+    "go.sum",
+    "*.lock",
+    ".git"
+  ],
+  "words": [
+    "actionlint",
+    "aquasecurity",
+    "bandit",
+    "brakeman",
+    "bridgecrewio",
+    "checkov",
+    "chezmoi",
+    "chezmoiexternal",
+    "cleanups",
+    "clippy",
+    "coreutils",
+    "cspell",
+    "dependabot",
+    "dotnet",
+    "editorconfig",
+    "errcheck",
+    "eslint",
+    "footgun",
+    "frontmatter",
+    "gitleaks",
+    "godoc",
+    "gofmt",
+    "gofumpt",
+    "goimports",
+    "golangci",
+    "gomod",
+    "gosec",
+    "gotchas",
+    "govet",
+    "govulncheck",
+    "hadolint",
+    "handoff",
+    "hashicorp",
+    "ineffassign",
+    "jsdoc",
+    "linters",
+    "lockfiles",
+    "markdownlint",
+    "mkdocs",
+    "mypy",
+    "nuget",
+    "phpdoc",
+    "phpstan",
+    "pipx",
+    "pkill",
+    "pytest",
+    "pyupgrade",
+    "rhysd",
+    "rubocop",
+    "ruff",
+    "rustdoc",
+    "rustfmt",
+    "rustsec",
+    "semgrep",
+    "shellcheck",
+    "shfmt",
+    "shivammathur",
+    "siloed",
+    "speedup",
+    "staticcheck",
+    "streetsidesoftware",
+    "subdirs",
+    "temurin",
+    "tflint",
+    "tradeoffs",
+    "trivy",
+    "tseslint",
+    "typecheck",
+    "worktree"
+  ],
+  "dictionaries": ["en_GB", "softwareTerms", "companies", "misc"]
+}
+```
+
+The `files` pattern limits cspell to prose-heavy file types — markdown, plain text, reStructuredText, and YAML. This avoids noise from code identifiers.
+
+The seeded `words` list is deliberate, not decoration: it covers the names of every tool these setup skills install and the config identifiers their own templates write (the YAML samples above are spell-checked too, since `.yml` matches the `files` pattern), plus recurring dev jargon the base dictionaries miss. Without the seed, the very first `pre-commit run --all-files` flags dozens of words the skill itself just wrote. Do **not** seed user- or project-specific proper nouns (personal handles, repo names) — leave those for the consumer to add as they surface — and never add a word that is actually a typo.
+
+Add a cspell pre-commit hook to `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/streetsidesoftware/cspell-cli
+    rev: <latest tag>
+    hooks:
+      - id: cspell
+        types_or: [markdown, plain-text, yaml]
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+The `words` array is the project-specific dictionary. As cspell flags legitimate words during the verify step, add them here.
+
+### 4. actionlint (GitHub Actions linting)
+
+Add an actionlint pre-commit hook to `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/rhysd/actionlint
+    rev: <latest tag>
+    hooks:
+      - id: actionlint
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+### 5. semgrep (static analysis)
+
+Add a semgrep pre-commit hook to `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/semgrep/semgrep
+    rev: <latest tag>
+    hooks:
+      - id: semgrep
+        args: ["--config", "auto", "--error"]
+        pass_filenames: false
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+The `--config auto` flag uses Semgrep's curated rulesets appropriate for the languages detected in the repo. The other two lines matter:
+
+- `--error` — semgrep exits 0 on findings by default, so without it the hook always passes and the gate is decorative.
+- `pass_filenames: false` — pre-commit hands hooks explicit filenames, and giving semgrep explicit paths makes it bypass its own default excludes (notably `*_test.go`), reporting findings CI never sees. Scanning the repo instead keeps hook and CI seeing the same thing.
+
+### 6. .gitignore
+
+Create `.gitignore` if it doesn't exist, or append missing entries. Ensure it includes at least:
+
+```gitignore
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+
+# Environment
+.env
+.env.local
+.env.*.local
+```
+
+Read any existing `.gitignore` first and only add lines that are missing.
+
+### 7. GitHub Actions workflows
+
+Create or update CI workflows. Gitleaks, cspell, and semgrep run on all files (no path filter). Actionlint only needs to run when workflow files change.
+
+Add to `.github/workflows/ci.yml` (or create if needed):
+
+```yaml
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@<full-sha> # <version>
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  cspell:
+    name: Spell Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: streetsidesoftware/cspell-action@<full-sha> # <version>
+        with:
+          files: '**/*.{md,txt,rst,yaml,yml}'
+
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - run: semgrep scan --config auto --error
+```
+
+(`--error` for the same reason as the hook: without it findings don't fail the job.)
+
+The gitleaks job's `permissions:` block is required: the default `GITHUB_TOKEN` no longer grants `pull-requests: read`, and `gitleaks-action` needs it in PR context to fetch the PR's commit list — without it, the first PR run fails with `403 Resource not accessible by integration`. Job-level rather than workflow-level keeps it least-privilege; cspell and semgrep don't need it.
+
+Create a separate `.github/workflows/actionlint.yml` with a path filter (or add to existing CI with the same filter). `rhysd/actionlint` publishes no GitHub Action to pin, so use the official download script rather than `rhysd/actionlint@main` (a mutable branch reference that fails the repo's own semgrep gate):
+
+```yaml
+name: Actionlint
+on:
+  push:
+    paths: ['.github/workflows/**']
+  pull_request:
+    paths: ['.github/workflows/**']
+
+jobs:
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - name: Download actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Run actionlint
+        run: ./actionlint -color
+```
+
+Don't duplicate if any of these jobs already exist. Every `uses:` reference must be pinned to a full commit SHA with a version comment — look up the latest release of each action and substitute the real SHA for `<full-sha>`, e.g.:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+```
+
+A floating tag (`@v4`) or branch (`@main`) is a mutable reference — it fails the semgrep gate installed above (`github-actions-mutable-action-tag` is a blocking finding), so samples committed with floating tags fail their own repo's CI.
+
+### 8. Dependabot auto-merge
+
+Create `.github/workflows/dependabot-auto-merge.yml` (if it doesn't already exist):
+
+```yaml
+name: Dependabot Auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+`--squash` here is deliberate and is the one place it stays. The global default is merge-commit (see the Git Workflow section of the user's global agent policy), because squash's SHA rewrite punishes stacked branches — but a Dependabot PR is a single-commit version bump that nothing is ever stacked on, and one commit per bump keeps `main` readable. Don't "fix" this to match the default.
+
+Also ensure `.github/dependabot.yml` exists with the base structure. If it doesn't exist, create it:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+If `.github/dependabot.yml` already exists, read it first and ensure the `github-actions` ecosystem entry is present. Don't duplicate entries.
+
+The `cooldown` block is load-bearing, not a lint nit: this same skill installs auto-merge, so without a cooldown a freshly published malicious or broken version can land on `main` with nobody looking at it. Seven days gives upstream time to yank a bad release first. Every ecosystem entry — here and in the language skills — carries the same block (semgrep's `dependabot-missing-cooldown` rule blocks on entries without one).
+
+> **Note:** Auto-merge requires branch protection or rulesets with required status checks enabled on the default branch. Without this, `--auto` merges immediately without waiting for CI.
+
+### 9. Verify
+
+Run `pre-commit run --all-files` to confirm everything works. Fix any issues that come up.
+
+### 10. Closing summary
+
+End the closing summary with this reminder (verbatim or close to it):
+
+```text
+Local baseline applied. Run /setup-repo next to apply the GitHub-side
+settings (branch protection, squash-merge rules, secret scanning, labels).
+```
+
+The two commands are a pair that is easy to half-apply: this one writes local files, `setup-repo` configures the remote (different preconditions, different blast radius — the split is deliberate). Naming what `setup-repo` adds is the load-bearing part of the reminder; skip it only if `setup-repo` was already run this session.
+
+## Important
+
+- Do NOT blindly overwrite existing config files. Read them first and merge.

--- a/home/skills/setup-docker/SKILL.md
+++ b/home/skills/setup-docker/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: setup-docker
+description: Set up container linting and image security scanning for a project that has a Dockerfile or Containerfile — hadolint and trivy, wired into pre-commit and CI.
+---
+
+# Set up Docker linting and scanning
+
+## What to install and configure
+
+### 1. Hadolint
+
+Create `.hadolint.yaml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```yaml
+ignored:
+  - DL3008  # Pin versions in apt-get install
+  - DL3018  # Pin versions in apk add
+
+trustedRegistries:
+  - docker.io
+  - gcr.io
+  - ghcr.io
+```
+
+### 2. .gitignore
+
+No Docker-specific entries needed. Confirm `setup-common` has already created a `.gitignore` with the standard entries.
+
+### 3. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/hadolint/hadolint
+    rev: <latest tag>
+    hooks:
+      - id: hadolint-docker
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include Docker linting and security scanning jobs that only run when Dockerfiles change. Use a separate workflow file (e.g., `.github/workflows/docker.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Docker
+on:
+  push:
+    paths: ['**/Dockerfile*', '**/docker-compose*.yml']
+  pull_request:
+    paths: ['**/Dockerfile*', '**/docker-compose*.yml']
+
+jobs:
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: hadolint/hadolint-action@<full-sha> # <version>
+        with:
+          dockerfile: Dockerfile
+
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: aquasecurity/trivy-action@<full-sha> # <version>
+        with:
+          scan-type: 'fs'
+          scanners: 'misconfig'
+```
+
+Don't duplicate if Docker lint jobs already exist. Look up latest action versions.
+
+If the project builds container images, suggest also adding an image scan step that runs `trivy image` after the build.
+
+### 5. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `docker` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 6. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- If the project has multiple Dockerfiles, configure hadolint-action to scan all of them.

--- a/home/skills/setup-dotnet/SKILL.md
+++ b/home/skills/setup-dotnet/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: setup-dotnet
+description: Set up .NET and C# formatting, analysers, security scanning and dependency auditing for a project — dotnet format, Roslyn analysers, SecurityCodeScan, wired into pre-commit and CI.
+---
+
+# Set up .NET tooling
+
+## What to install and configure
+
+### 1. EditorConfig for CSharp
+
+Append C#-specific settings to `.editorconfig` (merge with existing):
+
+```ini
+[*.cs]
+indent_size = 4
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+dotnet_sort_system_directives_first = true
+
+# Naming conventions
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_naming_style.camel_case.capitalization = camel_case
+dotnet_naming_style.underscore_prefix.capitalization = camel_case
+dotnet_naming_style.underscore_prefix.required_prefix = _
+```
+
+### 2. Directory.Build.props (Roslyn analysers + SecurityCodeScan)
+
+Create or update `Directory.Build.props` in the solution root:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SecurityCodeScan.VS2019" Version="*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>
+```
+
+Look up the latest stable version of `SecurityCodeScan.VS2019` (or `SecurityCodeScan.VS2022` for .NET 8+) and pin it instead of `*`.
+
+### 3. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# .NET
+bin/
+obj/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+packages/
+*.nupkg
+project.lock.json
+```
+
+### 4. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/dotnet/format
+    rev: <latest tag>
+    hooks:
+      - id: dotnet-format
+        args: ['--verbosity', 'minimal']
+```
+
+If no pre-commit hook is available for `dotnet format`, use a local hook instead:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: dotnet-format
+        name: dotnet format
+        entry: dotnet format --verbosity minimal
+        language: system
+        types: [c#]
+```
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include .NET build, lint, and security scanning jobs that only run when C# files change. Use a separate workflow file (e.g., `.github/workflows/dotnet.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: .NET
+on:
+  push:
+    paths: ['**/*.cs', '**/*.csproj', '**/*.sln', 'Directory.Build.props']
+  pull_request:
+    paths: ['**/*.cs', '**/*.csproj', '**/*.sln', 'Directory.Build.props']
+
+jobs:
+  build-and-lint:
+    name: Build & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-dotnet@<full-sha> # <version>
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet restore
+      - run: dotnet build --no-restore /p:TreatWarningsAsErrors=true
+      - run: dotnet format --verify-no-changes --verbosity minimal
+
+  outdated:
+    name: Dependency Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-dotnet@<full-sha> # <version>
+        with:
+          dotnet-version: '8.0.x'
+      - run: dotnet tool install --global dotnet-outdated-tool
+      - run: dotnet outdated
+```
+
+Adjust `dotnet-version` to match the project. Don't duplicate if .NET build jobs already exist. Look up latest action versions.
+
+### 6. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `nuget` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "dotnet"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 7. Verify
+
+Run `dotnet build` to confirm analysers are active and no warnings are emitted. Run `dotnet format --verify-no-changes` to confirm formatting.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- If the project uses a `.sln` file, ensure `dotnet format` targets the solution.
+- Adjust the .NET SDK version in CI to match the project's target framework.

--- a/home/skills/setup-go/SKILL.md
+++ b/home/skills/setup-go/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: setup-go
+description: Set up Go formatting, linting and vulnerability scanning for a project — gofmt, goimports, golangci-lint and govulncheck, wired into pre-commit and CI.
+---
+
+# Set up Go tooling
+
+## What to install and configure
+
+### 1. golangci-lint
+
+Create `.golangci.yml` in the project root (if it doesn't already exist). If one exists, review and suggest additions — and if it's in the v1 schema (top-level `linters-settings`, no `version` key), migrate it: golangci-lint v2 rejects v1 configs outright.
+
+```yaml
+# golangci-lint v2 schema. The v1 layout (top-level linters-settings, gosimple
+# as its own linter) is rejected outright by v2.
+version: "2"
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - staticcheck
+    - unused
+    - ineffassign
+    - revive
+    - misspell
+    - gosec
+  settings:
+    revive:
+      rules:
+        - name: exported
+          severity: warning
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - <module path>  # set to the module path from go.mod
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+run:
+  timeout: 5m
+```
+
+Replace `<module path>` with the module path from `go.mod`. v2 schema gotchas, in case you are adapting an existing config:
+
+- `gosimple` was merged into `staticcheck` and `typecheck` was never a real enableable linter — neither may appear in `enable:`.
+- Formatting tools (`gofmt`, `goimports`, `gofumpt`) live in the top-level `formatters:` block, not `linters:`.
+- A settings key that is present but empty parses as `null` and fails `golangci-lint config verify` — even though `golangci-lint run` tolerates it. Omit the key entirely rather than leaving it blank. (`run` is generally more permissive than `config verify`, and CI runs `config verify` first — so a config can pass locally and still fail CI.)
+- v1's `issues.exclude-use-default` is gone; exclusions are configured under `linters.exclusions`.
+
+After writing the config, run `golangci-lint config verify` to confirm it parses — not just `golangci-lint run`.
+
+### 2. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Go
+bin/
+dist/
+*.exe
+*.test
+*.out
+coverage.out
+coverage.html
+vendor/
+```
+
+### 3. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/golangci/golangci-lint
+    rev: <latest tag>
+    hooks:
+      - id: golangci-lint-config-verify
+      - id: golangci-lint
+      - id: golangci-lint-fmt
+```
+
+Look up the latest release tag and use it for the `rev:` value. All three hooks come from the one binary, so hook and CI can never run different versions:
+
+- `golangci-lint-config-verify` catches the run/verify strictness gap locally instead of in CI (it only fires when `.golangci.yml` changes).
+- `golangci-lint-fmt` runs the `formatters:` block (`gofmt`/`goimports`), replacing any separate formatting hook — do not add `tekwizely/pre-commit-golang` alongside it.
+
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include Go lint and vulnerability scanning jobs that only run when Go files change. Use a separate workflow file (e.g., `.github/workflows/go.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Go
+on:
+  push:
+    paths: ['**/*.go', 'go.mod', 'go.sum']
+  pull_request:
+    paths: ['**/*.go', 'go.mod', 'go.sum']
+
+jobs:
+  lint:
+    name: Go Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-go@<full-sha> # <version>
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@<full-sha> # <version>
+
+  govulncheck:
+    name: Govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-go@<full-sha> # <version>
+        with:
+          go-version-file: go.mod
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...
+```
+
+Don't duplicate if Go lint jobs already exist. Look up latest action versions.
+
+### 5. govulncheck (local)
+
+Check if `govulncheck` is installed (`go install golang.org/x/vuln/cmd/govulncheck@latest`). If not, tell the user to install it. It's run manually or in CI (above), not as a pre-commit hook (too slow).
+
+### 6. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `gomod` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "go"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 7. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- If there's no `go.mod`, warn the user — Go tooling requires a module.

--- a/home/skills/setup-java/SKILL.md
+++ b/home/skills/setup-java/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: setup-java
+description: Set up Java formatting, linting and dependency auditing for a project — spotless or google-java-format, checkstyle, SpotBugs, PMD and OWASP dependency-check, wired into pre-commit and CI.
+---
+
+# Set up Java tooling
+
+## What to install and configure
+
+### 1. google-java-format / spotless
+
+If the project uses **Gradle**, add the Spotless plugin to `build.gradle` or `build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("com.diffplug.spotless") version "<latest>"
+}
+
+spotless {
+    java {
+        googleJavaFormat()
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+```
+
+If the project uses **Maven**, add the Spotless plugin to `pom.xml`:
+
+```xml
+<plugin>
+    <groupId>com.diffplug.spotless</groupId>
+    <artifactId>spotless-maven-plugin</artifactId>
+    <version>LATEST</version>
+    <configuration>
+        <java>
+            <googleJavaFormat/>
+            <removeUnusedImports/>
+            <trimTrailingWhitespace/>
+            <endWithNewline/>
+        </java>
+    </configuration>
+</plugin>
+```
+
+Look up the latest stable version of the Spotless plugin.
+
+### 2. Checkstyle
+
+Create `checkstyle.xml` in the project root (if it doesn't already exist) or use Google's published config:
+
+```xml
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="GoogleStyle"/>
+    </module>
+</module>
+```
+
+For most projects, using the Google style checkstyle config via Spotless is sufficient. Only add standalone checkstyle if the project has custom rules.
+
+### 3. SpotBugs / PMD
+
+If the project uses Gradle, add:
+
+```kotlin
+plugins {
+    id("com.github.spotbugs") version "<latest>"
+    id("pmd")
+}
+
+pmd {
+    isConsoleOutput = true
+    ruleSetFiles = files("pmd-ruleset.xml")
+}
+```
+
+If these are too noisy for an existing codebase, start with Spotless formatting only and add linters incrementally.
+
+### 4. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Java
+*.class
+*.jar
+*.war
+*.ear
+target/
+build/
+.gradle/
+out/
+*.iml
+.idea/
+```
+
+### 5. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: spotless-check
+        name: spotless check
+        entry: ./gradlew spotlessCheck
+        language: system
+        types: [java]
+        pass_filenames: false
+```
+
+For Maven projects, use `mvn spotless:check` as the entry instead.
+
+### 6. GitHub Actions workflow
+
+Create or update the CI workflow to include Java linting and dependency auditing jobs that only run when Java files change. Use a separate workflow file (e.g., `.github/workflows/java.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Java
+on:
+  push:
+    paths: ['**/*.java', 'build.gradle*', 'pom.xml', 'settings.gradle*']
+  pull_request:
+    paths: ['**/*.java', 'build.gradle*', 'pom.xml', 'settings.gradle*']
+
+jobs:
+  lint:
+    name: Spotless & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-java@<full-sha> # <version>
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - run: ./gradlew spotlessCheck
+      - run: ./gradlew check
+
+  dependency-check:
+    name: OWASP Dependency Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-java@<full-sha> # <version>
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: dependency-check/Dependency-Check_Action@<full-sha> # <version>
+        with:
+          project: '${{ github.repository }}'
+          path: '.'
+          format: 'HTML'
+```
+
+Adjust for Maven if the project uses `pom.xml` instead of Gradle. Don't duplicate if Java lint jobs already exist. Look up latest action versions.
+
+### 7. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `maven` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "java"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+If the project uses Gradle instead of Maven, use `gradle` as the `package-ecosystem` value.
+
+### 8. Verify
+
+Run `./gradlew spotlessCheck` (or `mvn spotless:check`) to confirm formatting. Fix any issues with `./gradlew spotlessApply`.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- Ask the user whether the project uses Gradle or Maven before configuring.
+- Adjust the Java version in CI to match the project's target.

--- a/home/skills/setup-markdown/SKILL.md
+++ b/home/skills/setup-markdown/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: setup-markdown
+description: Set up markdown linting and formatting for a project — markdownlint-cli2 and prettier, wired into pre-commit and CI.
+---
+
+# Set up markdown linting
+
+## What to install and configure
+
+### 1. markdownlint-cli2
+
+Create `.markdownlint.yaml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```yaml
+# Default state for all rules
+default: true
+
+# MD013 - Line length
+MD013: false
+
+# MD033 - Inline HTML
+MD033: false
+
+# MD041 - First line should be a top-level heading
+MD041: false
+```
+
+### 2. Prettier (markdown formatting)
+
+Add markdown configuration to `.prettierrc` (create if needed, merge if exists):
+
+```json
+{
+  "proseWrap": "always",
+  "printWidth": 120,
+  "tabWidth": 2
+}
+```
+
+Create `.prettierignore` if it doesn't exist:
+
+```text
+CHANGELOG.md
+```
+
+### 3. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: <latest tag>
+    hooks:
+      - id: markdownlint-cli2
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+For the prettier hook, do **not** use `pre-commit/mirrors-prettier` — it is archived and no longer receives releases. Use a `repo: local` hook running the project's own binary. If the project has a `package.json`, add prettier as a devDependency (`npm install -D prettier`) and use:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: npx --no-install prettier --write
+        language: system
+        types_or: [markdown]
+```
+
+(`--no-install` matters: without it, a missing `node_modules` makes npx silently download some other version instead of failing.)
+
+If the project has no `package.json` (a docs-only repo), either install prettier globally (`brew install prettier`) and use `entry: prettier --write`, or skip the prettier hook — markdownlint-cli2 already covers lint-level formatting.
+
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include a markdown lint job that only runs when markdown files change.
+
+```yaml
+  markdown-lint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: DavidAnson/markdownlint-cli2-action@<full-sha> # <version>
+```
+
+Add a path filter on the workflow trigger so this job only runs when relevant files change:
+
+```yaml
+on:
+  push:
+    paths: ['**/*.md']
+  pull_request:
+    paths: ['**/*.md']
+```
+
+If there's already a CI workflow with broader triggers, add the job there and use a job-level `if` with `github.event.pull_request` changed files, or create a separate workflow file (e.g., `.github/workflows/markdown.yml`) with the path filter. Don't duplicate if a markdown lint job already exists.
+
+### 5. Verify
+
+Run `pre-commit run --all-files` to confirm. Fix any markdown lint issues that surface.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.

--- a/home/skills/setup-node/SKILL.md
+++ b/home/skills/setup-node/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: setup-node
+description: Set up Node.js formatting, linting and dependency auditing for a JavaScript project — prettier, eslint and npm audit, wired into pre-commit and CI.
+---
+
+# Set up Node.js tooling
+
+## What to install and configure
+
+### 1. Prettier (formatting)
+
+Create `.prettierrc` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```json
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}
+```
+
+Create `.prettierignore` if it doesn't exist:
+
+```text
+node_modules/
+dist/
+build/
+coverage/
+```
+
+### 2. ESLint
+
+Create `eslint.config.js` (flat config) in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```js
+import js from '@eslint/js';
+
+export default [
+  js.configs.recommended,
+  {
+    rules: {
+      'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-console': 'warn',
+      'prefer-const': 'error',
+      'no-var': 'error',
+    },
+  },
+  {
+    ignores: ['node_modules/', 'dist/', 'build/', 'coverage/'],
+  },
+];
+```
+
+If the project uses CommonJS (no `"type": "module"` in `package.json`), use `eslint.config.cjs` with `require()` instead.
+
+### 3. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Node.js
+node_modules/
+dist/
+build/
+coverage/
+*.tgz
+.npm
+.eslintcache
+```
+
+### 4. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`. Use `repo: local` hooks running the project's own binaries — not the `pre-commit/mirrors-*` repos: `mirrors-prettier` is archived and no longer receives releases, and both mirrors pin their own copy of the tool, so the hook and `package.json` can silently run different versions.
+
+```yaml
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: npx --no-install prettier --write
+        language: system
+        types_or: [javascript, jsx, json, css, markdown]
+      - id: eslint
+        name: eslint
+        entry: npx --no-install eslint
+        language: system
+        types: [javascript]
+```
+
+`--no-install` matters: without it, a missing `node_modules` makes npx silently download some other version instead of failing. Both tools must be devDependencies — `npm install -D prettier eslint @eslint/js` if they aren't already.
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include Node.js linting and dependency auditing jobs that only run when JS files change. Use a separate workflow file (e.g., `.github/workflows/node.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Node.js
+on:
+  push:
+    paths: ['**/*.js', '**/*.mjs', '**/*.cjs', 'package.json', 'package-lock.json']
+  pull_request:
+    paths: ['**/*.js', '**/*.mjs', '**/*.cjs', 'package.json', 'package-lock.json']
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prettier --check .
+      - run: npx eslint .
+
+  audit:
+    name: npm Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
+        with:
+          node-version-file: '.node-version'
+      - run: npm audit --audit-level=high
+```
+
+If the project doesn't have `.node-version`, use a fixed `node-version: '22'` (or whatever the project uses). Don't duplicate if Node.js lint jobs already exist. Look up latest action versions.
+
+### 6. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `npm` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 7. Verify
+
+Run `npx prettier --check .` and `npx eslint .` to confirm. Fix formatting issues with `npx prettier --write .`.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- Use ESLint flat config format (eslint.config.js) for new projects. If the project has an existing `.eslintrc.*`, don't migrate unless asked.
+- If the project uses yarn or pnpm instead of npm, adjust commands and CI accordingly.

--- a/home/skills/setup-php/SKILL.md
+++ b/home/skills/setup-php/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: setup-php
+description: Set up PHP formatting, static analysis and dependency auditing for a project — PHP-CS-Fixer, PHPStan or Psalm, and composer audit, wired into pre-commit and CI.
+---
+
+# Set up PHP tooling
+
+## What to install and configure
+
+### 1. PHP-CS-Fixer (formatting)
+
+Create `.php-cs-fixer.dist.php` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```php
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->exclude('vendor');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'no_unused_imports' => true,
+        'trailing_comma_in_multiline' => true,
+        'single_quote' => true,
+    ])
+    ->setFinder($finder);
+```
+
+### 2. PHPStan (static analysis)
+
+Create `phpstan.neon` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```neon
+parameters:
+    level: 6
+    paths:
+        - src
+    excludePaths:
+        - vendor
+```
+
+Adjust `paths` and `level` to match the project. Level 6 is a good starting point; level 9 is maximum strictness. For existing codebases, start lower and increase incrementally.
+
+### 3. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# PHP
+vendor/
+composer.lock
+.phpunit.result.cache
+.php-cs-fixer.cache
+phpstan-baseline.neon
+```
+
+Note: `composer.lock` should be committed for applications but may be ignored for libraries. Ask the user which type this project is and adjust accordingly.
+
+### 4. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: php-cs-fixer
+        name: php-cs-fixer
+        entry: vendor/bin/php-cs-fixer fix --dry-run --diff
+        language: system
+        types: [php]
+        pass_filenames: false
+      - id: phpstan
+        name: phpstan
+        entry: vendor/bin/phpstan analyse
+        language: system
+        types: [php]
+        pass_filenames: false
+```
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include PHP linting and dependency auditing jobs that only run when PHP files change. Use a separate workflow file (e.g., `.github/workflows/php.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: PHP
+on:
+  push:
+    paths: ['**/*.php', 'composer.json', 'composer.lock', 'phpstan.neon']
+  pull_request:
+    paths: ['**/*.php', 'composer.json', 'composer.lock', 'phpstan.neon']
+
+jobs:
+  lint:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: shivammathur/setup-php@<full-sha> # <version>
+        with:
+          php-version: '8.3'
+      - run: composer install --no-progress
+      - run: vendor/bin/php-cs-fixer fix --dry-run --diff
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: shivammathur/setup-php@<full-sha> # <version>
+        with:
+          php-version: '8.3'
+      - run: composer install --no-progress
+      - run: vendor/bin/phpstan analyse
+
+  audit:
+    name: Composer Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: shivammathur/setup-php@<full-sha> # <version>
+        with:
+          php-version: '8.3'
+      - run: composer audit
+```
+
+Adjust `php-version` to match the project. Don't duplicate if PHP lint jobs already exist. Look up latest action versions.
+
+### 6. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `composer` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "php"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 7. Verify
+
+Run `vendor/bin/php-cs-fixer fix --dry-run --diff` and `vendor/bin/phpstan analyse` to confirm. Fix any issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- If the project uses Psalm instead of PHPStan, substitute accordingly.
+- Adjust the PHP version in CI to match the project's minimum supported version.

--- a/home/skills/setup-python/SKILL.md
+++ b/home/skills/setup-python/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: setup-python
+description: Set up Python formatting, linting, type checking and security scanning for a project — ruff, mypy or pyright, bandit and pip-audit, wired into pre-commit and CI.
+---
+
+# Set up Python tooling
+
+Use `uv` for all Python package management. Never use `pip install` or `pipx` directly.
+
+## What to install and configure
+
+### 1. ruff (formatting + linting)
+
+Add ruff configuration to `pyproject.toml` (create if needed, merge if exists):
+
+```toml
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "UP",   # pyupgrade
+    "SIM",  # flake8-simplify
+    "S",    # flake8-bandit (security)
+    "RUF",  # ruff-specific rules
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101"]  # Allow assert in tests
+```
+
+Adjust `target-version` to match the project's minimum Python version.
+
+### 2. mypy (type checking)
+
+Add mypy configuration to `pyproject.toml`:
+
+```toml
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+```
+
+Adjust `python_version` to match the project. If `strict = true` is too aggressive for an existing codebase, start with:
+
+```toml
+[tool.mypy]
+python_version = "3.12"
+check_untyped_defs = true
+disallow_untyped_defs = false
+```
+
+### 3. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+dist/
+build/
+.eggs/
+*.egg
+.venv/
+venv/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+htmlcov/
+coverage.xml
+.coverage
+```
+
+### 4. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: <latest tag>
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: <latest tag>
+    hooks:
+      - id: mypy
+        additional_dependencies: []  # Add project deps that have type stubs
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+The `additional_dependencies` list in the mypy hook should include any packages that provide type stubs needed by the project (e.g., `types-requests`).
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include Python linting, type checking, and security scanning jobs that only run when Python files change. Use a separate workflow file (e.g., `.github/workflows/python.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Python
+on:
+  push:
+    paths: ['**/*.py', 'pyproject.toml', 'uv.lock']
+  pull_request:
+    paths: ['**/*.py', 'pyproject.toml', 'uv.lock']
+
+jobs:
+  lint:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: astral-sh/ruff-action@<full-sha> # <version>
+
+  typecheck:
+    name: Mypy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: astral-sh/setup-uv@<full-sha> # <version>
+      - run: uv sync
+      - run: uv run mypy .
+
+  security:
+    name: Bandit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: astral-sh/setup-uv@<full-sha> # <version>
+      - run: uv tool run bandit -r . -c pyproject.toml
+```
+
+Don't duplicate if Python lint jobs already exist. Look up latest action versions.
+
+### 6. Bandit configuration
+
+Add bandit configuration to `pyproject.toml`:
+
+```toml
+[tool.bandit]
+exclude_dirs = ["tests", ".venv", "venv"]
+skips = []
+```
+
+### 7. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `pip` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+If `pyproject.toml` is in a subdirectory rather than the repo root, adjust `directory` accordingly.
+
+### 8. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or type issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- Always use `uv` for Python package management, never `pip` directly.
+- If the project uses `pyright` instead of `mypy`, substitute accordingly.
+- Note that ruff's `S` rules overlap with bandit. Having both is intentional — ruff catches issues inline during editing, bandit provides deeper analysis in CI.

--- a/home/skills/setup-repo/SKILL.md
+++ b/home/skills/setup-repo/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: setup-repo
+description: Configure a GitHub repository's settings and branch protection: merge methods, required status checks, auto-delete of merged branches, and the P0-P4 and type labels. Independent of local tooling setup.
+---
+
+# Configure GitHub repository settings
+
+> **Note:** This command uses `gh repo edit` and `gh api` to modify remote GitHub settings. Each call will prompt for approval.
+
+## Modes
+
+| Invocation | What runs |
+| --- | --- |
+| `setup-repo` | The full baseline — steps 1–8 below |
+| `/setup-repo --labels-only` | **Step 7 only** (work-tracking labels), then a short confirmation. Skips repo settings, merge strategy, secret scanning, branch protection and verification entirely |
+
+`--labels-only` exists for **infra and secondary repos** that will never get the full treatment — a Terraform-only sibling repo, a fork used as a mirror — but that still need the `P0`–`P4` / `type: *` label set so cross-repo Issues filed against them can follow the convention in `agentic-coding-config` `docs/github-issues-workflow.md`. Without it such repos carry only GitHub's defaults and `gh issue create --label "type: task,P2"` fails.
+
+Step 7's established-taxonomy guard applies **unchanged** in this mode: a repo with a purposeful labelling scheme of its own is still left alone.
+
+## What to configure
+
+### 1. Detect current state
+
+Before making changes, gather the current repository configuration:
+
+- Run `gh repo view --json name,owner,defaultBranchRef,deleteBranchOnMerge,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,isPrivate,hasWikiEnabled,hasProjectsEnabled` to get repo metadata
+- Run `gh api repos/{owner}/{repo}/branches/{default_branch}/protection` to check existing branch protection (a 404 means none is configured)
+- Check if `.github/workflows/` exists and list workflow files to detect CI
+
+Display a summary table showing **current vs proposed** values before applying any changes.
+
+### 2. Repository settings
+
+Apply all settings in a single `gh repo edit` call:
+
+```sh
+gh repo edit \
+  --delete-branch-on-merge \
+  --enable-merge-commit \
+  --enable-squash-merge \
+  --enable-rebase-merge=false \
+  --enable-auto-merge \
+  --allow-update-branch \
+  --enable-wiki=false \
+  --enable-projects=false
+```
+
+**Why both merge-commit and squash, and never rebase.** Merge-commit is the default (see the Git Workflow section of the user's global agent policy): squash replaces a branch's commits with a new SHA, so anything stacked on it re-applies work `main` already has. Rebase-merge shares that defect and offers no cleanup in return, so it is disabled outright rather than left as a tempting third button. Squash stays enabled for the case it is actually good at — a branch carrying WIP or fixup commits.
+
+GitHub has no "default merge method" field; the only levers are these three booleans, so leaving rebase enabled is what lets it drift back into use.
+
+If wiki or projects are currently enabled, note this in the summary but still disable them. Most hobby projects don't use these features.
+
+### 3. Merge commit message formats
+
+Set both message formats, so whichever method a PR uses produces a useful commit subject:
+
+```sh
+gh repo edit --enable-squash-merge --squash-merge-commit-message pr-title
+gh api -X PATCH repos/{owner}/{repo} -f merge_commit_title=PR_TITLE -f merge_commit_message=PR_BODY
+```
+
+`--enable-squash-merge` must be in the **same invocation** as `--squash-merge-commit-message` even though step 2 already enabled it: `gh` gates the message flag on the enable flag being present in the same call. Without it, `gh repo edit` prints its help text, exits 0, and applies nothing — the output looks like documentation, not an error, so check that it actually applied.
+
+The merge-commit format needs the API directly: `gh repo edit` has **no** `--merge-commit-title`/`--merge-commit-message` flags, only the squash pair. The API also accepts just three title/message combinations — `PR_TITLE`+`PR_BODY`, `PR_TITLE`+`BLANK`, and the default `MERGE_MESSAGE`+`PR_TITLE`. Anything else returns a 422 naming the valid set. `PR_TITLE`+`PR_BODY` is the one that matches what squash does with `pr-title`, so `main`'s log reads the same whichever method a PR used.
+
+### 4. Secret scanning (public repos only)
+
+If the repository is **public**, enable secret scanning and push protection:
+
+```sh
+gh repo edit --enable-secret-scanning --enable-secret-scanning-push-protection
+```
+
+If the repository is **private**, skip this step and note: "Secret scanning requires GitHub Advanced Security (paid) for private repos. Skipping."
+
+### 5. Branch protection
+
+Determine the CI status check names to require. Prefer deriving them from an **actual completed run** — `gh pr checks <n>` on a recent PR, or `gh api repos/{owner}/{repo}/commits/{sha}/check-runs --jq '.check_runs[].name'` — rather than reading the workflow YAML: the rendered check name can differ from the job key, and a wrong string here blocks every PR (see below). Fall back to reading `name:` values from `pull_request`-triggered jobs in `.github/workflows/` only when no run exists yet.
+
+Two hazards to warn the user about while doing this:
+
+- **Required checks are a rename trap.** Branch protection stores check names as opaque strings. Rename or remove a CI job and the old name is required forever, never reports, and every PR is blocked with no failing check to point at — nothing warns you. Whenever a CI job is renamed, removed, or a language port swaps one check for another, the protection contexts must be updated in the same change.
+- **Path-filtered jobs cannot be required checks.** A job behind a `paths:` filter never reports on PRs it skips, so PRs touching other files block forever. `setup-common` and the language skills deliberately suggest path filters — those jobs are ineligible; only require checks that run on every PR.
+
+Apply branch protection to the default branch using the GitHub API. The JSON payload should contain:
+
+- `required_status_checks.strict`: `true` (branch must be up-to-date before merging)
+- `required_status_checks.contexts`: array of detected CI check names, or `[]` if no CI workflows exist
+- `required_pull_request_reviews`: `null` (solo developer — cannot require approvals from others)
+- `enforce_admins`: `true` (critical — prevents admin-level tokens and coding agents from bypassing rules)
+- `restrictions`: `null` (not applicable for personal repos)
+- `required_linear_history`: `false` — **do not set this true.** Linear history blocks merge commits on the protected branch outright, and merge-commit is the default method (step 2). A repo with both applied cannot merge a PR at all by the sanctioned route, and the failure appears at merge time on an approved, green PR — long after the setting that caused it. It reads like a tidy-up worth restoring; it isn't
+- `allow_force_pushes`: `false`
+- `allow_deletions`: `false`
+
+Use `gh api -X PUT repos/{owner}/{repo}/branches/{default_branch}/protection` with the payload. Do not use heredocs to pass the JSON — use `--input` with process substitution or write a temporary file.
+
+If the repo has no CI workflows, the `contexts` array will be empty. This still prevents direct pushes to the default branch and enforces PRs, but won't require any specific checks to pass. Note this and suggest running `setup-common` to add CI.
+
+If branch protection already exists, show the current configuration alongside the proposed one so the user can see what will change. The PUT endpoint **replaces** the entire protection config — existing custom settings (like specific required reviewers or additional status checks) will be overwritten.
+
+### 6. Default branch name check
+
+If the default branch is `master` instead of `main`, **do not rename it automatically**. Renaming is disruptive (breaks CI, open PRs, local clones). Instead, display a warning with the manual steps:
+
+```text
+Warning: Default branch is 'master'. Consider renaming to 'main':
+  git branch -m master main
+  git push -u origin main
+  gh api -X PATCH repos/{owner}/{repo} -f default_branch=main
+  git push origin --delete master
+```
+
+### 7. Work-tracking labels
+
+*This is the step `--labels-only` runs on its own (see Modes above).*
+
+**Guard: skip this step in repos with an established label taxonomy.** Run
+`gh label list` first — if the repo already has a purposeful labelling scheme
+(e.g. `lifeos`, whose `kind:`/`effort:`/`area:`/`list:` labels are a format
+contract parsed by its mobile apps), do NOT add the standard set; the local
+taxonomy is authoritative. Only bootstrap repos with default/no labels.
+
+Create the standard work-tracking label set (see `agentic-coding-config`
+`docs/github-issues-workflow.md`). `--force` makes this idempotent —
+existing labels are updated, not duplicated:
+
+```sh
+gh label create "P0" --color b60205 --description "Critical" --force
+gh label create "P1" --color d93f0b --description "High" --force
+gh label create "P2" --color fbca04 --description "Medium" --force
+gh label create "P3" --color 0e8a16 --description "Low" --force
+gh label create "P4" --color c5def5 --description "Backlog" --force
+gh label create "type: epic" --color 1d76db --force
+gh label create "type: feature" --color 1d76db --force
+gh label create "type: task" --color 1d76db --force
+gh label create "type: bug" --color 1d76db --force
+```
+
+### 8. Verify
+
+In `--labels-only` mode, verify with `gh label list` alone — confirm the nine labels exist — and stop. Do not touch repo settings or branch protection.
+
+After a full run, verify the configuration took effect:
+
+- Run `gh repo view --json deleteBranchOnMerge,squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed` and confirm values match — expect `mergeCommitAllowed` and `squashMergeAllowed` true, `rebaseMergeAllowed` false
+- Run `gh api repos/{owner}/{repo}/branches/{default_branch}/protection` and confirm the protection rules are in place, and specifically that `required_linear_history.enabled` is `false` — if it is true, merge commits are blocked and step 5 did not apply as intended
+- Display a final summary showing all applied settings
+
+## Important
+
+- This command modifies **remote GitHub settings**, not local files. It is safe to re-run (idempotent).
+- Branch protection PUT replaces the entire config. If a repo has custom protection rules (e.g., required reviewers from a team), review the current config before overwriting.
+- Some branch protection features require GitHub Pro on private repos. If the API returns a 403, explain this to the user.
+- The `enforce_admins` setting is the most important for agent safety — without it, admin-level tokens bypass all other branch protection rules.
+- Required status check names are stored as opaque strings — remind the user that renaming a CI job later silently orphans the requirement and blocks all PRs until the protection is updated.

--- a/home/skills/setup-ruby/SKILL.md
+++ b/home/skills/setup-ruby/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: setup-ruby
+description: Set up Ruby formatting, linting and security scanning for a project — rubocop, brakeman and bundler-audit, wired into pre-commit and CI.
+---
+
+# Set up Ruby tooling
+
+## What to install and configure
+
+### 1. RuboCop (formatting + linting)
+
+Create `.rubocop.yml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```yaml
+require:
+  - rubocop-performance
+  - rubocop-rake
+
+AllCops:
+  TargetRubyVersion: 3.3
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - 'vendor/**/*'
+    - 'db/schema.rb'
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/MethodLength:
+  Max: 20
+
+Layout/LineLength:
+  Max: 120
+```
+
+Adjust `TargetRubyVersion` to match the project. If the project uses Rails, add `rubocop-rails` to the require list.
+
+### 2. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Ruby
+*.gem
+*.rbc
+.bundle/
+vendor/bundle/
+coverage/
+tmp/
+log/
+.byebug_history
+```
+
+### 3. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/rubocop/rubocop
+    rev: <latest tag>
+    hooks:
+      - id: rubocop
+        args: ['--auto-correct']
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include Ruby linting and security scanning jobs that only run when Ruby files change. Use a separate workflow file (e.g., `.github/workflows/ruby.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Ruby
+on:
+  push:
+    paths: ['**/*.rb', 'Gemfile', 'Gemfile.lock', '.rubocop.yml']
+  pull_request:
+    paths: ['**/*.rb', 'Gemfile', 'Gemfile.lock', '.rubocop.yml']
+
+jobs:
+  rubocop:
+    name: RuboCop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: ruby/setup-ruby@<full-sha> # <version>
+        with:
+          bundler-cache: true
+      - run: bundle exec rubocop
+
+  brakeman:
+    name: Brakeman
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: ruby/setup-ruby@<full-sha> # <version>
+        with:
+          bundler-cache: true
+      - run: gem install brakeman
+      - run: brakeman --no-pager
+
+  bundler-audit:
+    name: Bundler Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: ruby/setup-ruby@<full-sha> # <version>
+        with:
+          bundler-cache: true
+      - run: gem install bundler-audit
+      - run: bundle-audit check --update
+```
+
+Don't duplicate if Ruby lint jobs already exist. Look up latest action versions.
+
+Brakeman is only relevant for Rails applications. If the project is not a Rails app, skip the brakeman job.
+
+### 5. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `bundler` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "ruby"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 6. Verify
+
+Run `bundle exec rubocop` to confirm. Fix any issues with `bundle exec rubocop --auto-correct`.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- If the project uses Rails, add `rubocop-rails` to the RuboCop config and Gemfile.
+- Only include brakeman for Rails applications.

--- a/home/skills/setup-rust/SKILL.md
+++ b/home/skills/setup-rust/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: setup-rust
+description: Set up Rust formatting, linting and dependency auditing for a project — rustfmt, clippy, cargo-audit and cargo-deny, wired into pre-commit and CI.
+---
+
+# Set up Rust tooling
+
+## What to install and configure
+
+### 1. rustfmt
+
+Create `rustfmt.toml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```toml
+edition = "2021"
+max_width = 100
+use_field_init_shorthand = true
+use_try_shorthand = true
+```
+
+Adjust `edition` to match `Cargo.toml`.
+
+### 2. clippy
+
+Create `clippy.toml` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```toml
+too-many-arguments-threshold = 7
+```
+
+Add clippy configuration to `Cargo.toml` or `.cargo/config.toml`:
+
+```toml
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+unwrap_used = "warn"
+expect_used = "warn"
+```
+
+If `pedantic` is too aggressive for an existing codebase, start with the default clippy lints and add selectively.
+
+### 3. deny.toml (cargo-deny)
+
+Create `deny.toml` in the project root (if it doesn't already exist):
+
+```toml
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+```
+
+### 4. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Rust
+target/
+Cargo.lock
+```
+
+Note: `Cargo.lock` should be committed for binary crates but ignored for library crates. Ask the user which type this project is and adjust accordingly.
+
+### 5. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+```
+
+### 6. GitHub Actions workflow
+
+Create or update the CI workflow to include Rust linting, formatting, and security scanning jobs that only run when Rust files change. Use a separate workflow file (e.g., `.github/workflows/rust.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Rust
+on:
+  push:
+    paths: ['**/*.rs', 'Cargo.toml', 'Cargo.lock']
+  pull_request:
+    paths: ['**/*.rs', 'Cargo.toml', 'Cargo.lock']
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: rustsec/audit-check@<full-sha> # <version>
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  deny:
+    name: Cargo Deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: EmbarkStudios/cargo-deny-action@<full-sha> # <version>
+```
+
+Don't duplicate if Rust lint jobs already exist. Look up latest action versions.
+
+### 7. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `cargo` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 8. Verify
+
+Run `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -- -D warnings` to confirm. Fix any issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- If the project is a workspace, ensure clippy and fmt run across all workspace members.

--- a/home/skills/setup-shell/SKILL.md
+++ b/home/skills/setup-shell/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: setup-shell
+description: Set up shell script linting and formatting for a project — shellcheck and shfmt, wired into pre-commit and CI.
+---
+
+# Set up shell script linting
+
+## What to install and configure
+
+### 1. ShellCheck
+
+Create `.shellcheckrc` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```ini
+# Default shell dialect
+shell=bash
+
+# Allow sourcing from paths that can't be followed
+external-sources=true
+
+# Disable specific rules if needed (keep this minimal)
+# disable=SC1091
+```
+
+### 2. shfmt
+
+shfmt reads its config from `.editorconfig` (indent_style and indent_size). Confirm `.editorconfig` exists and has sane defaults for shell files. If not, add:
+
+```ini
+[*.sh]
+indent_style = space
+indent_size = 2
+binary_next_line = true
+switch_case_indent = true
+```
+
+### 3. .gitignore
+
+No shell-specific entries needed. Confirm `setup-common` has already created a `.gitignore` with the standard entries (OS files, editor files, `.env`).
+
+### 4. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: <latest tag>
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: <latest tag>
+    hooks:
+      - id: shfmt
+```
+
+Look up the latest release tag for each repo and use those for the `rev:` values.
+
+### 5. GitHub Actions workflow
+
+Create or update the CI workflow to include a ShellCheck job that only runs when shell files change. Use a separate workflow file (e.g., `.github/workflows/shell.yml`) with path filters, or add a job to an existing workflow.
+
+```yaml
+name: Shell
+on:
+  push:
+    paths: ['**/*.sh', '**/*.bash']
+  pull_request:
+    paths: ['**/*.sh', '**/*.bash']
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: ludeeus/action-shellcheck@<full-sha> # <version>
+        with:
+          scandir: '.'
+```
+
+Don't duplicate if a ShellCheck job already exists. Look up the latest pinned commit SHA for `ludeeus/action-shellcheck`.
+
+### 6. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or formatting issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- If the project has `.bash` or other non-`.sh` extensions, add `types_or: [bash, sh]` to the shellcheck hook.

--- a/home/skills/setup-terraform/SKILL.md
+++ b/home/skills/setup-terraform/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: setup-terraform
+description: Set up Terraform formatting, linting and security scanning for a project — terraform fmt and validate, tflint, tfsec and checkov, wired into pre-commit and CI.
+---
+
+# Set up Terraform tooling
+
+## What to install and configure
+
+### 1. tflint
+
+Create `.tflint.hcl` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```hcl
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.31.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+```
+
+Adjust the cloud provider plugin based on what the project uses (AWS, Azure, GCP). Remove the AWS plugin if not applicable and add the relevant one. If unsure, ask the user.
+
+### 2. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfplan
+.terraform.lock.hcl
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+```
+
+### 3. Add pre-commit hooks
+
+Append these repos to the existing `.pre-commit-config.yaml`:
+
+```yaml
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: <latest tag>
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_tflint
+      - id: terraform_trivy
+      - id: terraform_checkov
+```
+
+Look up the latest release tag and use it for the `rev:` value.
+
+### 4. GitHub Actions workflow
+
+Create or update the CI workflow to include Terraform linting and security scanning jobs that only run when Terraform files change. Use a separate workflow file (e.g., `.github/workflows/terraform.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: Terraform
+on:
+  push:
+    paths: ['**/*.tf', '**/*.tfvars']
+  pull_request:
+    paths: ['**/*.tf', '**/*.tfvars']
+
+jobs:
+  lint:
+    name: Terraform Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: hashicorp/setup-terraform@<full-sha> # <version>
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
+
+  tflint:
+    name: TFLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: terraform-linters/setup-tflint@<full-sha> # <version>
+      - run: tflint --init
+      - run: tflint --recursive
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: aquasecurity/trivy-action@<full-sha> # <version>
+        with:
+          scan-type: config
+          scan-ref: .
+      - uses: bridgecrewio/checkov-action@<full-sha> # <version>
+        with:
+          directory: .
+          framework: terraform
+```
+
+Don't duplicate if Terraform lint jobs already exist. Look up latest action versions.
+
+### 5. Dependabot ecosystem
+
+Read `.github/dependabot.yml` and add the `terraform` ecosystem entry if it isn't already present. Don't duplicate entries.
+
+```yaml
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "terraform"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 6. Verify
+
+Run `pre-commit run --all-files` to confirm hooks work. Fix any lint or formatting issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- Ask the user which cloud provider(s) the project targets before configuring tflint plugins.

--- a/home/skills/setup-typescript/SKILL.md
+++ b/home/skills/setup-typescript/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: setup-typescript
+description: Set up TypeScript formatting, linting, type checking and dependency auditing for a project — prettier, eslint with typescript-eslint, tsc --noEmit and npm audit, wired into pre-commit and CI.
+---
+
+# Set up TypeScript tooling
+
+## What to install and configure
+
+### 1. Prettier (formatting)
+
+Create `.prettierrc` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```json
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}
+```
+
+Create `.prettierignore` if it doesn't exist:
+
+```text
+node_modules/
+dist/
+build/
+coverage/
+```
+
+### 2. ESLint with typescript-eslint
+
+Create `eslint.config.ts` in the project root (if it doesn't already exist). If one exists, review and suggest additions.
+
+```ts
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      'no-console': 'warn',
+    },
+  },
+  {
+    ignores: ['node_modules/', 'dist/', 'build/', 'coverage/'],
+  },
+);
+```
+
+If type-checked rules are too slow or noisy for the project, use `tseslint.configs.recommended` instead of `recommendedTypeChecked`.
+
+### 3. TypeScript strict mode
+
+Review `tsconfig.json` and suggest enabling strict mode if not already set:
+
+```json
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}
+```
+
+Do not overwrite existing `tsconfig.json`. Only suggest additions for missing strict options.
+
+### 4. .gitignore
+
+Append these lines to `.gitignore` if they aren't already present:
+
+```gitignore
+# Node.js / TypeScript
+node_modules/
+dist/
+build/
+coverage/
+*.tgz
+.npm
+.eslintcache
+*.tsbuildinfo
+```
+
+### 5. Add pre-commit hooks
+
+Append this repo to the existing `.pre-commit-config.yaml`. Use `repo: local` hooks running the project's own binaries — not the `pre-commit/mirrors-*` repos: `mirrors-prettier` is archived and no longer receives releases, and both mirrors pin their own copy of the tool, so the hook and `package.json` can silently run different versions.
+
+```yaml
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: npx --no-install prettier --write
+        language: system
+        types_or: [ts, tsx, javascript, jsx, json, css, markdown]
+      - id: eslint
+        name: eslint
+        entry: npx --no-install eslint
+        language: system
+        types_or: [ts, tsx]
+```
+
+`--no-install` matters: without it, a missing `node_modules` makes npx silently download some other version instead of failing. Both tools must be devDependencies — `npm install -D prettier eslint typescript typescript-eslint @eslint/js` if they aren't already.
+
+### 6. GitHub Actions workflow
+
+Create or update the CI workflow to include TypeScript linting, type checking, and dependency auditing jobs that only run when TS files change. Use a separate workflow file (e.g., `.github/workflows/typescript.yml`) with path filters, or add jobs to an existing workflow.
+
+```yaml
+name: TypeScript
+on:
+  push:
+    paths: ['**/*.ts', '**/*.tsx', 'package.json', 'package-lock.json', 'tsconfig.json']
+  pull_request:
+    paths: ['**/*.ts', '**/*.tsx', 'package.json', 'package-lock.json', 'tsconfig.json']
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prettier --check .
+      - run: npx eslint .
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx tsc --noEmit
+
+  audit:
+    name: npm Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@<full-sha> # <version>
+      - uses: actions/setup-node@<full-sha> # <version>
+        with:
+          node-version-file: '.node-version'
+      - run: npm audit --audit-level=high
+```
+
+If the project doesn't have `.node-version`, use a fixed `node-version: '22'` (or whatever the project uses). Don't duplicate if TypeScript lint jobs already exist. Look up latest action versions.
+
+### 7. Dependabot ecosystem
+
+If the `npm` ecosystem is already configured in `.github/dependabot.yml` (e.g. from `setup-node`), skip this step. Otherwise, read `.github/dependabot.yml` and add the `npm` ecosystem entry:
+
+```yaml
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+```
+
+### 8. Verify
+
+Run `npx tsc --noEmit`, `npx prettier --check .`, and `npx eslint .` to confirm. Fix any issues.
+
+## Important
+
+- Do NOT overwrite existing configs. Read first and merge.
+- If `.pre-commit-config.yaml` doesn't exist, tell the user to run `setup-common` first.
+- Use ESLint flat config format. If the project has an existing `.eslintrc.*`, don't migrate unless asked.
+- If the project uses yarn or pnpm instead of npm, adjust commands and CI accordingly.
+- If the project is a monorepo, adjust `tsconfig.json` paths and ESLint config accordingly.


### PR DESCRIPTION
Implements ADR-0014's first decision. 16 new `home/skills/<name>/SKILL.md` files.

## The list, confirmed rather than assumed

The issue said "16 provider-neutral commands (`/setup-*` × 14, `/repo-review`) — confirm the exact list during implementation". Grepping all 21 commands for `mcp__*`, "Claude Code", `~/.claude`, `CLAUDE.md`:

| References | Commands |
| --- | --- |
| 0 | the 13 language `/setup-*` |
| 1–2 | `/repo-review`, `/setup-repo`, `/setup-common` — incidental prose only |
| 3+ | `/promote-journal-inbox` (3), `/gcp-credentials` (14), `/start-session` (2)*, `/end-session` (18), `/retrospective` (23) |

So **16** is right, but the composition differs slightly from the issue's guess: it's `/setup-*` × **15** (not 14) plus `/repo-review`. `/start-session` shows only 2 references but is session-lifecycle and stays a command with `/end-session` and `/retrospective`.

`/gcp-credentials` is deliberately excluded — it already reaches sandboxes as a skill by another route, since `cloud/bootstrap.sh` writes it to `~/.agents/skills/`.

## The templating constraint needed no work

The audit found **zero** occurrences of `$ARGUMENTS`, `$1`, `` !`cmd` `` or `@file` imports across all 21 commands. The one `@`-looking match was `` `tool --metadata @file.json` `` inside a code span describing a CLI's own syntax. So there was nothing to reword — that's now asserted by grep rather than assumed.

## What was changed in the bodies

Only three prose references, and **only in the skill copies**:

| Was | Now |
| --- | --- |
| `prefer mcp__github__issue_write when the GitHub MCP server is connected` | `prefer a structured GitHub API tool over the CLI when the client offers one` |
| `see the Git Workflow section of ~/.claude/CLAUDE.md` (×2) | `…of the user's global agent policy` |
| `a global Claude Code PreToolUse hook … every git commit Claude makes` | `a global pre-tool hook … the agent makes` |

Plus slash-command cross-references (`` `/setup-common` `` → `` `setup-common` ``, 23 of them) — a leading slash means nothing outside Claude.

Verified by diffing each skill body against its source command: the only differing lines are the ones above. `grep -rniE 'mcp__|claude code|~/\.claude|CLAUDE\.md|\bClaude\b' home/skills/` now returns **nothing**.

## Descriptions

Written fresh rather than reused — the existing first lines lean on `/setup-common` cross-references ("Assumes `/setup-common` has already been run") which is context for a human reading a command list, not a trigger for skill selection. Each new one names the tools involved, since that's what a client is matching against:

> Set up Python formatting, linting, type checking and security scanning for a project — ruff, mypy or pyright, bandit and pip-audit, wired into pre-commit and CI.

## Both forms ship for now

The commands stay until the plugin cutover (#48), as the issue specifies. **That means the skill body is a copy and can drift** — the README says so explicitly rather than leaving it to be found later. This is the main thing worth a second opinion on.

Note also that `home/skills/` deploys to `~/.claude/skills/`, which Claude Code reads natively — so after the next apply, both `/setup-python` and the `setup-python` skill are live. Intended, but it does mean the duplication is visible in the UI, not just in the repo.

## Verification

- `markdownlint-cli2 "**/*.md"` — 0 issues across 52 files.
- Frontmatter validated programmatically: `name` matches the directory, is slug-cased, no unexpected fields, description present and sentence-shaped — 16/16.
- Templating grep — zero.

**Not verified**: that the skills load and invoke correctly in a live Claude Code session, which is the issue's first acceptance criterion and needs a real session after `chezmoi apply`. Worth doing before the commands are retired.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_