### PR TITLE
Correct the helper's contract header, and match commits by position

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
       # every laptop via chezmoi, so a regression here has no staging tier.
       - name: Run the credential-helper tests
         run: sh tests/gcp-credentials-test.sh
+      # The hook fires on every Bash call, so what it does and does not
+      # classify as a commit/push is the whole of its cost.
+      - name: Run the pre-commit hook classification tests
+        run: sh tests/precommit-hook-test.sh
 
   skills-sync:
     name: skills ↔ commands sync

--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -9,6 +9,8 @@
 #   request  ask for credentials and show the verification phrase, then return
 #            so the phrase can be relayed before anyone answers the card
 #   wait     collect the decision on that request and install the token
+#   renew    mint one token from an existing grant and exit — the recovery
+#            path when the refresh loop died but the grant is still live
 #   refresh  the refresh loop itself (started automatically by `request`;
 #            runnable in the foreground for debugging)
 #   status   report grant, refresh and gcloud state — never any secret
@@ -34,6 +36,10 @@
 #   4  timed out or expired — nobody answered, which is also a no
 #   5  rate limited by the broker
 #   6  not configured (no request key, or no broker URL)
+#   7  approved, but the agent identity never became usable — a fault, NOT a
+#      denial: nobody refused, so requesting again is legitimate
+#   8  this client is too old for the broker (HTTP 426), refused before any
+#      approval was spent — update the helper; retrying cannot help
 
 set -eu
 
@@ -567,7 +573,6 @@ cmd_request() {
 
     req_body="$TMPDIR_CB/request.json"
     req_resp="$TMPDIR_CB/request-resp.json"
-    hdr_cfg="$TMPDIR_CB/headers.conf"
 
     # env.CB_REQUEST_KEY, not --arg: jq arguments are argv, and argv is public.
     CB_REQUEST_KEY="$CB_KEY" jq -n \

--- a/home/bin/precommit-claude-hook
+++ b/home/bin/precommit-claude-hook
@@ -37,19 +37,67 @@ cwd=$(printf '%s' "$payload" | jq -r '.cwd // empty')
 # must exit immediately. Honour the standard --no-verify / -n escape hatch
 # (caveat: a message literally containing " --no-verify"/" -n " also skips —
 # a false skip, not a false block; CI still covers it).
+#
+# Matched by *position*, not by substring. `*"git commit"*` matched any command
+# merely containing the phrase, so writing it into a notes file or an issue body
+# triggered a whole pre-commit cycle -- harmless, but it costs the latency of
+# the full run on a call that was never going to commit anything.
+
+# git_subcommand prints the git subcommand a segment invokes, or nothing.
+# Skips git's own global options so `git -C path commit` still classifies.
+git_subcommand() {
+    gs_ifs=$IFS
+    IFS=' 	'
+    # shellcheck disable=SC2086  # deliberate: split the segment into words.
+    set -- $1
+    IFS=$gs_ifs
+    [ "${1:-}" = "git" ] || return 0
+    shift
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -C | -c | --git-dir | --work-tree | --namespace)
+                [ $# -ge 2 ] || return 0
+                shift 2
+                ;;
+            -*) shift ;;
+            *)
+                printf '%s' "$1"
+                return 0
+                ;;
+        esac
+    done
+}
+
+# Split on shell separators, so `cd x && git commit -m ...` still matches while
+# `echo "git commit"` does not.
 stage=""
-case "$cmd" in
-  *"git commit"*)
+cls_ifs=$IFS
+IFS='
+'
+# shellcheck disable=SC2046,SC2086  # deliberate: split on the inserted newlines.
+set -- $(printf '%s' "$cmd" | tr ';&|' '\n')
+IFS=$cls_ifs
+for seg in "$@"; do
+    case "$(git_subcommand "$seg")" in
+        commit)
+            stage="pre-commit"
+            break
+            ;;
+        push) [ -n "$stage" ] || stage="pre-push" ;;
+    esac
+done
+[ -n "$stage" ] || exit 0
+
+# Honour --no-verify / -n against the whole command, as before.
+case "$stage" in
+  "pre-commit")
     case "$cmd" in
       *" --no-verify "*|*" --no-verify"|*" -n "*|*" -n") exit 0 ;;
-    esac
-    stage="pre-commit" ;;
-  *"git push"*)
+    esac ;;
+  "pre-push")
     case "$cmd" in
       *" --no-verify "*|*" --no-verify") exit 0 ;;
-    esac
-    stage="pre-push" ;;
-  *) exit 0 ;;
+    esac ;;
 esac
 
 # --- Move into the repo the command targets. ------------------------------

