### PR TITLE
Retire .agent-policy, and fold /start-session's pre-flight into the gather

### DIFF
--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -20,8 +20,58 @@ set -uo pipefail
 
 progress() { printf '[gather] %s\n' "$*" >&2; }
 
+# --- Phase 0: pre-flight ------------------------------------------------
+# Folded in from /start-session, which used to run this as its own Bash call.
+# Everything below assumes a git repo, so this has to come before the fetch.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf '===not_a_git_repo (exit=1)===\n'
+    printf '/start-session requires a git-backed repo — nothing to sync.\n\n'
+    exit 1
+fi
+
 TMP=$(mktemp -d -t start-session-gather.XXXXXX)
 trap 'rm -rf "$TMP"' EXIT
+
+# --- Phase 0b: repo-level policy ----------------------------------------
+# Also folded in, and deliberately *parsed* rather than sourced.
+#
+# `/start-session` used to run `[ -f .agent-policy ] && . ./.agent-policy`,
+# which was wrong twice over. The compound form matches no single allow rule,
+# so it prompted on every run — the very pattern that command's own pre-flight
+# section warns against. And sourcing achieves nothing here anyway: shell state
+# does not survive between tool calls, so a variable set in one call is gone by
+# the next. The model needs these values in its context, not in a dead shell.
+#
+# Parsing also removes the arbitrary-code-execution surface that sourcing a
+# committed file carries, which the trust-model note previously had to caveat.
+POLICY_KEYS="AUTO_JOURNAL_PROMOTE"
+read_policy() {
+    [ -f .agent-policy ] || return 0
+    # Only well-formed KEY=VALUE lines, only recognised keys. Unknown keys are
+    # ignored rather than reported, matching the forward-compatibility rule.
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            '#'* | '') continue ;;
+        esac
+        case "$line" in
+            *=*) ;;
+            *) continue ;;
+        esac
+        rp_key=${line%%=*}
+        rp_val=${line#*=}
+        # Strip surrounding whitespace and any quoting the file may carry.
+        rp_key=$(printf '%s' "$rp_key" | tr -d '[:space:]')
+        rp_val=$(printf '%s' "$rp_val" | tr -d '[:space:]' | tr -d '"'"'"'"')
+        for rp_known in $POLICY_KEYS; do
+            if [ "$rp_key" = "$rp_known" ]; then
+                printf '%s=%s\n' "$rp_key" "$rp_val"
+                break
+            fi
+        done
+    done < .agent-policy
+}
+read_policy > "$TMP/policy.out" 2>&1
+echo $? > "$TMP/policy.exit"
 
 # --- Phase 1: git fetch (blocks remote-aware sections below) ---
 # Capture local default-branch SHA *before* fetch so we can later compute the
@@ -246,6 +296,6 @@ if [ "$FETCH_EXIT" -ne 0 ]; then
 fi
 printf '\n'
 
-for s in local_state main_ci recent_main_commits gh_ready gh_assigned claude_drift; do
+for s in policy local_state main_ci recent_main_commits gh_ready gh_assigned claude_drift; do
     [ -f "$TMP/$s.exit" ] && emit "$s"
 done

--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -32,47 +32,6 @@ fi
 TMP=$(mktemp -d -t start-session-gather.XXXXXX)
 trap 'rm -rf "$TMP"' EXIT
 
