### PR TITLE
Doc currency: beads framing, a historical narrative, and gates that did not run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,21 @@ blocked-by dependencies).
 No build step. Quality gates (run before pushing; CI runs the same):
 
 ```bash
-markdownlint-cli2 "**/*.md"        # markdown lint
-shellcheck home/bin/*              # shell scripts (CI scans home/bin/)
-HOME=/tmp/chezmoi-test chezmoi init --source . --dry-run  # template sanity
+markdownlint-cli2 "**/*.md"              # markdown lint
+sh tests/gcp-credentials-test.sh         # credential-helper behaviour
+python3 tests/skills-match-commands.py   # skills match their source commands
+
+# shell — CI scans home/bin/, cloud/ and tests/. Select by shebang: home/bin/
+# also holds a Python script, and `shellcheck home/bin/*` errors on it.
+find home/bin cloud tests -type f \
+  -exec sh -c 'head -1 "$1" | grep -q "^#!.*sh$"' _ {} \; -print0 \
+  | xargs -0 shellcheck
 ```
+
+**There is no chezmoi template check.** This repo contains no chezmoi
+templates: it is consumed as an **archive** external, so files deploy verbatim.
+The `chezmoi init --dry-run` gate listed here previously was inherited from
+`dotfiles`, where templates do exist, and never applied to this repo.
 
 ## Architecture Overview
 

--- a/adrs/0012-claude-code-config-via-dotfiles.md
+++ b/adrs/0012-claude-code-config-via-dotfiles.md
@@ -5,6 +5,12 @@
 - **Tags**: claude-code, tooling
 - **Scope**: user (applies to all personal repos and agent surfaces)
 
+> **Why the numbering starts at 0012.** This directory continues the
+> sequence begun in `pmgledhill102/dotfiles`, where the first eleven ADRs
+> live. `dotfiles` has since grown its own 0015, so a bare "ADR-0015" is
+> ambiguous across the two homes — **cross-repo references should use full
+> URLs**, as [ADR-0015](0015-tiered-adrs.md) requires for cross-tier links.
+
 ## Context
 
 Claude Code's user-level configuration (`~/.claude/`) defines the

--- a/adrs/0014-portable-agent-config-architecture.md
+++ b/adrs/0014-portable-agent-config-architecture.md
@@ -1,6 +1,9 @@
 # ADR-0014: Portable agent-config architecture (skills-first, provider-neutral core)
 
-- **Status**: Accepted (2026-08-09, ratified via PR #143)
+- **Status**: Accepted (2026-08-09, ratified via PR #143), **amended
+  2026-08-13 by [ADR-0016](0016-capability-delivery-principles.md)** —
+  which narrows decision 3: per-repo marketplace configuration is not the
+  delivery route for everything it implies here. Read 0016 alongside this.
 - **Date**: 2026-08-09
 - **Tags**: claude-code, codex, opencode, skills, plugins, architecture
 - **Scope**: user (applies to all personal repos and agent surfaces)

--- a/docs/end-session-design.md
+++ b/docs/end-session-design.md
@@ -17,51 +17,41 @@ Every step is classified by how much human judgment it needs:
 
 When in doubt we downgrade a tier rather than upgrade.
 
-## Retrospective — why the script split exists
+## Why the script split exists
 
-Two observations from using the command in anger.
+Two properties of the harness drove Phase 1's compound blocks into scripts.
+Both still hold, and both are what the extraction rules further down are
+derived from.
 
-> This section is a record of the April 2026 design work, not a
-> description of today's pipeline. It refers to `bd dolt push`, which was
-> genuinely one of the original 14 calls — beads was the tracker at the
-> time and has since been retired (see
-> [ADR-0013](../adrs/0013-github-issues-for-work-tracking.md)). Left as
-> written: editing it would falsify the measurement rather than update it.
+**The permission matcher sees a Bash call as one command string.** A rule like
+`Bash(git status *)` matches a call *beginning* with `git status`; it does not
+match a compound block that merely contains it alongside other commands. So a
+compound block never matches a narrow allow rule, however many of its pieces are
+individually allowed. Three fixes were available — pre-approve the exact
+compound strings (brittle: any whitespace edit breaks the match), split into N
+individual tool calls (works for a sequence, not for a pipeline, and inflates
+tool-call count), or extract the logic into a script and allow its path. The
+third gives one rule, is shellcheck-testable, and can be edited without
+reshuffling permissions.
 
-### Observation 1 — recurring approval prompts
+**Round-trip latency dominates.** Each tool call costs a model turn — emit,
+run, read, emit again — and at a large context that is seconds of latency
+independent of the command's own runtime. Most of Phase 1's reads are
+independent and network-bound, so running them serially multiplied that cost
+for no correctness benefit. Fanning them out behind a single `git fetch`
+collapses N sequential calls into one, and summed serial latency into
+max-of-parallel.
 
-Two steps of Phase 1 triggered explicit approval prompts every run, even though every individual sub-command in them was already on the permission allowlist:
+The remaining steps stay serial because they either need a y/n or depend on
+prior output. `/retrospective` was deliberately left alone: it is short, has no
+multi-line approval blockers, and its value is in agentic reasoning rather than
+fixed commands, so parallelising it would buy nothing.
 
-- Step 1 (state gather) — a compound `echo "===pwd==="; pwd; echo "===status==="; git status ...` block.
-- Step 6 Batch B (squash-merged detection) — a pipeline of `git for-each-ref | awk | grep | while read … git diff …`.
-
-**Root cause.** The Claude Code permission matcher sees a Bash tool call as a single command string. A pattern like `Bash(git status *)` matches a call whose command begins with `git status` — it does **not** match a compound block that happens to contain `git status` alongside other commands. So compound blocks never match a narrow allow rule no matter how many of their pieces are allowed individually.
-
-Three ways to fix this:
-
-1. Pre-approve the exact compound strings. Brittle — any whitespace edit breaks the match.
-2. Split the block into N individual tool calls. Works for Step 1 but not for Step 6 Batch B's pipeline, and inflates tool-call count / output noise.
-3. Extract the compound logic into a script and allow the script's path. One rule; shellcheck-testable; editable without reshuffling permissions.
-
-We picked (3).
-
-### Observation 2 — round-trip latency dominates
-
-The original Phase 1 issued ~14 sequential Bash tool calls. For each one: the model emits the call, the runtime runs the command (often network-bound — `git fetch`, `gh run list`, `gh pr list`, `bd dolt push`), the result comes back, the model reads it and emits the next call. With a large context (1M), every round trip costs meaningful seconds of model latency **independent of** the command's own runtime.
-
-Of those 14 calls, 8 are independent read-only queries with no inter-dependencies — they can all run in parallel after `git fetch`. Serialising them doubled the latency for no correctness benefit.
-
-Extracting the gather into a script that runs `git fetch` first, then fans out the 8 reads with `&` + `wait`, collapses:
-
-- ~8 sequential tool calls into 1.
-- Summed serial network latency into max-of-parallel.
-- ~7 model-turn round-trips (each ~3–8s at 1M context) into 1.
-
-Measured on the `dotfiles` repo (2026-04-21): Phase 1 gather wall time dropped from an estimated ~70s total to ~15s end-to-end (fetch-dominated). The remaining steps (Tier 2 destructive actions, `bd dolt push`, summary) are serial because they either need a y/n or depend on prior output.
-
-### Decision
-
-Extract two scripts, land one allow rule, rewrite Phase 1 to consume sectioned output. `/retrospective` was deliberately left alone — it's short, doesn't have multi-line approval blockers, and its value is in agentic reasoning rather than fixed commands; parallelisation would buy nothing.
+> The original write-up of this section carried the April 2026 measurements
+> that motivated the change, including a call to `bd dolt push` from when beads
+> was the tracker ([ADR-0013](../adrs/0013-github-issues-for-work-tracking.md)).
+> The conclusions above are what survived; the measurement narrative lives in
+> the PR that made the change.
 
 ## Architecture
 

--- a/docs/github-issues-workflow.md
+++ b/docs/github-issues-workflow.md
@@ -1,7 +1,8 @@
 # GitHub Issues workflow
 
-How work is tracked in personal repos, replacing beads
-(see [ADR-0013](../adrs/0013-github-issues-for-work-tracking.md)).
+How work is tracked in personal repos. The decision and the history behind it
+are in [ADR-0013](../adrs/0013-github-issues-for-work-tracking.md); this file
+states the current conventions only.
 
 ## Structure
 
@@ -9,7 +10,7 @@ How work is tracked in personal repos, replacing beads
 | --- | --- | --- |
 | Epic → Feature → Task | Sub-issues (`--parent`) | Nests up to 8 levels; 100 children per parent |
 | Type | Labels `type: epic\|feature\|task\|bug` | Issue *types* are org-only; labels work everywhere |
-| Priority | Labels `P0`–`P4` | P0 critical … P2 medium … P4 backlog (beads scale) |
+| Priority | Labels `P0`–`P4` | P0 critical … P2 medium … P4 backlog |
 | Dependencies | Native blocked-by (`--blocked-by`) | Max 50 per relationship type; blocked icon in lists |
 | History | Issue timeline | Automatic; includes label/state/relationship events |
 
@@ -46,8 +47,8 @@ commands above are the fallback and the cloud-sandbox option.
   `gh issue list` or direct reads (`gh issue view <n>`), which are
   strongly consistent. Deduplicate against `gh issue list --state all`,
   not search.
-- **Create an issue before starting work** (same habit as `bd create`),
-  and close it when the work merges: `gh issue close <n> --comment
+- **Create an issue before starting work**, and close it when the work
+  merges: `gh issue close <n> --comment
   "Shipped in #<pr>"`. Reference the issue from the PR body (`Closes
   #<n>`) so closure is automatic on merge.
 - **"Ready" is approximate.** `-is:blocked` filters direct blocks only;
@@ -74,9 +75,8 @@ for t in epic feature task bug; do
 done
 ```
 
-`/setup-repo` is the natural home for this — tracked in
-[#49](https://github.com/pmgledhill102/agentic-coding-config/issues/49)
-follow-ups.
+`/setup-repo` applies this as one of its steps, so a repo set up through it
+already has the labels; the loop above is for anything that was not.
 
 **Label-less infra repos**: a secondary repo that will never get the
 full `/setup-repo` baseline (a Terraform-only sibling, a mirror) ends up


### PR DESCRIPTION
All three items in #198, plus the two surviving items from #195.

## 1. Beads framing

`docs/github-issues-workflow.md` opened with "replacing beads", and carried "(beads scale)", "same habit as `bd create`", and a pointer to **#49 follow-ups** for label bootstrap — #49 closed in July, and `/setup-repo` has had the labels step since (it's even the thing `--labels-only` runs alone). ADR-0013 holds the history; the doc now states current conventions.

## 2. The historical narrative

`docs/end-session-design.md` had a section whose own callout admitted it described April 2026 and referenced retired tooling.

I **trimmed rather than deleted**. The section contains two conclusions that are still load-bearing — the permission matcher sees a Bash call as one string, and round-trip latency dominates — and the "when to extract a step into a script" rules further down the file are derived from them. Deleting outright would have orphaned those rules from their reasoning. What's gone is the dated measurement narrative and the `bd dolt push` residue, with a line saying where they went.

## 3. Quality gates

Two problems, one of which I only found by **running them**:

- The **chezmoi template-sanity check** is for a repo with no chezmoi templates — it's consumed as an archive external, so files deploy verbatim. Inherited from `dotfiles`.
- **`shellcheck home/bin/*` fails outright.** `home/bin/bd-migrate-to-github` is Python, and shellcheck errors `SC1071` on it. So that documented gate has never worked as written; CI passes because its action detects shell files by shebang.

The replacement selects by shebang, matching CI, and lists the test suites alongside. My first attempt at that was also wrong — a `grep -rlE '^#!'` picked up `cloud/README.md`, which has `#!/bin/bash` inside a fenced block. The committed form checks only the first line of each file.

**Every gate in the block was then run exactly as written**: markdownlint 0 issues, credential tests 71/71, skills sync 16/16, shellcheck clean across the 12 real shell files.

## Also: #195 items 1 and 4

Not in #198, but adjacent and small enough to carry:

- **ADR-0014** now records that **ADR-0016 amended it**. Without it, a reader of 0014 alone would apply its point 3 where 0016 narrows it.
- **ADR-0012** explains why the numbering starts at 0012, and warns that `dotfiles` has its own 0015 — so a bare "ADR-0015" is ambiguous and cross-repo references need full URLs.

That leaves #195 with only its ADR-0013 `#49` addendum outstanding; I'll comment there.

## Not included

`tests/precommit-hook-test.sh` isn't in the documented gates — it's added by #226 and doesn't exist on `main` yet. Worth adding to the block when that merges.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_