### PR TITLE
Point setup-repo at the Git Workflow section's new home

### DIFF
--- a/home/commands/setup-repo.md
+++ b/home/commands/setup-repo.md
@@ -41,7 +41,7 @@ gh repo edit \
   --enable-projects=false
 ```
 
-**Why both merge-commit and squash, and never rebase.** Merge-commit is the default (see the Git Workflow section of `~/.claude/CLAUDE.md`): squash replaces a branch's commits with a new SHA, so anything stacked on it re-applies work `main` already has. Rebase-merge shares that defect and offers no cleanup in return, so it is disabled outright rather than left as a tempting third button. Squash stays enabled for the case it is actually good at — a branch carrying WIP or fixup commits.
+**Why both merge-commit and squash, and never rebase.** Merge-commit is the default (see the Git Workflow section of `~/.claude/AGENTS.md`): squash replaces a branch's commits with a new SHA, so anything stacked on it re-applies work `main` already has. Rebase-merge shares that defect and offers no cleanup in return, so it is disabled outright rather than left as a tempting third button. Squash stays enabled for the case it is actually good at — a branch carrying WIP or fixup commits.
 
 GitHub has no "default merge method" field; the only levers are these three booleans, so leaving rebase enabled is what lets it drift back into use.
 


### PR DESCRIPTION
One-line follow-up to #138 (merged in #209) — a bug I left behind there.

## What

`home/commands/setup-repo.md` says:

> Merge-commit is the default (see the Git Workflow section of `~/.claude/CLAUDE.md`)

#138 moved that section to `home/AGENTS.md` and updated the *identical* reference in `setup-common.md`, but missed this one. On `main` right now, `home/CLAUDE.md` has no `## Git Workflow` section and `home/AGENTS.md` does — so the pointer names a file that doesn't contain what it claims.

## How it was found

Not by reading. While resyncing the skill copies in #218, I added a check that normalises away the intended generalisations and asserts nothing else differs between each skill body and its source command. It flagged `setup-repo`: the skill body said "the user's global agent policy" while the command still said `CLAUDE.md`. That mismatch was the generalisation doing its job and the command being stale.

## Scope

Only this one reference. I swept the rest:

- `home/local-machine.md` names `~/.claude/CLAUDE.md` **as a file** that chezmoi overwrites — still correct.
- `README.md` describes it in the layout tree — still correct.
- `settings.json.md` and `retrospective.md` say things like "user-level CLAUDE.md forbids heredocs" — still true, since `CLAUDE.md` imports `AGENTS.md`.

Only a pointer at a *section* that moved was actually wrong.

## Verification

`markdownlint-cli2` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_