--- a/tests/precommit-hook-test.sh
+++ b/tests/precommit-hook-test.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Classification tests for home/bin/precommit-claude-hook.
+#
+# The hook fires on EVERY Bash call Claude makes, so what it does and does not
+# classify as a commit/push is the whole of its cost. It used to match by
+# substring, which meant any command merely *containing* "git commit" -- writing
+# the phrase into a notes file, an issue body, this very file -- triggered a
+# full pre-commit run (#191).
+#
+# The hook exits 0 both when it declines to act and when the lint passes, so
+# these tests observe classification indirectly: they run it in a directory
+# with no .pre-commit-config.yaml, where a *classified* command reaches the
+# config check and exits 0 quietly, and an unclassified one exits earlier. To
+# tell those apart the hook is run with `sh -x` and its trace inspected for
+# whether `stage` was ever set.
+#
+# Usage: sh tests/precommit-hook-test.sh
+
+set -u
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+HOOK="$ROOT/home/bin/precommit-claude-hook"
+
+PASS=0
+FAIL=0
+
+# classify <command> -> prints the stage the hook acted on, or nothing.
+#
+# `stage` is assigned *before* the --no-verify escape hatch is evaluated, so the
+# assignment alone does not mean the hook acted. The repo-root lookup is the
+# first thing past the escape hatch, so its presence in the trace is what
+# distinguishes "classified and proceeding" from "classified then bailed".
+classify() {
+    _trace=$(printf '{"tool_input":{"command":%s},"cwd":"%s"}\n' \
+        "$(printf '%s' "$1" | jq -Rs .)" "$ROOT" | sh -x "$HOOK" 2>&1)
+    printf '%s' "$_trace" | grep -q 'show-toplevel' || return 0
+    printf '%s' "$_trace" | sed -n 's/^+* *stage=\(pre-[a-z]*\)$/\1/p' | tail -1
+}
+
+expect() { # label command expected
+    got=$(classify "$2")
+    [ -n "$got" ] || got="none"
+    if [ "$got" = "$3" ]; then
+        PASS=$((PASS + 1))
+        printf 'ok    %-52s -> %s\n' "$1" "$got"
+    else
+        FAIL=$((FAIL + 1))
+        printf 'FAIL  %-52s -> %s (want %s)\n' "$1" "$got" "$3"
+    fi
+}
+
+echo "--- commands that should be linted ---"
+expect "plain commit"            'git commit -m "x"'                       pre-commit
+expect "commit after cd"         'cd /tmp && git commit -m "x"'            pre-commit
+expect "commit with -C"          'git -C /tmp commit -m "x"'               pre-commit
+expect "commit with -c config"   'git -c user.name=x commit -m "y"'        pre-commit
+expect "plain push"              'git push -u origin main'                 pre-push
+expect "push after &&"           'git add -A && git push'                  pre-push
+expect "commit wins over push"   'git commit -m "x" && git push'           pre-commit
+expect "semicolon separated"     'echo hi; git commit -m "x"'              pre-commit
+
+echo "--- the #191 false trigger: a mention, not an invocation ---"
+expect "phrase in echo"          'echo "run git commit later" >> notes.md' none
+expect "phrase in a heredoc-ish" 'printf "%s" "git push origin main"'      none
+expect "phrase in a grep"        'grep -n "git commit" docs/*.md'          none
+expect "phrase in a filename"    'cat ./git-commit-notes.md'               none
+
+echo "--- other git subcommands are not our business ---"
+expect "git status"              'git status --porcelain'                  none
+expect "git log"                 'git log --oneline -5'                    none
+expect "git add only"            'git add -A'                              none
+expect "not git at all"          'ls -la'                                  none
+
+echo "--- escape hatch still honoured ---"
+expect "commit --no-verify"      'git commit --no-verify -m "x"'           none
+expect "push --no-verify"        'git push --no-verify'                    none
+
+echo ""
+echo "passed: $PASS   failed: $FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
All three nits in #191.

## 1. The header lied about the contract

`gcp-credentials` documented exit codes 0–6 but exits **7** and **8**. The command doc had them; the script's own header — the first thing a maintainer reads — did not. Both now documented with the distinction that matters (7 is a fault, not a denial, so retrying is legitimate; 8 is refused before an approval is spent, so retrying cannot help).

The subcommand list also omitted `renew`, which is the recovery path when the refresh loop dies but the grant is live.

## 2. The hook matched by substring

`*"git commit"*` matched any Bash call *containing* the phrase. Writing it into a notes file or an issue body triggered a full pre-commit cycle.

I **anchored** rather than documented it, of the two options the issue offered — this hook fires on every Bash call Claude makes, so what it decides to act on is the whole of its cost.

It now splits on shell separators and inspects each segment's own words, skipping git's global options:

| Command | Before | After |
| --- | --- | --- |
| `git commit -m "x"` | pre-commit | pre-commit |
| `cd /tmp && git commit -m "x"` | pre-commit | pre-commit |
| `git -C /tmp commit -m "x"` | pre-commit | pre-commit |
| `echo "run git commit later" >> notes.md` | **pre-commit** | none |
| `grep -n "git commit" docs/*.md` | **pre-commit** | none |

`tests/precommit-hook-test.sh` — **18 assertions**, in CI: eight that must lint, four mentions that must not, four other git subcommands, and both `--no-verify` escape hatches.

Worth noting how the test observes classification: the hook exits 0 both when it declines and when linting passes, so it runs the hook under `sh -x` and reads the trace. My first version got the two `--no-verify` cases wrong — `stage` is assigned *before* the escape hatch is evaluated, so the assignment alone doesn't mean the hook acted. It now keys on the repo-root lookup, the first step past the hatch.

## 3. Dead assignment

`hdr_cfg` in `cmd_request` — `poll_and_install` re-derives it.

## Verification

`shellcheck` clean on both scripts and both test harnesses · `actionlint` clean · credential-helper tests still 71/71 · `markdownlint-cli2` 0 issues.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_