### PR TITLE
Port the hooks to the plugin, and make one copy stand down

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ array.
 | `bin/` helpers | yes, at `~/.claude/bin/` | yes, added to the Bash tool's `PATH` |
 | Policy prose (`AGENTS.md`, `CLAUDE.md`) | yes | **no** |
 | Permission allowlist (`settings.json`) | yes | **no** |
-| Hooks | yes, via `settings.json` | not yet — see below |
+| Hooks | yes, via `settings.json` | yes, via `hooks/hooks.json` |
 
 Two limits are structural rather than temporary:
 
@@ -64,10 +64,23 @@ Two limits are structural rather than temporary:
 - **Permissions travel only in repo `.claude/settings.json`**, which is the one
   place a cloud session reads them from.
 
-**Hooks are not in the plugin yet.** They live in `home/settings.json` and
-reference `~/.claude/bin/` paths that don't exist in a sandbox. Porting them
-means a `home/hooks/hooks.json` plus a per-hook surface audit — several are
-workstation-only by nature — so it is deliberately separate work.
+### Hooks, declared twice, run once
+
+The surface audit the hooks port was waiting on found nothing workstation-only:
+all five fail open without `gh`, `jq`, a git repo or terraform, so all five are
+in `hooks/hooks.json`. Two details make the double declaration safe:
+
+- Claude Code runs every matching hook from **every** source, so a local
+  machine in a plugin-enabled repo has both copies live. The plugin's three
+  script hooks go through `bin/plugin-hook-dispatch`, which stands down when
+  `~/.claude/bin/<hook>` exists — the chezmoi copy wins wherever it is
+  deployed, and neither channel is ever skipped entirely.
+- `prchecks-wait-claude-hook` finds its wrapper beside itself
+  (`$(dirname "$0")/gh-pr-checks-wait`) instead of at a fixed `~/.claude/bin`
+  path, so one file serves both channels.
+
+`home/settings.json.md` carries the per-hook detail, including which parts do
+still run twice and why that is fine.
 
 Locally, nothing changes: chezmoi delivers the same content directly, and the
 plugin manifests simply ride along inert.

