### PR TITLE
Assert in CI that skill bodies match their source commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v19
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff # v24.2.0
         with:
           globs: "**/*.md"
 
@@ -57,6 +57,18 @@ jobs:
       # every laptop via chezmoi, so a regression here has no staging tier.
       - name: Run the credential-helper tests
         run: sh tests/gcp-credentials-test.sh
+
+  skills-sync:
+    name: skills ↔ commands sync
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Both copies ship until the plugin cutover (#48), so the skill bodies
+      # are copies of the commands and drift silently. Retire this job with
+      # home/commands/ at that cutover.
+      - name: Skill bodies must match their source commands
+        run: python3 tests/skills-match-commands.py
 
   actionlint:
     name: Action Lint

--- a/tests/skills-match-commands.py
+++ b/tests/skills-match-commands.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Assert every skill body still matches the command it was copied from.
+
+#137 converted the 16 provider-neutral commands to Agent Skills but kept
+`home/commands/*.md` in place until the plugin cutover (#48). The skill body
+is therefore a *copy*, and the README asks that a change to one be made to
+the other.
+
+That note lasted about an hour. Two independent merges caused drift the same
+afternoon: #141 added a 39-line section to `repo-review.md` that the skill
+copy silently lost, and #138 changed a cross-reference in `setup-common.md`
+that happened to be benign only by luck. Both were caught by hand.
+
+So the differences are enumerated here instead. Every deliberate difference
+between a command and its skill is one of the transforms below; anything else
+is drift and fails the build. Adding a new generalisation means declaring it
+here, which is the point — the set stays closed and visible.
+
+**Retire this together with `home/commands/` at the #48 cutover.** Once the
+skills are the only copy there is nothing to compare, and leaving this behind
+would fail the build the day the commands are deleted.
+
+Usage: python3 tests/skills-match-commands.py
+Exits non-zero on unexplained drift, naming the file and the differing lines.
+"""
+
+import difflib
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+COMMANDS = ROOT / "home" / "commands"
+SKILLS = ROOT / "home" / "skills"
+
+# Prose the skill bodies deliberately generalise, because a skill is read by
+# clients that have never heard of Claude Code. Written command-side first.
+GENERALISATIONS = [
+    (
+        "prefer `mcp__github__issue_write` when the GitHub MCP server is connected",
+        "prefer a structured GitHub API tool over the CLI when the client offers one",
+    ),
+    (
+        "see the Git Workflow section of `~/.claude/AGENTS.md`",
+        "see the Git Workflow section of the user's global agent policy",
+    ),
+    (
+        "a global Claude Code `PreToolUse` hook runs pre-commit on every "
+        "`git commit`/`git push` Claude makes",
+        "a global pre-tool hook runs pre-commit on every "
+        "`git commit`/`git push` the agent makes",
+    ),
+]
+
+# `/setup-common` is a Claude slash-command spelling; a leading slash means
+# nothing to a client that loads the same content as a skill.
+SLASH_REF = re.compile(
+    r"`/(setup-[a-z]+|repo-review|end-session|start-session|retrospective)`"
+)
+
+
+def command_as_skill_body(text):
+    """Transform a command body the way the conversion did."""
+    for was, now in GENERALISATIONS:
+        text = text.replace(was, now)
+    return SLASH_REF.sub(r"`\1`", text)
+
+
+def strip_command_description(text):
+    """Drop the command's first-line description; `description` frontmatter carries it."""
+    return text.split("\n", 1)[1] if "\n" in text else ""
+
+
+def strip_skill_preamble(text, path):
+    """Drop the frontmatter block and the H1 that replaced the description."""
+    m = re.match(r"^---\n.*?\n---\n\n# [^\n]+\n", text, re.S)
+    if not m:
+        raise SystemExit(f"{path}: expected YAML frontmatter followed by an H1")
+    return text[m.end():]
+
+
+def main():
+    if not SKILLS.is_dir():
+        print("no home/skills/ — nothing to check")
+        return 0
+
+    skills = sorted(SKILLS.glob("*/SKILL.md"))
+    if not skills:
+        print("no skills found — nothing to check")
+        return 0
+
+    failures = 0
+    for skill_path in skills:
+        name = skill_path.parent.name
+        command_path = COMMANDS / f"{name}.md"
+
+        if not command_path.exists():
+            # Once the commands are retired this script goes with them; until
+            # then a skill without a source is a rename nobody finished.
+            print(f"FAIL {name}: no home/commands/{name}.md to compare against")
+            failures += 1
+            continue
+
+        expected = command_as_skill_body(
+            strip_command_description(command_path.read_text())
+        )
+        actual = strip_skill_preamble(skill_path.read_text(), skill_path)
+
+        if expected == actual:
+            continue
+
+        failures += 1
+        print(f"FAIL {name}: skill body has drifted from home/commands/{name}.md")
+        diff = [
+            line
+            for line in difflib.unified_diff(
+                expected.split("\n"), actual.split("\n"),
+                fromfile=f"home/commands/{name}.md (transformed)",
+                tofile=f"home/skills/{name}/SKILL.md",
+                lineterm="", n=1,
+            )
+        ]
+        for line in diff[:40]:
+            print(f"    {line[:200]}")
+        if len(diff) > 40:
+            print(f"    ... and {len(diff) - 40} more diff lines")
+        print()
+
+    if failures:
+        print(
+            f"{failures} of {len(skills)} skills have drifted.\n"
+            "\n"
+            "Both copies ship until the plugin cutover (#48), so a change to a\n"
+            "command needs the same change to its skill. If the difference is a\n"
+            "new deliberate generalisation, declare it in GENERALISATIONS in this\n"
+            "file rather than silencing the check."
+        )
+        return 1
+
+    print(f"all {len(skills)} skill bodies match their source commands")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

#137 kept `home/commands/` alongside the new `home/skills/` until the #48 cutover, so each skill body is a copy. The README asks that a change to one be made to the other.

That note lasted about an hour:

- **#141** added a 39-line *Phase A2 — Tier fit* section to `repo-review.md`; the skill copy silently lost it.
- **#138** changed a cross-reference in `setup-common.md`; benign, but only because it happened to be a line the skill generalises away.

Both were caught by hand. The next one wouldn't be.

## What

`tests/skills-match-commands.py` enumerates the deliberate differences — three prose generalisations plus the slash-command cross-reference spelling — normalises them out, and fails on anything left, printing a unified diff naming the file and lines.

The key property: **adding a new generalisation means declaring it in `GENERALISATIONS`**. The set of intended differences stays closed and visible instead of accumulating quietly, which is what made the drift possible in the first place.

New CI job `skills ↔ commands sync`, named to mirror the existing `settings.json ↔ settings.json.md sync`.

## Verified against the real failure modes

| Case | Result |
| --- | --- |
| clean tree | `all 16 skill bodies match their source commands`, exit 0 |
| command gains a section (the #141 case) | exit 1, names `setup-go`, shows the added lines |
| skill body edited in place | exit 1, shows the before/after line |
| skill with no source command | exit 1, `no home/commands/orphan.md to compare against` |

Two of my own first-pass tests were wrong and worth mentioning: one checked `head`'s exit code rather than the script's, and one edited the frontmatter `description` — which the check *correctly* ignores, since frontmatter is the one part that's meant to differ. Both retested properly above.

## Also: a wrong version comment

`markdownlint-cli2-action` was pinned to a SHA commented `# v19`. That SHA is **v24.2.0**. It was already wrong (v23.0.0) before Dependabot's #212, and **the bump did not fix it** — Dependabot updated the pin and left the annotation. I'd told you #212 would fix this; it didn't.

Audited the other three in the same pass:

| Action | Comment | Actual |
| --- | --- | --- |
| `actions/checkout` | v7.0.1 | v7.0.1 ✅ |
| `gitleaks/gitleaks-action` | v3.0.0 | v3.0.0 ✅ |
| `ludeeus/action-shellcheck` | master | no semver tag at that SHA — comment is honest |

## Retirement

The script and the job both carry a note to go with `home/commands/` at the #48 cutover. Left behind, the check would fail the build the day the commands are deleted.

## Scope note

This checks *drift*, not frontmatter validity. The `name`/`description` validation I ran ad hoc in #137 isn't included — different concern, and #220's criteria are all about drift. The script does enforce the frontmatter+H1 *shape* as a side effect, since it has to strip it.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_