### PR TITLE
Move the ephemeral-first import into the portable core

### DIFF
--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -4,15 +4,19 @@ Portable working policy, in AGENTS.md format. Everything here holds for any
 agent on any surface — Claude Code, Codex, OpenCode, local machine or cloud
 sandbox.
 
-Two companions carry what does *not* belong here:
+Companions:
 
+- `ephemeral-first.md` — portable too, kept separate because it is a coherent
+  set of principles rather than a rule list. Imported below.
 - `CLAUDE.md` — the Claude Code adapter: tool-name mappings and anything
   meaningless to another provider. It imports this file.
 - `local-machine.md` — guidance that is only true on a workstation:
   chezmoi, the interactive shell, macOS paths.
 
-Keep a statement in exactly one of the three. If a rule is portable it
-belongs here, and the adapter should reference it rather than restate it.
+Keep a statement in exactly one of these. If a rule is portable it belongs
+here, and the adapter should reference it rather than restate it.
+
+@ephemeral-first.md
 
 ## Git Workflow
 

--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -12,11 +12,6 @@ Anything portable belongs in `AGENTS.md`, not here. This file is for what
 would be meaningless to Codex or OpenCode: Claude Code tool names, and the
 MCP servers configured on this surface.
 
-Ephemeral-first engineering principles are maintained separately, because
-they are portable policy rather than Claude-specific:
-
-@ephemeral-first.md
-
 ## GitHub MCP
 
 - **Prefer `mcp__github__*` tools over the `gh` CLI for all GitHub operations** when the GitHub MCP server is connected. Only fall back to `gh` if the MCP server is unavailable or a specific capability is missing


### PR DESCRIPTION
One line moved. `@ephemeral-first.md` now imports from `home/AGENTS.md` instead of `home/CLAUDE.md`.

## Why it was in the wrong place

Ordering, not judgment: #197 and #138 were open at the same time, #197 landed against a `CLAUDE.md` that was about to be split into a core plus an adapter, and its PR body said the import would want moving once #138 landed. It landed.

Nothing in the file is Claude-specific — environment-as-script, the repo as durable output channel, granted durable storage, external state checkpointing all hold on any surface. Left alone, the adapter accumulates portable policy, which is the thing #138 set out to stop, and the file's own preamble ("Portable policy. Applies to any agent session, on any surface.") contradicted where it was being imported from.

## Also

`AGENTS.md`'s companion list now names all three companions rather than two, and says why this one is a separate file at all: it's a coherent set of principles rather than a rule list, so it reads better standalone than inlined.

The file itself is unchanged.

## Verification

`markdownlint-cli2 "**/*.md"` — 0 issues across 57 files. `grep` confirms `CLAUDE.md` no longer mentions it and `AGENTS.md` does.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_