--- a/home/bin/plugin-hook-dispatch
+++ b/home/bin/plugin-hook-dispatch
@@ -1,0 +1,54 @@
+#!/bin/sh
+# plugin-hook-dispatch — run a hook script from the plugin copy, but only when
+# the chezmoi copy isn't already handling it.
+#
+# WHY THIS EXISTS: the hook scripts reach an agent by two channels. chezmoi
+# deploys them to ~/.claude/bin/ and wires them in ~/.claude/settings.json;
+# the plugin ships the same scripts and wires them in hooks/hooks.json. A
+# local machine working in a repo that has enabled the plugin therefore has
+# BOTH live, and Claude Code runs every matching hook from every source. Left
+# alone that means precommit-claude-hook runs pre-commit twice on every commit
+# — up to 120s of duplicated work on the user's hottest path.
+#
+# The rule is: the chezmoi copy wins where it exists. It is the older channel,
+# it is what a machine has before it ever enables a plugin, and its allow rules
+# in settings.json name ~/.claude/bin paths. So the plugin entry checks for the
+# deployed copy and stands down if it finds one.
+#
+# This holds through the whole #142 transition, in both orders:
+#   - old settings.json + no plugin       -> chezmoi copy runs (unchanged)
+#   - old settings.json + plugin enabled  -> chezmoi copy runs, plugin defers
+#   - new settings.json + pruned bin/     -> plugin copy runs
+# Never twice, never zero.
+#
+# Usage: plugin-hook-dispatch <hook-script-name>
+# stdin (the hook payload) is passed through untouched via exec.
+#
+# Exit: 0 when it stands down or cannot find a script to run — a dispatcher
+#       that fails is not a reason to block a tool call. Otherwise the exit
+#       code is the hook's own, including the blocking `exit 2`.
+
+set -u
+
+name="${1:-}"
+[ -n "$name" ] || exit 0
+
+# Refuse anything that could escape the bin directory. The argument comes from
+# hooks.json, so this is a typo guard rather than a security boundary.
+case "$name" in
+    */* | *..*) exit 0 ;;
+esac
+
+# The chezmoi copy is authoritative wherever it is deployed.
+CLAUDE_DIR="${CLAUDE_DIR:-$HOME/.claude}"
+[ -x "$CLAUDE_DIR/bin/$name" ] && exit 0
+
+# Prefer the plugin root Claude Code hands us; fall back to this script's own
+# directory, which is the same place and keeps the dispatcher runnable by hand.
+root="${CLAUDE_PLUGIN_ROOT:-}"
+[ -n "$root" ] || root=$(dirname -- "$(dirname -- "$0")")
+
+script="$root/bin/$name"
+[ -x "$script" ] || exit 0
+
+exec "$script"

--- a/home/bin/prchecks-wait-claude-hook
+++ b/home/bin/prchecks-wait-claude-hook
@@ -1,10 +1,10 @@
 #!/bin/sh
 # prchecks-wait-claude-hook — Claude Code PreToolUse(Bash) hook.
 #
-# Rewrites `gh pr checks ... --watch` commands to go through
-# ~/.claude/bin/gh-pr-checks-wait, which waits (bounded) for GitHub to
-# register check runs before watching. Without this, a --watch issued in
-# the seconds after `gh pr create` exits immediately with "no checks
+# Rewrites `gh pr checks ... --watch` commands to go through the
+# gh-pr-checks-wait sitting beside this script, which waits (bounded) for
+# GitHub to register check runs before watching. Without this, a --watch
+# issued in the seconds after `gh pr create` exits immediately with "no checks
 # reported" — the registration lag is variable (0-60s+ observed), so a
 # fixed sleep after create doesn't fix it and penalises the wrong command.
 #
@@ -16,7 +16,7 @@
 #
 # Fast-exits with no output (command runs unmodified) when: the command
 # isn't a `gh pr checks ... --watch`, it's already wrapped, jq is missing,
-# or the wrapper isn't deployed/executable (fresh machine before
+# or the wrapper isn't present/executable beside it (fresh machine before
 # chezmoi apply). Non-watch `gh pr checks` calls pass through — poll loops
 # using --json handle the empty case themselves.
 
@@ -39,7 +39,9 @@ case "$cmd" in
   *gh-pr-checks-wait*) exit 0 ;;   # already wrapped — never rewrite twice
 esac
 
-wrapper="$HOME/.claude/bin/gh-pr-checks-wait"
+# Resolved next to this script rather than at a fixed ~/.claude/bin path, so
+# the same file works from the chezmoi deployment and from the plugin's bin/.
+wrapper="$(dirname -- "$0")/gh-pr-checks-wait"
 [ -x "$wrapper" ] || exit 0
 
 printf '%s' "$payload" | jq -c --arg w "$wrapper" '

--- a/home/hooks/hooks.json
+++ b/home/hooks/hooks.json
@@ -1,0 +1,43 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/bin/plugin-hook-dispatch\" prchecks-wait-claude-hook",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/bin/plugin-hook-dispatch\" prepush-guard-claude-hook",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/bin/plugin-hook-dispatch\" precommit-claude-hook",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v terraform >/dev/null 2>&1 || exit 0; FILE_PATH=$(jq -r '.tool_input.file_path // empty'); case \"$FILE_PATH\" in *.tf) terraform fmt \"$FILE_PATH\" ;; esac; true",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "command -v terraform >/dev/null 2>&1 || exit 0; FILE_PATH=$(jq -r '.tool_input.file_path // empty'); case \"$FILE_PATH\" in *.tf) DIR=$(dirname \"$FILE_PATH\"); [ -d \"$DIR/.terraform\" ] && cd \"$DIR\" && terraform validate ;; esac; true",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/home/settings.json
+++ b/home/settings.json
@@ -356,7 +356,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE_PATH=$(jq -r '.tool_input.file_path // empty'); [[ \"$FILE_PATH\" == *.tf ]] && terraform fmt \"$FILE_PATH\" || true",
+            "command": "command -v terraform >/dev/null 2>&1 || exit 0; FILE_PATH=$(jq -r '.tool_input.file_path // empty'); case \"$FILE_PATH\" in *.tf) terraform fmt \"$FILE_PATH\" ;; esac; true",
             "timeout": 10
           }
         ]
@@ -366,7 +366,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE_PATH=$(jq -r '.tool_input.file_path // empty'); [[ \"$FILE_PATH\" == *.tf ]] && DIR=$(dirname \"$FILE_PATH\") && [[ -d \"$DIR/.terraform\" ]] && cd \"$DIR\" && terraform validate || true",
+            "command": "command -v terraform >/dev/null 2>&1 || exit 0; FILE_PATH=$(jq -r '.tool_input.file_path // empty'); case \"$FILE_PATH\" in *.tf) DIR=$(dirname \"$FILE_PATH\"); [ -d \"$DIR/.terraform\" ] && cd \"$DIR\" && terraform validate ;; esac; true",
             "timeout": 30
           }
         ]

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -698,6 +698,10 @@ the user revisits it.
 
 ## Hooks
 
+Every hook below is also declared in `home/hooks/hooks.json`, which is what
+carries them to a cloud session — see "Two channels, one set of hooks" at the
+end of this section for how the two copies avoid running twice.
+
 ### PreToolUse (Bash)
 
 1. **pr-checks registration-race rewrite** —
@@ -787,6 +791,43 @@ the user revisits it.
 2. **terraform validate** — Validates the module directory after `.tf` file
    changes. Only runs if `.terraform/` exists in the file's directory
    (i.e., `terraform init` has been run). 30s timeout.
+
+Both are written in POSIX `sh` (`case`, not `[[ ]]`) and lead with
+`command -v terraform || exit 0`. The bash-only test was fine on a workstation
+and silently never matched under `dash`, which is what a Linux sandbox is
+likely to run these with; the `command -v` guard keeps a sandbox that edits a
+`.tf` file from emitting "terraform: not found" on every Write.
+
+### Two channels, one set of hooks
+
+The same five hooks are declared twice: here, for the chezmoi deployment, and
+in `home/hooks/hooks.json`, for the plugin. Claude Code runs every matching
+hook from every source, so a local machine working in a repo that has enabled
+the plugin has both live at once — and `precommit-claude-hook` running
+pre-commit twice on every commit is up to 120s of duplicated work on the
+hottest path there is.
+
+The three script hooks therefore go through `bin/plugin-hook-dispatch` in the
+plugin copy. It stands down when `~/.claude/bin/<hook>` exists, so **the
+chezmoi copy wins wherever it is deployed** — which is also the copy the
+`Bash(~/.claude/bin/gh-pr-checks-wait *)` allow rule below is written for.
+That rule holds through the #142 transition in either order: a machine on an
+old `settings.json` with the plugin already enabled runs each hook once via
+chezmoi, and a machine whose `bin/` has been pruned runs each hook once via
+the plugin. Never twice, never zero.
+
+The two terraform hooks are inline commands rather than scripts, so they have
+no dispatcher and do run twice where both channels are live. Accepted: `fmt`
+is idempotent and instant, `validate` re-reads a module that is already
+initialised, and both no-op entirely without terraform on PATH.
+
+`prchecks-wait-claude-hook` resolves its wrapper as
+`$(dirname "$0")/gh-pr-checks-wait` rather than at a fixed `~/.claude/bin`
+path, which is what lets one file serve both channels. Note the consequence
+for permissions: from the plugin the rewritten command names a path under the
+plugin root, which this allowlist cannot match — cloud sessions read their
+permissions from the project repo's own `.claude/settings.json`, so that is
+where the grant has to be if the rewrite is to stay auto-approved there.
 
 ## StatusLine
 

--- a/tests/plugin-manifests.py
+++ b/tests/plugin-manifests.py
@@ -13,6 +13,7 @@ Usage: python3 tests/plugin-manifests.py
 """
 
 import json
+import os
 import pathlib
 import re
 import sys
@@ -27,6 +28,24 @@ MARKETPLACE = ROOT / ".claude-plugin" / "marketplace.json"
 PLUGIN_COMPONENT_DIRS = {"skills", "commands", "agents", "hooks", "bin", "monitors"}
 
 NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# Hook events a plugin's hooks/hooks.json may declare.
+HOOK_EVENTS = {
+    "PreToolUse",
+    "PostToolUse",
+    "UserPromptSubmit",
+    "Notification",
+    "Stop",
+    "SubagentStop",
+    "SessionStart",
+    "SessionEnd",
+    "PreCompact",
+}
+
+# `${CLAUDE_PLUGIN_ROOT}/bin/foo` -> `bin/foo`, and the bare script name a
+# `plugin-hook-dispatch foo` invocation resolves under bin/.
+PLUGIN_ROOT_REF = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([A-Za-z0-9._/-]+)")
+DISPATCH_REF = re.compile(r"plugin-hook-dispatch\"?\s+([A-Za-z0-9._-]+)")
 
 errors = []
 
@@ -123,6 +142,72 @@ def check_plugin_entry(entry):
         err(f"plugin '{name}' has no component directories at its root")
     else:
         print(f"  plugin '{name}' at {source}: {', '.join(found)}")
+
+    check_hooks(plugin_root)
+
+
+def check_hooks(plugin_root):
+    """Validate hooks/hooks.json, and that every script it names is really there.
+
+    A hook whose command points at a path that no longer exists fails at tool-use
+    time, in a sandbox, as a non-blocking warning nobody reads -- so a renamed or
+    deleted script under bin/ would go unnoticed indefinitely. Resolving the
+    references here is the cheap way to catch it.
+    """
+    hooks_file = plugin_root / "hooks" / "hooks.json"
+    if not hooks_file.exists():
+        # A plugin without hooks is legitimate; only a broken one is an error.
+        return
+    rel = hooks_file.relative_to(ROOT)
+    try:
+        data = json.loads(hooks_file.read_text())
+    except json.JSONDecodeError as e:
+        err(f"{rel} is not valid JSON: {e}")
+        return
+
+    events = data.get("hooks")
+    if not isinstance(events, dict) or not events:
+        err(f"{rel} must have a non-empty top-level 'hooks' object")
+        return
+
+    count = 0
+    for event, matchers in events.items():
+        if event not in HOOK_EVENTS:
+            err(f"{rel}: unknown hook event '{event}'")
+        if not isinstance(matchers, list):
+            err(f"{rel}: '{event}' must be a list of matcher groups")
+            continue
+        for group in matchers:
+            for hook in group.get("hooks", []):
+                count += 1
+                if hook.get("type") != "command":
+                    err(f"{rel}: '{event}' hook has type '{hook.get('type')}', expected 'command'")
+                command = hook.get("command", "")
+                if not isinstance(command, str) or not command:
+                    err(f"{rel}: '{event}' hook has no command string")
+                    continue
+                if "timeout" in hook and not isinstance(hook["timeout"], int):
+                    err(f"{rel}: '{event}' hook timeout must be an integer")
+                check_hook_targets(rel, plugin_root, command)
+    print(f"  hooks.json: {count} hooks across {len(events)} events")
+
+
+def check_hook_targets(rel, plugin_root, command):
+    for ref in PLUGIN_ROOT_REF.findall(command):
+        target = plugin_root / ref
+        if not target.is_file():
+            err(f"{rel}: command references ${{CLAUDE_PLUGIN_ROOT}}/{ref}, which does not exist")
+        elif not os.access(target, os.X_OK):
+            err(f"{rel}: ${{CLAUDE_PLUGIN_ROOT}}/{ref} is not executable")
+
+    # The dispatcher takes a bare script name and runs bin/<name>; a typo there
+    # is invisible to the reference check above.
+    for name in DISPATCH_REF.findall(command):
+        target = plugin_root / "bin" / name
+        if not target.is_file():
+            err(f"{rel}: plugin-hook-dispatch names '{name}', which is not in bin/")
+        elif not os.access(target, os.X_OK):
+            err(f"{rel}: bin/{name} is not executable")
 
 
 def main():


### PR DESCRIPTION
Ports the hooks to the plugin channel — the last piece of #48 that lives in this repo.

## The audit the deferral was waiting on

#225 left hooks out with a note that "several are workstation-only by nature". Reading them, none are. All five degrade to a no-op on a surface that can't support them:

| Hook | Fails open without |
| --- | --- |
| `prchecks-wait-claude-hook` | `jq`, or the wrapper beside it |
| `prepush-guard-claude-hook` | `gh`, `jq`, a repo, a PR |
| `precommit-claude-hook` | `pre-commit`, `.pre-commit-config.yaml` |
| terraform `fmt` / `validate` | `terraform` on `PATH` |

So all five are in `home/hooks/hooks.json`.

## Double-firing, which was the real obstacle

Claude Code runs every matching hook from **every** source. A local machine working in a repo that has enabled the plugin has both copies live, and `precommit-claude-hook` running pre-commit twice is up to 120s of duplicated work on the hottest path in the workflow.

The plugin's three script hooks go through `bin/plugin-hook-dispatch`, which stands down when `~/.claude/bin/<hook>` exists. The chezmoi copy wins wherever it is deployed — it is the older channel, it is what a machine has before it enables any plugin, and it is the copy the `Bash(~/.claude/bin/gh-pr-checks-wait *)` allow rule is written for.

That rule is stable through the whole #142 transition, in either order:

| Machine state | What runs |
| --- | --- |
| old `settings.json`, no plugin | chezmoi copy |
| old `settings.json`, plugin enabled | chezmoi copy; plugin defers |
| new `settings.json`, `bin/` pruned | plugin copy |

Never twice, never zero — including on a machine that hasn't run `chezmoi apply` since #142 merges, which given the 168h `refreshPeriod` could be a week.

The two terraform hooks are inline commands, not scripts, so they have no dispatcher and do run twice where both channels are live. Accepted: `fmt` is idempotent and instant, `validate` re-reads an already-initialised module, and both no-op without terraform.

## Two portability fixes found on the way

- **`prchecks-wait-claude-hook` resolved its wrapper at `$HOME/.claude/bin/gh-pr-checks-wait`**, which doesn't exist in a sandbox — the hook would have loaded and then quietly never rewritten anything. It now uses `$(dirname "$0")/gh-pr-checks-wait`, so one file serves both channels.
- **The terraform hooks were bash-only** (`[[ "$FILE_PATH" == *.tf ]]`). Fine under zsh/bash on a workstation; under `dash`, which is a plausible `sh` in a Linux sandbox, `[[` fails and the trailing `|| true` swallows it — the hook would have been silently inert. Rewritten in POSIX `sh` in **both** copies as identical strings, so they can't drift, and prefixed with `command -v terraform || exit 0` so a sandbox editing a `.tf` file doesn't emit "terraform: not found" on every Write.

## Verification

`tests/plugin-manifests.py` now validates `hooks/hooks.json`: event names, hook shape, integer timeouts, and — the part that earns its keep — it resolves every script the commands name, including the bare name handed to the dispatcher. Renaming something under `bin/` without updating `hooks.json` would otherwise show up only as a non-blocking warning in someone else's sandbox. Confirmed it fails on a deliberately mistyped name.

The dispatcher was exercised by hand across six cases: chezmoi copy present (defers, exit 0), absent (runs, stdin passed through intact, `exit 2` preserved so blocking still works), `CLAUDE_PLUGIN_ROOT` unset (falls back to `$0`'s tree), unknown name, path traversal, and no argument.

All gates green: markdownlint 0 issues; shellcheck clean; plugin manifests valid; 16/16 skills in sync; 18/18 hook tests; 71/71 credential tests.

## What this leaves on #48

The two remaining acceptance criteria are both yours — each needs a real cloud session:

- [ ] a cloud session on a stamped project repo invokes a plugin-shipped command end to end
- [ ] the empirical check that setup-script-planted `~/.claude/` files are ignored in cloud sessions

Refs #48.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_