### PR TITLE
Serve this repo as a plugin marketplace so cloud sessions get the config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "name": "agentic-config",
+  "owner": {
+    "name": "pmgledhill102",
+    "url": "https://github.com/pmgledhill102"
+  },
+  "metadata": {
+    "description": "Personal agent configuration: setup skills, session lifecycle commands, and the credential-broker client.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "agentic-config",
+      "source": "./home",
+      "description": "Project setup skills for 15 language and tooling stacks, a repo currency review, session lifecycle commands, and the GCP credential-broker client.",
+      "version": "0.1.0",
+      "author": {
+        "name": "pmgledhill102"
+      },
+      "homepage": "https://github.com/pmgledhill102/agentic-coding-config",
+      "license": "MIT",
+      "keywords": [
+        "setup",
+        "linting",
+        "pre-commit",
+        "session-lifecycle",
+        "gcp"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,18 @@ jobs:
       - name: Run the credential-helper tests
         run: sh tests/gcp-credentials-test.sh
 
+  plugin-manifests:
+    name: plugin manifests
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # A broken catalog fails at install time, in someone else's session, on a
+      # repo that merely enabled the plugin — a long way from the change that
+      # broke it.
+      - name: Marketplace and plugin manifests must be valid
+        run: python3 tests/plugin-manifests.py
+
   actionlint:
     name: Action Lint
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/README.md
+++ b/README.md
@@ -9,13 +9,68 @@ depends on where the session is running:
 | Channel | Surface | Mechanism |
 | --- | --- | --- |
 | [chezmoi external][chezmoi-externals] | local machines | `home/` mounts at `~/.claude/`, via [dotfiles][dotfiles] |
-| network fetch | cloud sandboxes | `cloud/bootstrap.sh`, run by the environment's setup script |
+| **plugin** | cloud sessions | this repo is a plugin marketplace; project repos enable it in `.claude/settings.json` |
+| network fetch | cloud sandboxes (credentials) | `cloud/bootstrap.sh`, run by the environment's setup script |
 
-The second exists because a cloud sandbox starts empty and never sees your
-machine's user-level config. See [`cloud/README.md`](cloud/README.md) for
-the per-environment setup and
-[ADR-0016](adrs/0016-capability-delivery-principles.md) for why the substance
-lives in a fetched script rather than in the setup script itself.
+The second and third exist because a cloud session starts empty and reads
+**only the project repo's `.claude/`** — nothing from `~/.claude/` is
+transferred. See [`cloud/README.md`](cloud/README.md) for the per-environment
+setup and [ADR-0016](adrs/0016-capability-delivery-principles.md) for why the
+credential substance lives in a fetched script rather than in the setup script.
+
+## The plugin channel
+
+`home/` doubles as the plugin root: it already had `commands/`, `skills/` and
+`bin/` in exactly the layout a plugin expects, so no tree is duplicated or
+generated. Two manifests make it a marketplace:
+
+| File | Role |
+| --- | --- |
+| `.claude-plugin/marketplace.json` (repo root) | the catalog; repo-meta, never deploys |
+| `home/.claude-plugin/plugin.json` | the plugin manifest, at the plugin root |
+
+A project repo opts in by committing to its own `.claude/settings.json` —
+`/setup-common` stamps this:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "agentic-config": {
+      "source": { "source": "github", "repo": "pmgledhill102/agentic-coding-config" }
+    }
+  },
+  "enabledPlugins": { "agentic-config@agentic-config": true }
+}
+```
+
+Note `enabledPlugins` is an **object** keyed `<plugin>@<marketplace>`, not an
+array.
+
+### What each channel can and cannot carry
+
+| Content | chezmoi | plugin |
+| --- | :-: | :-: |
+| `commands/`, `skills/` | yes | yes |
+| `bin/` helpers | yes, at `~/.claude/bin/` | yes, added to the Bash tool's `PATH` |
+| Policy prose (`AGENTS.md`, `CLAUDE.md`) | yes | **no** |
+| Permission allowlist (`settings.json`) | yes | **no** |
+| Hooks | yes, via `settings.json` | not yet — see below |
+
+Two limits are structural rather than temporary:
+
+- **Policy prose can't ride a plugin.** A plugin's own `settings.json` supports
+  only a couple of keys. Process rules reach a cloud session through the
+  project repo's own `CLAUDE.md`/`AGENTS.md`, not through this.
+- **Permissions travel only in repo `.claude/settings.json`**, which is the one
+  place a cloud session reads them from.
+
+**Hooks are not in the plugin yet.** They live in `home/settings.json` and
+reference `~/.claude/bin/` paths that don't exist in a sandbox. Porting them
+means a `home/hooks/hooks.json` plus a per-hook surface audit — several are
+workstation-only by nature — so it is deliberately separate work.
+
+Locally, nothing changes: chezmoi delivers the same content directly, and the
+plugin manifests simply ride along inert.
 
 [chezmoi-externals]: https://www.chezmoi.io/reference/special-files-and-directories/chezmoiexternal-format/
 [dotfiles]: https://github.com/pmgledhill102/dotfiles
@@ -68,10 +123,13 @@ restructure that introduced `home/` is on top of that history.
 ├── adrs/                      # repo-meta: architecture decisions
 ├── docs/                      # repo-meta: workflow docs and runbooks
 ├── .github/, .pre-commit-config.yaml, .markdownlint.yaml, .gitignore
+├── .claude-plugin/            # repo-meta: marketplace.json (the plugin catalog)
+├── tests/                     # repo-meta: behavioural tests for home/bin/
 ├── cloud/                     # ← fetched over the network into cloud sandboxes
 │   ├── bootstrap.sh           #   installs the helper + skill into a container
 │   └── README.md              #   per-environment setup (script, domains, vars)
-└── home/                      # ← THIS subdirectory mounts at ~/.claude/
+└── home/                      # ← mounts at ~/.claude/ AND is the plugin root
+    ├── .claude-plugin/        #   plugin.json — the plugin manifest
     ├── AGENTS.md              → ~/.claude/AGENTS.md  (portable policy core — every provider)
     ├── CLAUDE.md              → ~/.claude/CLAUDE.md  (Claude adapter; imports the other two)
     ├── local-machine.md       → ~/.claude/local-machine.md  (workstation-only guidance)

--- a/home/.claude-plugin/plugin.json
+++ b/home/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "agentic-config",
+  "description": "Project setup skills for 15 language and tooling stacks, a repo currency review, session lifecycle commands, and the GCP credential-broker client.",
+  "version": "0.1.0",
+  "author": {
+    "name": "pmgledhill102"
+  },
+  "homepage": "https://github.com/pmgledhill102/agentic-coding-config",
+  "repository": "https://github.com/pmgledhill102/agentic-coding-config",
+  "license": "MIT"
+}

--- a/home/commands/setup-common.md
+++ b/home/commands/setup-common.md
@@ -349,11 +349,59 @@ The `cooldown` block is load-bearing, not a lint nit: this same skill installs a
 
 > **Note:** Auto-merge requires branch protection or rulesets with required status checks enabled on the default branch. Without this, `--auto` merges immediately without waiting for CI.
 
-### 9. Verify
+### 9. Agent plugin (Claude Code only)
+
+**Provider-specific step — skip it on any client that is not Claude Code.**
+Everything else in this skill is provider-neutral; this one configures Claude
+Code's plugin system by name. The equivalent for another client is whatever
+mechanism it uses to load shared skills into a session that cannot see the
+user's machine; there is no portable spelling of it yet.
+
+Stamp the marketplace and plugin declaration into the project's
+`.claude/settings.json`, creating the file if absent and **merging** if present:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "agentic-config": {
+      "source": {
+        "source": "github",
+        "repo": "pmgledhill102/agentic-coding-config"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "agentic-config@agentic-config": true
+  }
+}
+```
+
+Note `enabledPlugins` is an **object** keyed `<plugin>@<marketplace>`, not an
+array of names.
+
+**This is the only route by which a cloud session gets any of this.** Cloud
+sessions read the project repo's `.claude/` and nothing from `~/.claude/`, so a
+repo without these two keys runs bare: no setup skills, no session commands, no
+credential helper. Locally the same content already arrives via chezmoi, so
+stamping a repo changes nothing there — it is purely what makes the cloud
+surface match.
+
+Commit the file; it is meant to be shared, not gitignored. If the repo already
+has `.claude/settings.json`, add these keys alongside whatever is there rather
+than replacing it.
+
+Permission allowlists are a separate matter: a plugin cannot carry them (a
+plugin's `settings.json` supports only a couple of keys), and repo
+`.claude/settings.json` is the **only** place a cloud session reads permissions
+from. Stamping a core allowlist there is a reasonable follow-on, deliberately
+not done automatically here — permissions are the one thing worth deciding per
+repo rather than by template.
+
+### 10. Verify
 
 Run `pre-commit run --all-files` to confirm everything works. Fix any issues that come up.
 
-### 10. Closing summary
+### 11. Closing summary
 
 End the closing summary with this reminder (verbatim or close to it):
 

--- a/home/skills/setup-common/SKILL.md
+++ b/home/skills/setup-common/SKILL.md
@@ -354,11 +354,59 @@ The `cooldown` block is load-bearing, not a lint nit: this same skill installs a
 
 > **Note:** Auto-merge requires branch protection or rulesets with required status checks enabled on the default branch. Without this, `--auto` merges immediately without waiting for CI.
 
-### 9. Verify
+### 9. Agent plugin (Claude Code only)
+
+**Provider-specific step — skip it on any client that is not Claude Code.**
+Everything else in this skill is provider-neutral; this one configures Claude
+Code's plugin system by name. The equivalent for another client is whatever
+mechanism it uses to load shared skills into a session that cannot see the
+user's machine; there is no portable spelling of it yet.
+
+Stamp the marketplace and plugin declaration into the project's
+`.claude/settings.json`, creating the file if absent and **merging** if present:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "agentic-config": {
+      "source": {
+        "source": "github",
+        "repo": "pmgledhill102/agentic-coding-config"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "agentic-config@agentic-config": true
+  }
+}
+```
+
+Note `enabledPlugins` is an **object** keyed `<plugin>@<marketplace>`, not an
+array of names.
+
+**This is the only route by which a cloud session gets any of this.** Cloud
+sessions read the project repo's `.claude/` and nothing from `~/.claude/`, so a
+repo without these two keys runs bare: no setup skills, no session commands, no
+credential helper. Locally the same content already arrives via chezmoi, so
+stamping a repo changes nothing there — it is purely what makes the cloud
+surface match.
+
+Commit the file; it is meant to be shared, not gitignored. If the repo already
+has `.claude/settings.json`, add these keys alongside whatever is there rather
+than replacing it.
+
+Permission allowlists are a separate matter: a plugin cannot carry them (a
+plugin's `settings.json` supports only a couple of keys), and repo
+`.claude/settings.json` is the **only** place a cloud session reads permissions
+from. Stamping a core allowlist there is a reasonable follow-on, deliberately
+not done automatically here — permissions are the one thing worth deciding per
+repo rather than by template.
+
+### 10. Verify
 
 Run `pre-commit run --all-files` to confirm everything works. Fix any issues that come up.
 
-### 10. Closing summary
+### 11. Closing summary
 
 End the closing summary with this reminder (verbatim or close to it):
 

--- a/tests/plugin-manifests.py
+++ b/tests/plugin-manifests.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Validate the plugin marketplace and plugin manifests.
+
+This repo is its own plugin marketplace (#48): `.claude-plugin/marketplace.json`
+at the root is the catalog, and `home/.claude-plugin/plugin.json` is the plugin
+manifest, with `home/` doubling as the plugin root.
+
+A broken manifest fails at *install* time, in someone else's session, on a repo
+that merely enabled the plugin — which is a long way from the change that broke
+it. These are the checks that can be made here instead.
+
+Usage: python3 tests/plugin-manifests.py
+"""
+
+import json
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
+
+# Directories a plugin root may contain, per the plugin structure reference.
+# `.claude-plugin/` holds ONLY plugin.json -- putting commands/, skills/,
+# agents/ or hooks/ inside it is the documented common mistake, and it fails
+# silently by simply not loading anything.
+PLUGIN_COMPONENT_DIRS = {"skills", "commands", "agents", "hooks", "bin", "monitors"}
+
+NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+errors = []
+
+
+def err(msg):
+    errors.append(msg)
+
+
+def check_marketplace():
+    if not MARKETPLACE.exists():
+        err(f"{MARKETPLACE.relative_to(ROOT)} is missing")
+        return None
+    try:
+        data = json.loads(MARKETPLACE.read_text())
+    except json.JSONDecodeError as e:
+        err(f"marketplace.json is not valid JSON: {e}")
+        return None
+
+    for field in ("name", "owner", "plugins"):
+        if field not in data:
+            err(f"marketplace.json is missing required field '{field}'")
+    if not isinstance(data.get("plugins"), list) or not data.get("plugins"):
+        err("marketplace.json 'plugins' must be a non-empty list")
+        return None
+    if "name" in data and not NAME_RE.match(data["name"]):
+        err(f"marketplace name '{data['name']}' is not slug-cased")
+    return data
+
+
+def check_plugin_entry(entry):
+    for field in ("name", "source"):
+        if field not in entry:
+            err(f"marketplace plugin entry is missing required field '{field}'")
+            return
+    name = entry["name"]
+    if not NAME_RE.match(name):
+        err(f"plugin name '{name}' is not slug-cased")
+
+    source = entry["source"]
+    if not isinstance(source, str):
+        # Non-path sources (github/git/command) are valid but out of scope for
+        # this repo, which serves its plugin from a subdirectory of itself.
+        return
+    plugin_root = (ROOT / source).resolve()
+    try:
+        plugin_root.relative_to(ROOT)
+    except ValueError:
+        err(f"plugin source '{source}' escapes the repository")
+        return
+    if not plugin_root.is_dir():
+        err(f"plugin source '{source}' does not exist")
+        return
+
+    manifest = plugin_root / ".claude-plugin" / "plugin.json"
+    if not manifest.exists():
+        err(f"plugin source '{source}' has no .claude-plugin/plugin.json")
+        return
+    try:
+        pdata = json.loads(manifest.read_text())
+    except json.JSONDecodeError as e:
+        err(f"{manifest.relative_to(ROOT)} is not valid JSON: {e}")
+        return
+
+    if "name" not in pdata:
+        err(f"{manifest.relative_to(ROOT)} is missing required field 'name'")
+    elif pdata["name"] != name:
+        # The name is the skill namespace (/name:skill), so a mismatch between
+        # catalog and manifest is a real inconsistency, not cosmetic.
+        err(
+            f"plugin name mismatch: marketplace says '{name}', "
+            f"{manifest.relative_to(ROOT)} says '{pdata['name']}'"
+        )
+
+    if "version" in entry and "version" in pdata and entry["version"] != pdata["version"]:
+        err(
+            f"version mismatch for '{name}': marketplace says "
+            f"'{entry['version']}', plugin.json says '{pdata['version']}'"
+        )
+
+    # The documented common mistake: component dirs nested under .claude-plugin/
+    # load nothing, and nothing warns.
+    for child in (plugin_root / ".claude-plugin").iterdir():
+        if child.is_dir() and child.name in PLUGIN_COMPONENT_DIRS:
+            err(
+                f"{child.relative_to(ROOT)} must live at the plugin root, "
+                "not inside .claude-plugin/"
+            )
+
+    found = sorted(
+        d.name for d in plugin_root.iterdir()
+        if d.is_dir() and d.name in PLUGIN_COMPONENT_DIRS
+    )
+    if not found:
+        err(f"plugin '{name}' has no component directories at its root")
+    else:
+        print(f"  plugin '{name}' at {source}: {', '.join(found)}")
+
+
+def main():
+    data = check_marketplace()
+    if data:
+        for entry in data["plugins"]:
+            check_plugin_entry(entry)
+
+    if errors:
+        print("\nplugin manifest validation FAILED:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print("plugin manifests are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Refs #48** — not `Closes`, because two acceptance criteria need a real cloud session. Detail at the bottom.

## Layout decision: `home/` *is* the plugin root

#48 offered "restructure `home/` to double as the plugin source, or generate/symlink a plugin tree from it". The first, and it turned out to need no restructuring at all — `home/` already had `commands/`, `skills/` and `bin/` in exactly the layout a plugin expects.

That matters beyond tidiness: a generated or symlinked tree would be a second copy, and this repo spent today proving how fast a second copy drifts (#220).

| File | Role |
| --- | --- |
| `.claude-plugin/marketplace.json` (root) | the catalog — repo-meta, never deploys |
| `home/.claude-plugin/plugin.json` | the plugin manifest, at the plugin root |

A bonus from the docs: a plugin's `bin/` is **added to the Bash tool's `PATH`** while enabled — tidier than the `~/.claude/bin/` paths the commands used to hard-code, and it composes with the `${CLAUDE_PLUGIN_ROOT}` work from #139.

## `/setup-common` stamping

New step 9 writes (merging, not replacing):

```json
{
  "extraKnownMarketplaces": {
    "agentic-config": { "source": { "source": "github", "repo": "pmgledhill102/agentic-coding-config" } }
  },
  "enabledPlugins": { "agentic-config@agentic-config": true }
}
```

**`enabledPlugins` is an object keyed `<plugin>@<marketplace>`, not an array.** #48's draft proposed `["agentic-config"]`; the current docs take the object form. Worth flagging since the issue would otherwise have been implemented wrong.

The step is explicitly marked **provider-specific and skippable** — it configures Claude Code's plugin system by name while the rest of that skill is neutral. Without that marker it would have silently leaked Claude-specific setup into the provider-neutral skill copy, which is what happened on my first pass and is why the framing is there.

## CI validation

`tests/plugin-manifests.py` + a `plugin manifests` job. A broken catalog otherwise fails at *install* time, in someone else's session, on a repo that merely enabled the plugin — a long way from the change that broke it.

Checks, each verified with a deliberate break:

| Failure | Caught |
| --- | --- |
| invalid JSON | ✅ |
| name not slug-cased | ✅ |
| catalog/manifest name mismatch | ✅ (it's the skill namespace, so a mismatch is real) |
| version mismatch | ✅ |
| source path missing | ✅ |
| source escapes the repo | ✅ |
| component dir nested inside `.claude-plugin/` | ✅ (the documented common mistake — loads nothing, warns about nothing) |

## chezmoi unchanged

The external includes only `agentic-coding-config-main/home/**`, so the root catalog never deploys. `home/.claude-plugin/plugin.json` does deploy, to `~/.claude/.claude-plugin/plugin.json`, where it is inert — the docs are explicit that the plugin root "is never `~/.claude/`".

**I could not run the template test**: chezmoi isn't installed in this sandbox. `HOME=/tmp/chezmoi-test chezmoi init --source . --dry-run` still wants running before merge.

## What's deliberately deferred

**Hooks.** They live in `home/settings.json` and reference `~/.claude/bin/` paths that don't exist in a sandbox. Porting means a `home/hooks/hooks.json` *plus* a per-hook surface audit — `prepush-guard` and `precommit` are arguably universal, the chezmoi-adjacent ones are not. Shipping half-working hooks is worse than shipping none, and #48 itself says to audit rather than port blindly.

Two limits are structural, not deferred, and the README now says so: **policy prose can't ride a plugin** (a plugin's `settings.json` takes only a couple of keys), and **permissions travel only in repo `.claude/settings.json`**.

## Acceptance criteria

- [x] Repo serves as a marketplace; plugin exposes the commands and skills under `home/`
- [ ] chezmoi apply unchanged — reasoned through, **not executed** (no chezmoi here)
- [x] `/setup-common` stamps the declaration
- [ ] Verified end-to-end in a cloud session on a stamped repo
- [ ] Empirical check that setup-script-planted `~/.claude/` files are ignored
- [x] README documents the dual channel and what each can and cannot carry

The two unticked verifications are yours — both need a real cloud session, and the empirical one is the evidence #48 asks for behind its own rationale.

## Verification

`actionlint` clean · `markdownlint-cli2` 0 issues/57 files · plugin manifests valid · all JSON parses · **skills ↔ commands sync passes** (I ran #223's checker against this branch — editing `setup-common.md` created exactly the drift it exists to catch, and the skill copy is synced).

Refs #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_