### PR TITLE
Correct the beads-retirement status in ADR-0013 and the runbook

### DIFF
--- a/adrs/0013-github-issues-for-work-tracking.md
+++ b/adrs/0013-github-issues-for-work-tracking.md
@@ -60,10 +60,17 @@ Summary of the conventions:
 
 ## Consequences
 
-- The beads integration in this repo (bd `prime` hooks, `bd-*` commands,
-  `bd-push-safe`, permission allowlist entries, `.beads/` workspaces)
-  retires once migration is proven — tracked as follow-up work under
-  issue #49, deliberately separate from this decision.
+- The beads integration in this repo retires as migration proves out,
+  deliberately separate from this decision. Most of it has now gone: the
+  `bd prime` hooks, the `bd-*` commands, `bd-push-safe` and the
+  `bd`/`beads`/`dolt` permission entries were removed on 2026-07-18
+  ([#123](https://github.com/pmgledhill102/agentic-coding-config/issues/123)),
+  and the retired paths are listed in `home/retired-paths` so machines that
+  already had them lose them on the next apply
+  ([#125](https://github.com/pmgledhill102/agentic-coding-config/issues/125)).
+  One helper remains — `home/bin/bd-migrate-to-github` — which retires with
+  the last repo still on beads, along with that repo's `.beads/` workspace
+  ([#131](https://github.com/pmgledhill102/agentic-coding-config/issues/131)).
 - Work tracking now requires network access. Accepted: offline operation
   was explicitly not a requirement.
 - Ticket data lives in GitHub rather than in-repo. History is preserved

--- a/docs/beads-migration-runbook.md
+++ b/docs/beads-migration-runbook.md
@@ -160,9 +160,19 @@ carrying on with bd.
 
 ## Global cleanup (once all repos are migrated)
 
-Tracked as follow-up work under
-[#49](https://github.com/pmgledhill102/agentic-coding-config/issues/49):
-retire the `bd prime` hooks, `bd-*` commands, `bd-push-safe`, and the
-`bd`/`beads`/`dolt` permission allowlist entries from `home/`; update
-`/start-session`, `/end-session`, `/retrospective`, and `/repo-review`
-to target GitHub Issues.
+Mostly done. Removed from `home/` on 2026-07-18
+([#123](https://github.com/pmgledhill102/agentic-coding-config/issues/123)):
+the `bd prime` hooks, the `bd-*` commands, `bd-push-safe`, and the
+`bd`/`beads`/`dolt` permission allowlist entries. `/start-session`,
+`/end-session`, `/retrospective` and `/repo-review` now target GitHub
+Issues and no longer mention beads at all. The retired paths are listed in
+`home/retired-paths`, so machines that already had them lose them on the
+next apply
+([#125](https://github.com/pmgledhill102/agentic-coding-config/issues/125),
+verified 2026-08-16).
+
+What remains is `home/bin/bd-migrate-to-github` — the tool this runbook
+drives. It retires with the last repo still on beads, along with that
+repo's `.beads/` workspace, tracked under
+[#131](https://github.com/pmgledhill102/agentic-coding-config/issues/131).
+This runbook retires with it.

--- a/home/local-machine.md
+++ b/home/local-machine.md
@@ -21,9 +21,17 @@ To change any of it, open an issue against `agentic-coding-config`; see
 
 A merge to that repo does **not** reach this machine immediately. The
 external carries a `refreshPeriod` of 168h, so a plain `chezmoi apply` can
-re-apply the cached archive: use `chezmoi apply --refresh-externals` (or
-`chezmoi update --refresh-externals`) when you specifically need a change
-that just merged.
+re-apply the cached archive.
+
+**`dotup` already handles this** — it runs `chezmoi update
+--refresh-externals`, which is pull plus apply with the cache bypassed, and
+it is the command to reach for after a merge. Drop to
+`chezmoi apply --refresh-externals` only when you want the apply without
+the rest of what `dotup` does (Oh My Zsh, plugins, Starship).
+
+The same apply is what removes retired files: `dotup` triggers dotfiles'
+post-apply hook, which runs `~/.claude/bin/claude-prune-retired` against
+the `retired-paths` list that just arrived through the external.
 
 ## The interactive shell is zsh
 


### PR DESCRIPTION
The last item on #195, plus the `dotup` doc fix.

## The stale pointer, which turned out to be two

ADR-0013's consequences said the beads integration "retires once migration is proven — tracked as follow-up work under issue #49". #49 was the 2026-07-13 tool evaluation and closed in July, and the cleanup it stood in for has since happened. A reader chasing that reference lands on a closed research issue and learns nothing about the state of the work.

`docs/beads-migration-runbook.md` had the same forward-pointer, in more detail — #195 only named the ADR.

## Verified rather than assumed

Before rewriting either, I checked each claim the old text made:

| Claim | State |
| --- | --- |
| `bd`/`beads`/`dolt` permission entries in `settings.json` | gone |
| `bd-*` commands, `bd-push-safe` in `home/` | gone, and listed in `home/retired-paths` |
| `/start-session`, `/end-session`, `/retrospective`, `/repo-review` target GitHub Issues | yes — no mention of beads in any of the four |
| Retired files removed from machines | confirmed on a real workstation 2026-08-16, which closed #125 |
| `bd prime` hooks | gone |

One thing is genuinely not done: `home/bin/bd-migrate-to-github` is still there, because the last repo isn't off beads yet. Both files now say so and point at #131 rather than at a closed issue. The runbook additionally records that it retires with the tool it documents — otherwise the runbook outlives its subject and nobody notices.

## The `dotup` fix

`home/local-machine.md` told the reader to use `chezmoi apply --refresh-externals`, or `chezmoi update --refresh-externals`, and never mentioned `dotup` — the command actually typed on that machine, which already runs `chezmoi update --refresh-externals` and more. Sending someone to the lower-level tool for no reason.

It now leads with `dotup`, keeps the bare `chezmoi` form for when you want the apply without Oh My Zsh and the rest, and records that the same apply is what triggers dotfiles' post-apply hook and therefore the `retired-paths` pruner. That connection wasn't written down anywhere on this side, and it's the bit that makes retiring a file actually reach machines.

## Verification

markdownlint 0 issues; 16/16 skills in sync; plugin manifests valid; retired-paths 12/12; hook tests 18/18; credential tests 71/71. Grepped for surviving `#49` follow-up pointers: none. The two remaining `#49` references are both historical citations of the evaluation itself, which are correct.

## The loose end is filed, so this closes cleanly

#195's first comment also noted a `paul-context` follow-up from #141 — recording that `decisions/` is formally the personal ADR tier. That's now **pmgledhill102/paul-context#49**, written against the repo at `d099d11` rather than from memory. Two things it found:

- Nothing in `paul-context` mentions ADR-0015, "tier", or "personal tier" at all. Its `README.md` describes `decisions/` as "Lightweight ADR-style", which is accurate but doesn't say the folder *is* a named tier that a public user-tier ADR points at by name.
- **0 of 10 files in `decisions/` carry a `Scope:` header.** ADR-0015 requires one so a record's blast radius is stated rather than inferred from its location — and inference from location is precisely what's happening. `/repo-review`'s Phase A2 flags exactly this, so all ten would light up the first time that repo is reviewed.

Closes #195.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)