-# --- Phase 0b: repo-level policy ----------------------------------------
-# Also folded in, and deliberately *parsed* rather than sourced.
-#
-# `/start-session` used to run `[ -f .agent-policy ] && . ./.agent-policy`,
-# which was wrong twice over. The compound form matches no single allow rule,
-# so it prompted on every run — the very pattern that command's own pre-flight
-# section warns against. And sourcing achieves nothing here anyway: shell state
-# does not survive between tool calls, so a variable set in one call is gone by
-# the next. The model needs these values in its context, not in a dead shell.
-#
-# Parsing also removes the arbitrary-code-execution surface that sourcing a
-# committed file carries, which the trust-model note previously had to caveat.
-POLICY_KEYS="AUTO_JOURNAL_PROMOTE"
-read_policy() {
-    [ -f .agent-policy ] || return 0
-    # Only well-formed KEY=VALUE lines, only recognised keys. Unknown keys are
-    # ignored rather than reported, matching the forward-compatibility rule.
-    while IFS= read -r line || [ -n "$line" ]; do
-        case "$line" in
-            '#'* | '') continue ;;
-        esac
-        case "$line" in
-            *=*) ;;
-            *) continue ;;
-        esac
-        rp_key=${line%%=*}
-        rp_val=${line#*=}
-        # Strip surrounding whitespace and any quoting the file may carry.
-        rp_key=$(printf '%s' "$rp_key" | tr -d '[:space:]')
-        rp_val=$(printf '%s' "$rp_val" | tr -d '[:space:]' | tr -d '"'"'"'"')
-        for rp_known in $POLICY_KEYS; do
-            if [ "$rp_key" = "$rp_known" ]; then
-                printf '%s=%s\n' "$rp_key" "$rp_val"
-                break
-            fi
-        done
-    done < .agent-policy
-}
-read_policy > "$TMP/policy.out" 2>&1
-echo $? > "$TMP/policy.exit"
-
 # --- Phase 1: git fetch (blocks remote-aware sections below) ---
 # Capture local default-branch SHA *before* fetch so we can later compute the
 # delta of newly-merged commits (origin advanced; local hasn't pulled yet).
@@ -296,6 +255,6 @@ if [ "$FETCH_EXIT" -ne 0 ]; then
 fi
 printf '\n'
 
