### PR TITLE
Add the undeploy half of the prune list, and test the validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,41 +140,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Entries must be safe and actually retired
-        run: |
-          set -eu
-          list=home/retired-paths
-          if [ ! -f "$list" ]; then
-            echo "$list not present — nothing to validate."
-            exit 0
-          fi
-          rc=0
-          while IFS= read -r line || [ -n "$line" ]; do
-            path=$(printf '%s' "$line" | sed 's/[[:space:]]*$//')
-            case "$path" in
-              '' | '#'*) continue ;;
-            esac
-            # Must not escape ~/.claude/ — the pruner refuses these too, but
-            # failing here means a bad entry never reaches a machine.
-            case "$path" in
-              /* | *..*)
-                echo "::error file=$list::unsafe entry (absolute or ..): $path"
-                rc=1
-                continue
-                ;;
-            esac
-            # The whole point is that the file is GONE from home/. An entry
-            # that still exists would have the pruner delete a live file on
-            # every apply, and chezmoi restore it on the next one.
-            if [ -e "home/$path" ]; then
-              echo "::error file=$list::still present in home/ — retire the file first, or drop this entry: $path"
-              rc=1
-            fi
-          done < "$list"
-          if [ "$rc" -eq 0 ]; then
-            echo "All retired-paths entries are safe and refer to removed files."
-          fi
-          exit "$rc"
+      - name: Entries must be safe and correctly sectioned
+        run: sh tests/retired-paths.sh
+      - name: The validator itself must catch a bad entry
+        run: sh tests/retired-paths-test.sh
 
   settings-sync:
     name: settings.json ↔ settings.json.md sync

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,11 @@ No build step. Quality gates (run before pushing; CI runs the same):
 ```bash
 markdownlint-cli2 "**/*.md"              # markdown lint
 sh tests/gcp-credentials-test.sh         # credential-helper behaviour
+sh tests/precommit-hook-test.sh          # pre-commit hook matching
+sh tests/retired-paths.sh                # the prune list is safe and sectioned
+sh tests/retired-paths-test.sh           # ...and its validator still catches
 python3 tests/skills-match-commands.py   # skills match their source commands
+python3 tests/plugin-manifests.py        # marketplace, plugin and hook manifests
 
 # shell — CI scans home/bin/, cloud/ and tests/. Select by shebang: home/bin/
 # also holds a Python script, and `shellcheck home/bin/*` errors on it.

--- a/README.md
+++ b/README.md
@@ -291,6 +291,53 @@ never has to change again.
 Entries are permanent: a machine that hasn't been applied to in a year
 still needs them.
 
+### Undeploying a file, which is not the same as retiring it
+
+Since `home/` doubles as the plugin root, the paths that move to the plugin
+channel **cannot be deleted from `home/`** — that would remove them from the
+plugin too. But they still have to leave `~/.claude/`, because chezmoi never
+deletes a target it has stopped managing. Same pruner, opposite precondition.
+
+`home/retired-paths` therefore has two sections, split by an `UNDEPLOYED`
+marker line:
+
+| Section | Meaning | CI asserts |
+| --- | --- | --- |
+| Above the marker | Retired — gone from `home/`, gone from machines | the path is **absent** from `home/` |
+| Below the marker | Undeployed — the plugin still ships it, chezmoi no longer delivers it | the path is **present** in `home/` |
+
+The inversion is the guard: an entry on the wrong side fails the build, so
+neither section can quietly absorb the other's mistakes. `tests/retired-paths.sh`
+is the validator and runs in CI; `tests/retired-paths-test.sh` checks the
+validator against both mirror-image mistakes, because the real list is empty
+below the marker and so exercises neither branch on its own.
+
+**The undeployed section is empty on purpose.** An entry is only correct once
+the chezmoi external has stopped deploying that path — a change to the
+`include` filter in `dotfiles`, which this repo cannot make. List a path while
+chezmoi still deploys it and every `chezmoi apply` writes the file, then the
+post-apply pruner deletes it again: convergent, but churn masquerading as
+working. The order is dotfiles first, entries second. See [#142][issue-142].
+
+### The residue this is heading for
+
+Once the plugin channel is verified end to end ([#48][issue-48]), what chezmoi
+deploys shrinks to the part a plugin structurally cannot carry:
+
+| Stays deployed | Why |
+| --- | --- |
+| `CLAUDE.md`, `AGENTS.md`, `ephemeral-first.md`, `local-machine.md` | Policy prose can't ride a plugin |
+| `settings.json`, `settings.json.md` | Permission allowlists can't ride a plugin |
+| `retired-paths` | Read by the pruner at `~/.claude/retired-paths` |
+| `bin/claude-prune-retired` | Invoked by dotfiles after each apply |
+
+Everything else — `commands/`, `skills/`, `hooks/`, the rest of `bin/` — is
+delivered by the plugin and belongs below the `UNDEPLOYED` marker when that
+step is taken. Note this is a longer list than [#142][issue-142] originally
+assumed: it was written before `home/` became the plugin root, and named only
+the machine-local fragment as residue, when in fact all four policy files are
+structurally stuck on the chezmoi channel.
+
 `/end-session` step 11 remains the backstop. It compares `chezmoi
 managed` against the real contents of `~/.claude/commands/` and
 `~/.claude/bin/`, so it catches drift the list doesn't know about — a
@@ -299,6 +346,8 @@ file retired without a list entry, or one left by another tool.
 [dotfiles-371]: https://github.com/pmgledhill102/dotfiles/issues/371
 
 [issue-125]: https://github.com/pmgledhill102/agentic-coding-config/issues/125
+
+[issue-142]: https://github.com/pmgledhill102/agentic-coding-config/issues/142
 
 ## Slash commands
 

--- a/home/retired-paths
+++ b/home/retired-paths
@@ -23,9 +23,41 @@
 # Entries are permanent. Removing a line once the file is gone everywhere is
 # not worth the risk — a machine that hasn't been applied to in a year still
 # needs it. Group by retirement with a dated comment.
+#
+# THIS FILE HAS TWO SECTIONS. Everything above the UNDEPLOYED marker below is
+# retired: gone from home/, gone from every machine. Everything below it is
+# still in home/ — because home/ is also the plugin root — but is no longer
+# delivered to ~/.claude/. The pruner treats both the same way and needs no
+# knowledge of the distinction; CI is what tells them apart, and it asserts
+# the OPPOSITE condition for each. See the marker comment for the rules.
 
 # 2026-07-18 (d7a3f6d) — beads tracker retired in favour of GitHub Issues (#123)
 commands/bd-enable-server-mode.md
 commands/bd-import-github-issues.md
 commands/bd-modernize.md
 bin/bd-push-safe
+
+# === UNDEPLOYED: delivered by the plugin, no longer deployed by chezmoi ===
+#
+# WHY A SECOND SECTION: #48 made home/ double as the plugin root, so the paths
+# that move to the plugin cannot be deleted from home/ the way a retired file
+# is — deleting them would remove them from the plugin too. They still have to
+# be removed from ~/.claude/ on machines that already have them, because
+# chezmoi never deletes a target it has stopped managing. Same pruner, opposite
+# precondition.
+#
+# CI RULE: an entry below this marker MUST still exist in home/. If it doesn't,
+# it isn't undeployed — it's retired, and belongs above the marker. That
+# inversion is the guard: neither section can silently absorb the other's
+# mistakes, and moving the marker without moving the entries fails the build.
+#
+# ORDERING, AND WHY THIS SECTION IS EMPTY: an entry here is only correct once
+# the chezmoi external has stopped deploying that path — which is a change to
+# the `include` filter in pmgledhill102/dotfiles, not something this repo can
+# make. Listing a path while chezmoi still deploys it makes every `chezmoi
+# apply` write the file and the post-apply pruner immediately delete it again.
+# That converges on the right end state, but it is churn masquerading as
+# working. So: dotfiles narrows the include FIRST, then the paths land here.
+#
+# It is also gated on #48's end-to-end verification — do not undeploy anything
+# the plugin has not been observed to deliver. See #142.

--- a/tests/retired-paths-test.sh
+++ b/tests/retired-paths-test.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# retired-paths-test.sh — check that tests/retired-paths.sh rejects what it
+# should and accepts what it should.
+#
+# A validator nobody has seen fail is a validator nobody knows works. The
+# section logic in particular has two mirror-image assertions, and getting one
+# of them backwards would still pass on the real list — which is currently
+# empty below the marker, so it exercises neither branch.
+#
+# Usage: sh tests/retired-paths-test.sh
+
+set -u
+
+DIR=$(dirname -- "$0")
+VALIDATOR="$DIR/retired-paths.sh"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+
+passed=0
+failed=0
+
+# A path that really is in home/, and one that really is not. Both are
+# resolved by the validator against the repo's own home/, so these have to be
+# true statements about the tree rather than invented names.
+PRESENT="bin/claude-prune-retired"
+ABSENT="commands/bd-modernize.md"
+
+check() {
+    desc=$1
+    want=$2
+    body=$3
+    printf '%s\n' "$body" > "$TMP/list"
+    out=$(sh "$VALIDATOR" "$TMP/list" 2>&1)
+    got=$?
+    if [ "$got" -eq "$want" ]; then
+        printf '  ok    %s\n' "$desc"
+        passed=$((passed + 1))
+    else
+        printf '  FAIL  %s (want exit %s, got %s)\n' "$desc" "$want" "$got"
+        printf '        %s\n' "$out"
+        failed=$((failed + 1))
+    fi
+}
+
+MARKER='# === UNDEPLOYED: delivered by the plugin, no longer deployed by chezmoi ==='
+
+echo "retired-paths validator:"
+
+check "empty list passes" 0 "# nothing here"
+check "retired entry that is gone from home/ passes" 0 "$ABSENT"
+check "retired entry still in home/ fails" 1 "$PRESENT"
+
+check "undeployed entry still in home/ passes" 0 "$MARKER
+$PRESENT"
+check "undeployed entry missing from home/ fails" 1 "$MARKER
+$ABSENT"
+
+check "both sections, both correct, passes" 0 "$ABSENT
+$MARKER
+$PRESENT"
+check "both sections, entries swapped, fails" 1 "$PRESENT
+$MARKER
+$ABSENT"
+
+check "absolute path refused above the marker" 1 "/etc/passwd"
+check "absolute path refused below the marker" 1 "$MARKER
+/etc/passwd"
+check "parent traversal refused" 1 "../../.ssh/id_rsa"
+check "comments and blanks ignored" 0 "# a comment
+
+$ABSENT
+"
+
+# The real list must pass, and must be the thing CI actually validates.
+if sh "$VALIDATOR" > /dev/null 2>&1; then
+    printf '  ok    the repo'"'"'s own home/retired-paths passes\n'
+    passed=$((passed + 1))
+else
+    printf '  FAIL  the repo'"'"'s own home/retired-paths does not pass\n'
+    failed=$((failed + 1))
+fi
+
+printf '\npassed: %s   failed: %s\n' "$passed" "$failed"
+[ "$failed" -eq 0 ]

--- a/tests/retired-paths.sh
+++ b/tests/retired-paths.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# retired-paths.sh — validate home/retired-paths.
+#
+# The list drives ~/.claude/bin/claude-prune-retired, which deletes every path
+# it names from ~/.claude/ after each chezmoi apply, on every machine. A bad
+# entry is therefore a delete loop nobody is watching, which is why this runs
+# in CI rather than being trusted to review.
+#
+# The file has two sections with OPPOSITE preconditions:
+#
+#   above the UNDEPLOYED marker   retired — the path must be GONE from home/
+#   below it                      undeployed — the path must STILL be in home/
+#
+# The inversion is deliberate. An undeployed path is one the plugin still ships
+# from home/ but chezmoi no longer delivers; if it isn't in home/ at all then it
+# is simply retired and the entry is on the wrong side. Checking each section
+# for the other's condition means neither can quietly absorb the other's
+# mistakes.
+#
+# Usage: sh tests/retired-paths.sh [path-to-list]
+# Exit: 0 if every entry is safe and correctly placed, 1 otherwise.
+
+set -u
+
+root=$(dirname -- "$0")/..
+list="${1:-$root/home/retired-paths}"
+home_dir="$root/home"
+
+# Validating a list that isn't the repo's own (the test cases below) still has
+# to resolve paths against the real home/, since that is what the assertions
+# are about.
+if [ ! -f "$list" ]; then
+    echo "$list not present — nothing to validate."
+    exit 0
+fi
+
+rc=0
+section=retired
+while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+        '# === UNDEPLOYED:'*) section=undeployed; continue ;;
+    esac
+
+    path=$(printf '%s' "$line" | sed 's/[[:space:]]*$//')
+    case "$path" in
+        '' | '#'*) continue ;;
+    esac
+
+    # Must not escape ~/.claude/. The pruner refuses these too, but failing
+    # here means a bad entry never reaches a machine. Both sections.
+    case "$path" in
+        /* | *..*)
+            echo "::error file=home/retired-paths::unsafe entry (absolute or ..): $path"
+            rc=1
+            continue
+            ;;
+    esac
+
+    if [ "$section" = retired ]; then
+        if [ -e "$home_dir/$path" ]; then
+            echo "::error file=home/retired-paths::still present in home/ — retire the file first, move it below the UNDEPLOYED marker, or drop this entry: $path"
+            rc=1
+        fi
+    else
+        if [ ! -e "$home_dir/$path" ]; then
+            echo "::error file=home/retired-paths::listed as undeployed but absent from home/ — move it above the UNDEPLOYED marker: $path"
+            rc=1
+        fi
+    fi
+done < "$list"
+
+if [ "$rc" -eq 0 ]; then
+    echo "retired-paths: entries are safe and on the correct side of the UNDEPLOYED marker."
+fi
+exit "$rc"


### PR DESCRIPTION
The enabling half of #142. It does **not** undeploy anything yet, and the reason is the interesting part.

## #142's written plan no longer works

> Retire migrated paths via the existing machinery: delete from `home/`, add each `commands/*` and `bin/*` path to `home/retired-paths`, same PR.

That was written on 2026-08-09. #48 then made `home/` double as the plugin root, so:

- deleting `commands/` or `bin/` from `home/` deletes them **from the plugin too**, which is the channel they are supposedly moving to;
- and CI already fails any `retired-paths` entry that still exists in `home/` — deliberately, because the pruner would otherwise delete a live file on every apply.

So the migrated paths are in a state the file has no vocabulary for: still in `home/`, no longer wanted at `~/.claude/`.

## Two sections, opposite assertions

`home/retired-paths` gains a section below an `UNDEPLOYED` marker.

| Section | Meaning | CI asserts |
| --- | --- | --- |
| Above the marker | Retired — gone from `home/`, gone from machines | path is **absent** from `home/` |
| Below the marker | Undeployed — plugin still ships it, chezmoi no longer delivers it | path is **present** in `home/` |

The pruner needs no change at all; it already deletes whatever it is given. CI is the only thing that tells the sections apart, and asserting the *opposite* condition for each is what makes it a guard rather than a bypass: an entry on the wrong side of the marker fails the build in either direction, so neither section can quietly absorb the other's mistakes.

## The section is empty on purpose

An entry is only correct once the chezmoi external has stopped deploying that path — a change to the `include` filter in `dotfiles`, which this repo can't make. List a path while chezmoi still deploys it and every `chezmoi apply` writes the file, then the post-apply pruner deletes it again. That converges on the right end state, but it's churn masquerading as working.

It's also gated on #48's end-to-end verification, per #142's own instruction not to retire anything the plugin hasn't been observed to deliver. Order: dotfiles narrows the include, then the entries land here.

## Validation moved out of the workflow

The check was ~25 lines of shell inlined in `ci.yml`, which meant it couldn't be run locally, couldn't be shellchecked, and couldn't be tested. It's now `tests/retired-paths.sh`, and CI calls it.

`tests/retired-paths-test.sh` covers it — 12 cases including both mirror-image mistakes (a retired entry that's still in `home/`, an undeployed entry that isn't), the swapped-sections case, and path-safety above *and* below the marker. That matters here more than usual: the real list is empty below the marker, so on its own it exercises neither branch of the new logic. A backwards assertion would have passed CI indefinitely.

## README

Documents undeploying as distinct from retiring, and describes the residue the deployed surface is shrinking to. One correction to #142 while writing it: the residue is bigger than the issue assumed. #142 names "the machine-local policy fragment (#138)" — but `AGENTS.md`, `CLAUDE.md` and `ephemeral-first.md` are equally stuck on the chezmoi channel, because policy prose can't ride a plugin at all. All four stay.

Also folds in two loose ends: `tests/precommit-hook-test.sh` (added by #226, never added to the documented gates) and `tests/plugin-manifests.py` now appear in `CLAUDE.md`'s gate block.

## Verification

markdownlint 0 issues; shellcheck clean; actionlint clean; retired-paths validator 12/12; hook tests 18/18; skills 16/16; plugin manifests valid; credential tests 71/71.

Refs #142.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxUPzaXE4mY4rvsGNsbWye)_