-for s in policy local_state main_ci recent_main_commits gh_ready gh_assigned claude_drift; do
+for s in local_state main_ci recent_main_commits gh_ready gh_assigned claude_drift; do
     [ -f "$TMP/$s.exit" ] && emit "$s"
 done

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -7,8 +7,8 @@ This command runs in two phases. Phase 1 is the tidy-up (mix of auto-actions and
 Every step in Phase 1 falls into one of three tiers — keep this in mind when adding or editing steps:
 
 - **Tier 1 — auto-act, no prompt**: safe, reversible, expected. Examples: `git fetch --prune`, `git pull --rebase`, read-only surface listings.
-- **Tier 2 — auto-act behind one batched confirmation**: destructive but predictable, judgment is yes/no for the whole list. Examples: deleting merged branches, deleting squash-merged branches, pushing `main` if ahead. Per-repo opt-in to Tier 1 is available via `.agent-policy` (see below) for users who always say "yes" in a given repo.
-- **Tier 3 — surface only, user drives**: needs per-item judgment, or affects shared state in ways one y/n can't capture. Examples: open PRs awaiting merge, open issues still assigned to you, stashes, user-started background processes. **Never** opt-in via `.agent-policy` — these require human judgment by design.
+- **Tier 2 — auto-act behind one batched confirmation**: destructive but predictable, judgment is yes/no for the whole list. Examples: deleting merged branches, deleting squash-merged branches, pushing `main` if ahead.
+- **Tier 3 — surface only, user drives**: needs per-item judgment, or affects shared state in ways one y/n can't capture. Examples: open PRs awaiting merge, open issues still assigned to you, stashes, user-started background processes.
 
 When in doubt, downgrade a tier (Tier 1 → 2, or 2 → 3). Never upgrade silently.
 
@@ -46,42 +46,7 @@ Stash hygiene (step 9) is worth calling out: stashes exist in a sandbox but mean
 something different — the container is disposable, so a stash left behind is
 lost rather than waiting. Surface it as usual, and say so.
 
-## Repo-level policy (`.agent-policy`)
-
-**Optional.** A POSIX shell `KEY=VALUE` file at the repo root that opts specific Tier 2 prompts into Tier 1 (auto-run, no prompt) on a per-repo basis. The file is shared with `/start-session` (which has its own keys); each command consults the keys it cares about. Defaults (file absent or key unset) preserve every prompt — adding the file never makes any repo behave more aggressively than before.
-
-**Supported keys (this command):**
-
-| Key | When `=true` | Affects |
-| --- | --- | --- |
-| `AUTO_DELETE_MERGED_BRANCHES` | Auto-delete Batch A (`-d`, fully merged into `origin/main`) — no prompt | Step 6 Batch A |
-| `AUTO_DELETE_SQUASH_MERGED_BRANCHES` | Auto-delete Batch B (`-D`, squash-merged with the safety net check) — no prompt | Step 6 Batch B |
-| `AUTO_PUSH_MAIN_IF_AHEAD` | Auto-push `main` when local is ahead of `origin/main` — no prompt | Step 7 |
-
-Any value other than `true` is treated as unset. Unknown keys (including `/start-session`'s own keys when read by this command) are ignored silently.
-
-**Trust model:** the file is sourced as POSIX shell, so a hostile commit could place arbitrary commands in it. Treat `.agent-policy` the same as `.envrc` / `.editorconfig` — only commit it on repos you control, and only opt into automation you actually want.
-
-**Note on the two delete keys:** Batch A and Batch B are separate keys deliberately. Batch A uses `-d` and only succeeds for branches with reachable upstream history — fully safe. Batch B uses `-D` (force) and relies on a safety net (empty diff vs `main` OR a merged PR via `gh`) to identify squash-merged work. Some users will trust Batch A but want to keep Batch B prompted.
-
-**Example `.agent-policy`:**
-
-```sh
-# .agent-policy — opt-in automation for /end-session in this repo
-AUTO_DELETE_MERGED_BRANCHES=true
-AUTO_PUSH_MAIN_IF_AHEAD=true
-# Leave AUTO_DELETE_SQUASH_MERGED_BRANCHES unset to keep the Batch B prompt.
-```
-
 ## Phase 1 — Tidy-up
-
-If `.agent-policy` exists at the repo root, source it once before proceeding:
-
-```sh
-[ -f .agent-policy ] && . ./.agent-policy
-```
-
-This loads any opt-in keys consulted by Tier 2 steps. The file is optional; if absent, every Tier 2 step prompts as today.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
@@ -173,7 +138,7 @@ git pull --rebase origin main
 
 If the rebase fails (conflicts, divergent history), stop and surface the error — don't attempt `--abort` or destructive recovery without asking.
 
-### 6. Prune obsolete local branches (Tier 2 — two batches, each prompted once; per-batch policy opt-in)
+### 6. Prune obsolete local branches (Tier 2 — two batches, each prompted once)
 
 Two batches. Present each list, ask **one** y/n per batch, then act on the whole list. Never iterate per-branch.
 
@@ -190,16 +155,14 @@ ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/end-session-squash-merged
 For each batch:
 
 - If empty, say so and move on.
-- Otherwise present the full list. Then **either**:
-  - **If the corresponding `.agent-policy` key is `true`** (`AUTO_DELETE_MERGED_BRANCHES` for Batch A, `AUTO_DELETE_SQUASH_MERGED_BRANCHES` for Batch B): skip the prompt and delete directly. Add a `Policy:` line to the Phase 1 summary noting the auto-delete fired with the deleted branch count.
-  - **Otherwise (default)**: ask once: "delete all of these? (y/n)".
-- On `y` (or policy fire): `-d` for Batch A, `-D` for Batch B.
+- Otherwise present the full list and ask once: "delete all of these? (y/n)".
+- On `y`: `-d` for Batch A, `-D` for Batch B.
 
 If a `[gone]` branch has a non-empty diff vs `main` AND no merged PR is found via `gh`, surface it by name ("`feat/x` — upstream gone but diffs against `main` and no merged PR found, left alone") so the user can decide manually. Don't roll it into Batch B — the safety net protects the auto-delete path too.
 
 For remote-tracking refs, `git fetch --prune` in step 2 already handled stale `origin/*` refs. Don't delete anything on the remote itself.
 
-### 7. Push main if ahead (Tier 2 — prompt, or Tier 1 with policy opt-in)
+### 7. Push main if ahead (Tier 2 — prompt)
 
 ```sh
 git log origin/main..HEAD --oneline
@@ -207,8 +170,7 @@ git log origin/main..HEAD --oneline
 
 If main is ahead of origin/main (shouldn't normally happen, but catches the case where commits landed locally):
 
-- **If `AUTO_PUSH_MAIN_IF_AHEAD=true` (from `.agent-policy`)**: push directly without prompting. Add a `Policy:` line to the Phase 1 summary noting the push fired and the commit count.
-- **Otherwise (default)**: ask before pushing.
+- Ask before pushing.
 
 ### 8. Open PRs needing your action (Tier 3 — surface only)
 
@@ -283,7 +245,6 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `<count, or "none">`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- Policy: `<list of .agent-policy keys that fired this session, e.g. "AUTO_DELETE_MERGED_BRANCHES → 3 deleted">` — omit the line entirely when no keys fired or the file is absent. Don't list keys that were set but had nothing to do (e.g. `AUTO_DELETE_MERGED_BRANCHES=true` with no merged branches).
 - Anything skipped/surfaced: `<list>`
 
 ## Phase 2 — Retrospective
@@ -304,9 +265,8 @@ On `n`: stop. The session is tidied; the user can run `/retrospective` later if 
 
 ## Guardrails
 
-- **`-D` (force delete) is allowed only for Batch B of step 6** — branches that are `[upstream: gone]` AND have an empty `git diff` against `main` (or a merged PR via `gh`). Everywhere else: always `-d`. If `-d` refuses, that's signal — surface it, don't override. The Batch B safety net protects the `AUTO_DELETE_SQUASH_MERGED_BRANCHES` opt-in path identically — auto-delete only acts on entries that already passed the safety check.
+- **`-D` (force delete) is allowed only for Batch B of step 6** — branches that are `[upstream: gone]` AND have an empty `git diff` against `main` (or a merged PR via `gh`). Everywhere else: always `-d`. If `-d` refuses, that's signal — surface it, don't override.
 - **Never `git push --force` or `git reset --hard`.** Those aren't session-tidy operations; if they're needed, the user should drive them.
 - **Never auto-merge PRs, auto-close issues, or auto-drop stashes.** Per-item judgment lives with the user (Tier 3).
-- **Ask before every Tier 2 destructive action by default** (branch deletes, force-pushing). One y/n per batch is fine — don't ask per-branch if a single list is presented. The `.agent-policy` keys (`AUTO_DELETE_MERGED_BRANCHES`, `AUTO_DELETE_SQUASH_MERGED_BRANCHES`, `AUTO_PUSH_MAIN_IF_AHEAD`) are the only sanctioned way to skip the prompt, and they're per-repo opt-in.
+- **Ask before every Tier 2 destructive action** (branch deletes, force-pushing). One y/n per batch is fine — don't ask per-branch if a single list is presented. There is no way to skip the prompt: a repo that wants different behaviour states it in its own `CLAUDE.md`.
 - **Don't modify settings, config, or unrelated files.** This command's scope is git, GitHub, and process state only.
-- **`.agent-policy` only promotes Tier 2 → Tier 1 for the keys it explicitly governs.** Tier 3 surfaces (user judgment) cannot be opted in. Unknown keys are ignored silently.

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -7,8 +7,8 @@ This command runs in a single phase. It mirrors `/end-session`'s shape — paral
 Every step falls into one of three tiers — keep this in mind when adding or editing steps:
 
 - **Tier 1 — auto-act, no prompt**: safe, reversible, expected. Examples: `git fetch --prune`, `git pull --rebase` on the default branch, read-only surface listings.
-- **Tier 2 — auto-act behind one batched confirmation**: predictable but should be a conscious choice. Example: chaining into `/promote-journal-inbox` when journal drafts are pending. Per-repo opt-in to Tier 1 is available via `.agent-policy` (see below) for users who always say "yes" in a given repo.
-- **Tier 3 — surface only, user drives**: needs per-item judgment. Examples: a feature branch trailing `main`, issues left assigned mid-flight from the last session, red `main` CI. **Never** opt-in via `.agent-policy` — these require human judgment by design.
+- **Tier 2 — auto-act behind one batched confirmation**: predictable but should be a conscious choice. Example: chaining into `/promote-journal-inbox` when journal drafts are pending.
+- **Tier 3 — surface only, user drives**: needs per-item judgment. Examples: a feature branch trailing `main`, issues left assigned mid-flight from the last session, red `main` CI.
 
 When in doubt, downgrade a tier (Tier 1 → 2, or 2 → 3). Never upgrade silently.
 
@@ -37,33 +37,10 @@ reports `n/a (sandbox)` in the summary rather than vanishing, so the brief means
 the same thing everywhere and a missing line is never ambiguous between "clean"
 and "could not check".
 
-## Repo-level policy (`.agent-policy`)
-
-**Optional.** A POSIX shell `KEY=VALUE` file at the repo root that opts specific Tier 2 prompts into Tier 1 (auto-run, no prompt) on a per-repo basis. Defaults (file absent or key unset) preserve the prompt — adding the file never makes any repo behave more aggressively than before.
-
-**Supported keys:**
-
-| Key | When `=true` | Affects |
-| --- | --- | --- |
-| `AUTO_JOURNAL_PROMOTE` | Auto-run `/promote-journal-inbox` when filesystem `_incoming/` count >= 1 — no prompt | Step 6 |
-
-Any value other than `true` is treated as unset. Unknown keys are ignored silently (forward-compatibility).
-
-**Trust model:** the file is **parsed, never sourced** — the gather reads well-formed `KEY=VALUE` lines and ignores everything else, so a hostile commit cannot get code out of it. What it *can* still do is turn on an automation you did not intend, so treat `.agent-policy` the same as `.editorconfig`: only commit it on repos you control, and only opt into automation you actually want. The file lives at the repo root (not under `.claude/`, which is reserved for the harness's own config).
-
-**Example `.agent-policy`:**
-
-```sh
-# .agent-policy — opt-in automation for /start-session in this repo
-AUTO_JOURNAL_PROMOTE=true
-```
-
 ## Phase 1 — Sync
 
-Everything starts with one script call. The pre-flight check and the
-`.agent-policy` read are both inside it, so this command makes **no standalone
-Bash calls before the gather** — which is the point: a compound `[ -f … ] && . …`
-matches no single allow rule and prompted on every run.
+Everything starts with one script call. The pre-flight check is inside it, so
+this command makes **no standalone Bash calls before the gather**.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
@@ -78,7 +55,6 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | Section | Drives step(s) | Notes on exit code |
 | --- | --- | --- |
 | `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
-| `policy` | 6 | Recognised `.agent-policy` keys as `KEY=VALUE`, one per line. Empty (or absent file) = all defaults. Unknown keys are dropped by the gather, matching the forward-compatibility rule. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
 | `main_ci` | 4 | Content `gh-unavailable` / `jq-unavailable` = silent skip. Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
@@ -173,7 +149,7 @@ design: applying config changes under an agent without the human reading them
 is its own hazard, and this repo deploys the harness the agent is running
 inside.
 
-### 6. Paul-context inbox surface (Tier 2 — prompt, paul-context only; Tier 1 with policy opt-in)
+### 6. Paul-context inbox surface (Tier 2 — prompt, paul-context only)
 
 **Only fires when the current working tree is `paul-context`** (`basename "$(git rev-parse --show-toplevel)" = "paul-context"`). Otherwise skip silently. This is a runtime filesystem check, not part of the gather output — `/start-session` runs in many repos and a generic gather section would always be empty for the rest.
 
@@ -186,7 +162,6 @@ Filter the listing to entries matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+\.
 - **0 matches**: skip silently.
 - **>= 1 match**: print the count and (up to first 5) filenames, then:
 
-  - **If the gather's `policy` section contains `AUTO_JOURNAL_PROMOTE=true`**: skip the prompt and invoke `/promote-journal-inbox` directly. Read it from that section, not from shell state — shell variables do not survive between tool calls, so nothing sourced earlier would still be set. Add a `Policy:` line to the session brief noting that the promote fired automatically.
   - **Otherwise (default)**: prompt:
 
     > `<N>` journal draft(s) pending in `_incoming/`. Run `/promote-journal-inbox` now? (y/n)
@@ -206,9 +181,6 @@ Repo:     <repo>             Branch: <branch> (<clean|dirty>)
 Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
 CI:       <green / N failing / N in-progress / n/a>
-
-Policy:                                             (omit when no policy keys fired)
-  AUTO_JOURNAL_PROMOTE=true → promoted <N> draft(s)
 
 Recent merges:                                      (omit when count=0)
   <short-sha>  <commit subject>
@@ -239,7 +211,6 @@ Rules:
 - "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work.
 - "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items).
 - "Recent merges" is sourced from gather section `recent_main_commits`. Omit the entire section when `count=0`.
-- "Policy" lists each `.agent-policy` key that fired this session (i.e. promoted a Tier 2 prompt to Tier 1 auto-action). Omit the entire section when no keys fired or the file is absent. Don't list keys that were set but had nothing to do (e.g. `AUTO_JOURNAL_PROMOTE=true` with an empty inbox) — only list actual fires.
 - If the repo has no GitHub origin (`gh_ready` / `gh_assigned` report `not-github` or are skipped), drop both issue sections silently (the brief still shows git/CI lines).
 - Truncate any title to ~78 columns to keep rows on one line.
 
@@ -248,6 +219,5 @@ Rules:
 - **Pre-flight gate is non-negotiable.** Never proceed when not in a git repo.
 - **Never auto-rebase a feature branch** onto an advanced default branch. Surface the gap and stop. The user picks the strategy.
 - **Never switch branches except when the upstream is gone and the tree is clean.** That single case (PR merged + branch auto-deleted on remote, no local uncommitted work) is auto-handled per Step 3. Otherwise, `/start-session` reports state on whatever branch the user is on.
-- **Don't push anything.** Pushes belong to `/end-session` (for git/`main`). `/start-session` is read-mostly. (Note: if `AUTO_JOURNAL_PROMOTE=true` fires, `/promote-journal-inbox` runs its own commit + push against `paul-context` — that's the promote command's contract, not a carve-out here.)
+- **Don't push anything.** Pushes belong to `/end-session` (for git/`main`). `/start-session` is read-mostly. (Note: if the user says yes to the journal-promote prompt, `/promote-journal-inbox` runs its own commit + push against `paul-context` — that's the promote command's contract, not a carve-out here.)
 - **Don't modify settings, config, or unrelated files.** Scope is git and GitHub-issue surface only.
-- **`.agent-policy` only promotes Tier 2 → Tier 1 for the keys it explicitly governs.** Tier 3 surfaces (user judgment) cannot be opted in. Unknown keys are ignored silently.

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -12,16 +12,6 @@ Every step falls into one of three tiers — keep this in mind when adding or ed
 
 When in doubt, downgrade a tier (Tier 1 → 2, or 2 → 3). Never upgrade silently.
 
-## Pre-flight
-
-This command **requires a git-backed repository**. Run the bare command below and branch on its exit code — don't paste a compound `||` / `&&` form, which won't match any single allow rule and will trigger a permission prompt.
-
-```sh
-git rev-parse --is-inside-work-tree
-```
-
-If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `/start-session` requires a git-backed repo — nothing to sync, stopping. ``) and stop.
-
 ## Surface
 
 This command runs on a workstation and in a cloud sandbox, and some steps only
@@ -59,7 +49,7 @@ and "could not check".
 
 Any value other than `true` is treated as unset. Unknown keys are ignored silently (forward-compatibility).
 
-**Trust model:** the file is sourced as POSIX shell, so a hostile commit could place arbitrary commands in it. Treat `.agent-policy` the same as `.envrc` / `.editorconfig` — only commit it on repos you control, and only opt into automation you actually want. The file lives at the repo root (not under `.claude/`, which is reserved for the harness's own config).
+**Trust model:** the file is **parsed, never sourced** — the gather reads well-formed `KEY=VALUE` lines and ignores everything else, so a hostile commit cannot get code out of it. What it *can* still do is turn on an automation you did not intend, so treat `.agent-policy` the same as `.editorconfig`: only commit it on repos you control, and only opt into automation you actually want. The file lives at the repo root (not under `.claude/`, which is reserved for the harness's own config).
 
 **Example `.agent-policy`:**
 
@@ -70,13 +60,10 @@ AUTO_JOURNAL_PROMOTE=true
 
 ## Phase 1 — Sync
 
-If `.agent-policy` exists at the repo root, source it once before proceeding:
-
-```sh
-[ -f .agent-policy ] && . ./.agent-policy
-```
-
-This loads any opt-in keys consulted by Tier 2 steps. The file is optional; if absent, every Tier 2 step prompts as today.
+Everything starts with one script call. The pre-flight check and the
+`.agent-policy` read are both inside it, so this command makes **no standalone
+Bash calls before the gather** — which is the point: a compound `[ -f … ] && . …`
+matches no single allow rule and prompted on every run.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
@@ -90,6 +77,8 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 
 | Section | Drives step(s) | Notes on exit code |
 | --- | --- | --- |
+| `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
+| `policy` | 6 | Recognised `.agent-policy` keys as `KEY=VALUE`, one per line. Empty (or absent file) = all defaults. Unknown keys are dropped by the gather, matching the forward-compatibility rule. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
 | `main_ci` | 4 | Content `gh-unavailable` / `jq-unavailable` = silent skip. Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
@@ -197,7 +186,7 @@ Filter the listing to entries matching `^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+\.
 - **0 matches**: skip silently.
 - **>= 1 match**: print the count and (up to first 5) filenames, then:
 
-  - **If `AUTO_JOURNAL_PROMOTE=true` (from `.agent-policy`)**: skip the prompt and invoke `/promote-journal-inbox` directly. Add a `Policy:` line to the session brief noting that the promote fired automatically.
+  - **If the gather's `policy` section contains `AUTO_JOURNAL_PROMOTE=true`**: skip the prompt and invoke `/promote-journal-inbox` directly. Read it from that section, not from shell state — shell variables do not survive between tool calls, so nothing sourced earlier would still be set. Add a `Policy:` line to the session brief noting that the promote fired automatically.
   - **Otherwise (default)**: prompt:
 
     > `<N>` journal draft(s) pending in `_incoming/`. Run `/promote-journal-inbox` now? (y/n)


### PR DESCRIPTION
**Rewritten.** This PR originally implemented #124 by folding the `.agent-policy` load into the gather. Having then looked at what `.agent-policy` is actually for, the answer is nothing — so it's deleted instead, and the half of #124 worth keeping stays.

## Why it goes

`af5d420` introduced it with two keys. The first:

> `AUTOMATE_GITHUB_IMPORT` — Auto-run `/bd-import-github-issues` when `count > 0` — no prompt

A **beads** command. The mechanism existed to skip a confirmation on the beads GitHub-issue import, and that key died with beads in `d7a3f6d`. What survived is the shell it was built in, carrying four keys added afterwards:

| Key | Reach |
| --- | --- |
| `AUTO_JOURNAL_PROMOTE` | **`paul-context` only** — step 6 doesn't fire elsewhere |
| `AUTO_DELETE_MERGED_BRANCHES` | any repo |
| `AUTO_DELETE_SQUASH_MERGED_BRANCHES` | any repo |
| `AUTO_PUSH_MAIN_IF_AHEAD` | any repo |

One is a single-repo special case dressed as a general mechanism. The other three are a real feature that has never been used — **no `.agent-policy` exists in this repo**, where the mechanism was built.

And it spent most of its life costing more than it saved: loading it ran `[ -f .agent-policy ] && . ./.agent-policy`, a compound form matching no allow rule. A mechanism whose purpose was removing prompts was adding one on every session.

## What changes

Every step that consulted a key now **prompts unconditionally** — the pre-`.agent-policy` behaviour, and the conservative direction. A repo that genuinely wants different behaviour states it in its own `CLAUDE.md`, which every session already reads and which needs no bespoke parser.

Gone from `start-session.md` and `end-session.md`: the "Repo-level policy" sections, both key tables, the sourcing stanzas, the branches in start-session step 6 and end-session steps 6a/6b/7, both `Policy:` summary lines, and the Tier-3 guardrails. `grep` for `.agent-policy` or any `AUTO_*` key across `home/`, `tests/` and `.github/` returns nothing.

## What stays from #124

The pre-flight fold, which is worth having on its own. `git rev-parse --is-inside-work-tree` runs inside `start-session-gather-state`, which emits `===not_a_git_repo (exit=1)===` and exits 1 rather than the command spending a separate Bash call on it. `/start-session` now makes one script call and nothing else.

## Verification

- Outside a git repo → `===not_a_git_repo (exit=1)===`, exit 1 ✅
- With an `.agent-policy` present → **no `policy` section**, file ignored entirely ✅
- `shellcheck` clean, `markdownlint-cli2` 0 issues/57 files, skills-sync 16/16

One note on that middle check: my first pass at it grepped the whole gather output for "policy" and reported a false failure — the word appears because `git status` lists the untracked `.agent-policy` and because this branch is *named* `…-policy`. Checking the section headers instead shows the seven real sections and no `policy` among them.

## Follow-up

**#231** tracks sweeping any `.agent-policy` files out of the repos themselves — a cross-repo job that needs a local terminal, and blocked by this landing first so removing the files can't silently change behaviour.

Closes #124
Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye