### PR TITLE
Deliver /retrospective to cloud sandboxes via the bootstrap

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -4,9 +4,16 @@ Everything a vendor's cloud sandbox needs to gain this repo's capabilities,
 without the repo you are working on carrying any of it.
 
 `bootstrap.sh` is the whole mechanism: an environment's setup script fetches it
-by ref and runs it, and it installs the helper and skill into the container.
-See [ADR-0016](../adrs/0016-capability-delivery-principles.md) for why the
-substance lives here rather than in the setup script itself.
+by ref and runs it, and it installs the credential helper and a named set of
+skills into the container. See
+[ADR-0016](../adrs/0016-capability-delivery-principles.md) for why the substance
+lives here rather than in the setup script itself.
+
+Which skills is an explicit whitelist — the `SKILLS` variable in the script —
+rather than everything under `home/skills/`. Raw GitHub offers no directory
+listing, so a wildcard would need the API, a token and a JSON parser; and the
+list being hand-maintained means adding a skill to every sandbox is a decision
+someone makes rather than a side effect of creating a file.
 
 ## Claude Code
 
@@ -125,6 +132,12 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `/usr/local/bin/gcp-credentials` | the helper (or `~/.local/bin` unprivileged) |
 | `~/.claude/bin/gcp-credentials` | symlink, because the skill still names that path |
 | `/usr/local/bin/gcloud` | wrapper: prefers the broker token, renews it when stale |
+| `~/.agents/skills/<name>/SKILL.md` | each whitelisted skill, canonical |
+| `~/.claude/skills/<name>` | symlink to the above, for Claude Code |
+
+Whitelisted today: `retrospective`. The 15 `setup-*` skills are held back
+pending a currency review — they are repo-scaffolding procedures a sandbox
+session rarely needs, and they predate this surface.
 
 ## Updating a running session
 

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -243,6 +243,56 @@ log "adapter -> $HOME/.claude/skills/gcp-credentials"
 # two sources for one command.
 rm -f "$HOME/.claude/commands/gcp-credentials.md"
 
+# --- the workflow skills ------------------------------------------------------
+#
+# Everything above installs the credential client. This section is what makes
+# the script a config channel rather than a credential one: an explicit list of
+# skills that a sandbox should have, fetched by name.
+#
+# WHY A WHITELIST AND NOT `home/skills/*`: there is no directory listing over
+# raw.githubusercontent.com, so a wildcard would need the GitHub API, a token,
+# and a JSON parser — three dependencies for a list that changes a few times a
+# year. Naming them is also the review point: a skill reaches every sandbox the
+# moment it is added here, so the addition should be a decision rather than a
+# side effect of creating a file. The 15 `setup-*` skills are deliberately
+# absent pending a currency review: they are repo-scaffolding procedures that a
+# sandbox session rarely needs, and they predate this surface by some months.
+#
+# WHY THESE FETCH A PRE-BUILT SKILL.md AND gcp-credentials DOES NOT: the 17
+# skills under `home/skills/` are checked in with frontmatter and guarded
+# against drifting from their source command by tests/skills-match-commands.py.
+# There is nothing to synthesise, so this loop just fetches. The credential
+# skill above predates that machinery and is still generated from its command
+# file at install time; when it joins `home/skills/` these two paths merge.
+
+SKILLS="retrospective"
+
+for skill in $SKILLS; do
+    curl -sSfL "$RAW/home/skills/$skill/SKILL.md" -o "$TMP/$skill.SKILL.md" ||
+        die "could not fetch the $skill skill from $REF"
+
+    # Same 404-as-content guard as the helper: a bad ref returns an HTML error
+    # page with a 200 from some proxies, and a skill whose body is HTML fails
+    # in a way that reads like the skill being wrong rather than absent.
+    head -1 "$TMP/$skill.SKILL.md" | grep -q '^---$' ||
+        die "fetched $skill skill has no frontmatter — check that $REF exists"
+
+    dir="$HOME/.agents/skills/$skill"
+    mkdir -p "$dir"
+    cp "$TMP/$skill.SKILL.md" "$dir/SKILL.md"
+
+    # Same canonical/adapter split as the credential skill above: the real file
+    # lives in the vendor-neutral tree, each vendor path is a symlink that
+    # cannot drift. See that comment for the reasoning.
+    rm -rf "$HOME/.claude/skills/$skill"
+    ln -sfn "$dir" "$HOME/.claude/skills/$skill"
+    log "skill   -> $dir/SKILL.md (+ ~/.claude/skills/$skill)"
+
+    # A previous chezmoi-era or hand-copied command file registers the same
+    # /name a second time. Same reasoning as gcp-credentials above.
+    rm -f "$HOME/.claude/commands/$skill.md"
+done
+
 # --- report -------------------------------------------------------------------
 #
 # The pinned ref is logged because a cached cloud environment can serve an older

--- a/home/skills/retrospective/SKILL.md
+++ b/home/skills/retrospective/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: retrospective
+description: 'Run an end-of-session retrospective: draft a per-session journal entry into paul-context/_incoming/ (or a journal-draft-labelled Issue when the local clone is unavailable), route actionable findings into GitHub Issues same-repo and cross-repo, and capture durable lessons as memories. Use when a work session is wrapping up, when the user asks for a retro or retrospective, or when end-session hands off to one.'
+---
+
+# Run a session retrospective
+
+## Steps
+
+### 1. Read context
+
+- **Current repo**: `git rev-parse --show-toplevel` to identify which repo we're in (if any).
+- **Current branch + state**: `git status` (branch name, dirty/clean).
+- **Issue state**: list open issues assigned to me, so the retro knows what was already in flight — `mcp__github__list_issues` when connected, else `gh issue list --assignee @me --state open`.
+- **Memory dir**: list `~/.claude/projects/<project>/memory/` (path matches the cwd-derived project key) and read `MEMORY.md` so you know what's already captured and don't propose duplicates.
+- **Settings**: read `~/.claude/settings.json` for permission-related observations.
+- **Surface**: `command -v chezmoi`. Present = workstation; absent = cloud sandbox. This decides which dimensions run in step 2.
+
+**The last two reads are workstation-only.** A cloud sandbox has no `~/.claude/settings.json` and no `projects/<project>/memory/` — nothing is wrong, that state simply lives on the machine the session is not running on.
+
+**Degrade explicitly, don't skip silently.** When either is absent, say so in the retro output — `settings: n/a (sandbox)`, `memory: n/a (sandbox)` — and carry on. A retro that quietly omits a dimension reads identically to one that ran it and found nothing, and the difference matters: the first means "not checked here", the second means "checked, all good".
+
+If we're not inside a git repo, treat the retro as cross-repo by default — every action becomes an Issue against `pmgledhill102/paul-context`.
+
+### 2. Analyse the session
+
+Review the full conversation history and evaluate each of these dimensions. Skip any that aren't relevant.
+
+**Two dimensions are surface-specific** — run whichever matches the surface detected in step 1, not both:
+
+- **Approval friction** — *workstation only*. Skip in a sandbox: the permission model there is the environment's, `~/.claude/settings.json` is not readable, and a recommendation to add an allow rule has nowhere to land.
+- **Missing sandbox config** — *sandbox only*. See below.
+
+- **Approval friction** (workstation only): Which tool calls required manual approval? Were any repeatedly approved and should be added to `allowedTools` in settings? Note the specific tool patterns.
+- **Missing sandbox config** (sandbox only): **what config, context or credentials were missing from this sandbox session?** This is the feedback loop that catches capability gaps, and it is the dimension most worth getting right, because a sandbox is the surface where a gap is invisible until it blocks something. Look for:
+  - **Tools absent** that the work needed — was `gcloud`, a linter, a language runtime missing because the environment's setup script does not install it? Name the tool and the setup-script change.
+  - **Credentials unavailable** — was GCP access needed and absent? The answer is the credential broker (`/gcp-credentials`), so the finding is usually "the broker was not configured for this environment", naming which of the request key, broker URL or allowed-domains entry was missing.
+  - **Context that only exists on a workstation** — did the session need a runbook, a decision record, or a policy statement that lives in `~/.claude/` or a private repo and is therefore unreachable from here? That is a portability gap, and the fix is usually to move the content into a public, fetched, or repo-committed home.
+  - **Guidance a local session would have had** — anything you had to work out that a `CLAUDE.md`/`AGENTS.md` on a laptop would simply have told you.
+
+  Route every finding as an Issue against `pmgledhill102/agentic-coding-config` — that is where the environment definition, the bootstrap and the policy core all live. Be specific enough to action without re-running the session: name the tool or setting, what failed without it, and where it should be configured.
+- **Shell-friction patterns**: Did Bash tool calls use shell shapes that a file-import alternative would replace? These shapes hide multi-line content on the rendered command line, can trigger the harness's re-prompt heuristic even with the bare command allow-listed, and break on quoting edge cases. Scan the transcript for these patterns:
+  - `--description="$(cat PATH)"` / `--body="$(cat PATH)"` / `--message="$(cat PATH)"` — propose the tool's file flag (e.g. `gh issue create --body-file=PATH`, `gh pr create --body-file=PATH`).
+  - Heredocs (`tool <<'EOF' … EOF`) — already banned in the user's CLAUDE.md, but spot any that leaked in. Propose `Write` to `/tmp/<slug>.md` followed by the tool's file flag.
+  - Inline JSON / multi-line flag values (`tool --metadata '{"k":"v",…}'`) — propose `tool --metadata @file.json` (or equivalent `@`-prefix file syntax).
+  - Long pipelines that re-derive content already on disk (`cat foo.md | tool --read-stdin`) — propose `tool --file=foo.md` when supported.
+
+  For each match, **verify the file alternative actually exists** before suggesting it (run `<tool> --help`, search docs, or rely on the known patterns above) — do not speculate. Surface findings as a concrete before/after snippet, and persist durable insights via Claude Code auto-memory (the harness handles it) or the repo's docs so future sessions default to the file form. Example: *"The 3 `gh issue create` calls in this session used `--body=\"$(cat …)\"`. Switch to `--body-file=` for cleaner shell and fewer re-prompts."*
+- **CI round-trips**: How many push-then-fix cycles happened? What caused each failure? Could any have been caught locally first?
+- **Errors and debugging**: What errors were encountered? How long did each take to resolve? Were any red herrings?
+- **Approach pivots**: Where did the initial approach fail and require a different strategy? What was learned?
+- **Prompt clarity**: Were instructions clear enough, or did ambiguity cause wasted work?
+- **Tool gaps**: Were there tasks that no available tool handled well?
+- **Missing tools**: Were any CLI tools, SDK components, or binaries expected but not installed or not at the required version? For each:
+  - What was attempted and what error or fallback occurred?
+  - Is the tool installable via Homebrew, apt, pip, npm, or a component manager (e.g., `gcloud components install alpha`)?
+  - Should the tool be added to the dotfiles repo (e.g., Brewfile, chezmoi scripts) so it's provisioned across all workstations?
+- **MCP opportunities**: Were CLI tools used via Bash where an MCP server could provide safer, more granular access? Look for:
+  - **Approval friction from dual-use CLIs**: Commands used read-only (e.g., `gh api` to query releases) but couldn't be auto-approved because the same command can also perform destructive actions. An MCP server with scoped, read-only tools would eliminate this friction.
+  - **Repeated Bash commands for API queries**: Chains of `gh`, `gcloud`, `aws`, `kubectl`, or similar CLI calls that could be replaced by a dedicated MCP server offering structured, auto-approvable tools.
+  - **Already-connected MCP servers that went unused**: Check if configured MCP servers had tools that could have replaced Bash commands used in this session.
+  - For each opportunity, name the specific MCP server (if one exists) or note that one should be found/built.
+- **Claude addon opportunities**: Did this session manually perform work that an official Claude skill, plugin, or Anthropic-published MCP server already handles? Distinct from the MCP bullet above (that one targets read-only CLI friction); this one targets procedural automation that's already packaged. Prefer official/Anthropic-published addons over community equivalents and over hand-rolled slash commands.
+  - **Skills**: A repeated procedure that overlaps with an installed or marketplace skill. Check `~/.claude/skills/` and the in-session "available skills" list before proposing a new slash command.
+  - **Plugins**: A coherent bundle (skill + commands + hooks) a published Claude Code plugin would provide in one install. Check `claude plugin marketplace` before bundling something in-house.
+  - **Anthropic-published MCP servers**: Was a third-party/community MCP (or a raw CLI in Bash) used where Anthropic now ships a first-party equivalent?
+- **Agent opportunities**: Did this session do work in the main thread that should have been delegated to a subagent — or do work that recurs often enough to warrant a custom agent definition? Two distinct cases:
+  - **Built-in subagents under-used**: Broad codebase research that could have gone to `Explore` (read-only, parallel-safe), open-ended multi-step work better suited to `general-purpose`, or design/architecture choices that should have used `Plan`. Look for: serial Read+Grep chains in the main thread, large tool-result bodies that bloated context, or heavy investigation done before any code was written.
+  - **Custom agent candidates**: A repeated investigation/synthesis pattern that has its own prompt shape — distinct from a slash command (which is procedural) and from a skill (which encodes user-facing workflow). Strong signals: the same multi-step research recipe ran more than once this session or across recent sessions; the work needs a specialised system prompt or tool restriction; the output is a structured report rather than file edits. Custom agents live in `~/.claude/agents/` (mirror to `agentic-coding-config/home/agents/`). For each, propose: agent name (kebab-case), one-line purpose, the tool subset it should be limited to, and the recurring trigger.
+- **Memory candidates**: What durable lessons should travel across sessions? Look for:
+  - Validated patterns confirmed in this session ("X approach worked, keep doing it").
+  - Anti-patterns to avoid ("Don't Y because Z").
+  - User preferences expressed or implied ("the user prefers terse summaries").
+  - Non-obvious facts about the user's repos, systems, or workflow.
+- **Issue hygiene**: Were GitHub Issues created before work started? Were they closed properly (`Closes #<n>` in the PR body, or `gh issue close <n>` with a comment)?
+- **Slash command opportunities**: Did this session perform a procedure that's likely to be repeated — either across other projects, or periodically in this one? Strong signals:
+  - The user explicitly mentioned having other projects/contexts that need the same treatment.
+  - The procedure had non-obvious ordering, workarounds, or gotchas that would be easy to forget on a re-run.
+  - Five-plus coherent sequential steps completed a single logical task.
+  - A back-out/retry happened because a step was performed in the wrong order.
+  - Investigation took disproportionate time relative to the eventual fix.
+
+  For each candidate, propose: a command name (kebab-case), a one-line description, the key pre-flight checks, and the gotchas the prompt must surface. Existing commands live in `agentic-coding-config/home/commands/` (deployed to `~/.claude/commands/`) — check there first to avoid duplicates.
+
+- **Slash command improvements**: Did this session invoke any existing slash command (or manually perform work that an existing one should have handled)? For each:
+  - Was a step missing, wrong, or stale?
+  - Did instructions cause a wrong decision via ambiguity?
+  - Did we deviate from the command's plan? Why — and should the command codify the deviation?
+
+  Recommend the specific edit (file path + which section).
+
+### 3. Categorise findings
+
+For each finding, decide what kind of artifact it should produce:
+
+| Kind | When to use | How to produce |
+| --- | --- | --- |
+| **Journal entry** | Always (unless the session was uneventful — then skip and stop). Captures the narrative thread, Continue items, and Observations that don't fit into actionable artifacts | Draft via the inbox/promote pattern. **Filesystem path** (preferred when `~/dev/paul-context/_incoming/` is writeable): `Write` to `~/dev/paul-context/_incoming/<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md` — **no git ops against `paul-context`**. **GitHub Issue fallback** (sandbox / remote VM / no local clone): `gh issue create --repo pmgledhill102/paul-context --label journal-draft --title="journal: <filename-without-.md>" --body-file=/tmp/<filename>`. Tight format: H1 title, project/duration metadata, Continue / Stop / Created / Observations sections, ~30-50 lines. Promoted into `paul-context/journal/` later by `/promote-journal-inbox` |
+| **Same-repo Issue** | Action whose subject is the **current cwd's repo** | Create an issue in the current repo with a `type: <task/bug/feature>` label and a `P0`–`P4` priority (P2 is "do this soon", P3 is "next time we touch this", P4 is "backlog") — `mcp__github__issue_write` when connected, else `gh issue create --title=... --label "type: <type>,P<n>"`. **Body MUST include**: "From retro: paul-context/journal/<file>.md" |
+| **Cross-repo Issue** | Action whose subject is a *different* personal repo from cwd | Create an issue against `pmgledhill102/<target>` — `mcp__github__issue_write` with an explicit `owner`/`repo`, else `gh issue create --repo pmgledhill102/<target>`. Picked up by `start-session` there. **Body MUST include** the journal cross-reference |
+| **paul-context Issue** | Cross-cutting or no-clear-home findings | Create an issue against `pmgledhill102/paul-context`, same two routes as above. **Body MUST include** the journal cross-reference |
+| **Memory write** | Durable lesson that should auto-load on future sessions | `Write` to `~/.claude/projects/<project>/memory/<slug>.md` with frontmatter, then `Edit` `MEMORY.md` index |
+| **Settings change** | Permission to add/move, hook to register, env var to set | File an Issue against `pmgledhill102/agentic-coding-config` describing the change and why — same routing as any other a-c-c finding. **Never edit a `settings.json` directly** (see 3b) |
+| **Observation only** | Something noted but not actionable ("everything went smoothly") | No artifact; mention in the journal's Observations section |
+
+### 3a. No cd-shortcut
+
+**Always name the target repo explicitly. Never `cd` into it.** Even when the target repo is checked out at a known path locally, do NOT change into it to file the issue from there. Retros run from a remote sandbox don't have target repos cloned — the command must be portable.
+
+Both routes satisfy this, because both take the repo as an argument rather than inferring it from the working directory: `mcp__github__issue_write` with an explicit `owner`/`repo`, or `gh issue create --repo pmgledhill102/<target>`. Either works identically from a sandbox or a laptop.
+
+Prefer MCP when it is connected. Keep `gh` in mind for headless or sandbox runs, where a `gh` token is more reliably present than an interactively-authenticated MCP server — that portability is the reason the `gh` forms are still written out here.
+
+### 3b. Never edit settings.json — file an a-c-c Issue
+
+Permissions, hooks, env vars and everything else in `~/.claude/settings.json` are **managed centrally** by `pmgledhill102/agentic-coding-config` and applied to each machine by chezmoi. A retro's job is to *route* a settings finding, not to apply it:
+
+- **Do not edit `~/.claude/settings.json`.** chezmoi overwrites it on the next apply and the change is silently lost.
+- **Do not "helpfully" redirect the change into the current project's `.claude/settings.json` or `.claude/settings.local.json` instead.** A globally-useful permission parked in one project repo only works in that repo, is invisible to the a-c-c inbox, and diverges from the managed set. This substitution is the specific failure this section exists to prevent.
+- **Do not invoke `/update-config`** for managed settings — that skill edits settings files in place, which is exactly the wrong outcome here. (It remains the right tool when the user is deliberately configuring a project-local harness setting, unrelated to a retro finding.)
+- **Do** file an Issue against `pmgledhill102/agentic-coding-config` with the exact rule (e.g. `Bash(rg --json *)`), the friction observed this session, and whether it's read-only. Same body requirements as any other cross-repo Issue, including the journal cross-reference.
+
+**The one exception**: a setting that is genuinely specific to the *current* repo and belongs to it permanently — a project-scoped hook, or a permission for a tool only this repo uses. That still goes in the repo's **checked-in** `.claude/settings.json` via the normal branch/PR flow, never as an untracked local edit. If the rule would be useful in any other repo, it isn't this case — file the a-c-c Issue.
+
+### 4. Routing heuristics for "which repo?"
+
+When a finding clearly mentions a target, route there. Otherwise apply this default split:
+
+- **Brewfile / package lists / shell config / OS bootstrap / chezmoi machinery** → `dotfiles`
+- **Slash commands / hooks / `~/.claude/settings.json` / MCP server config / the policy files (`home/AGENTS.md` portable, `home/CLAUDE.md` Claude-specific, `home/local-machine.md` workstation-only)** → `agentic-coding-config`
+- **Engineering principles / personal direction / repo registry / archive list / decisions** → `paul-context`
+- **Genuinely unsorted / "I had a thought"** → `paul-context` (default fallback)
+
+### 5. Propose
+
+Show the user a single table of proposed artifacts. **Do not create anything yet.** The journal entry is **always row 1** unless the session was uneventful (in which case the table has just one observation row and the flow stops). Format:
+
+```text
+Proposed retrospective output:
+
+#  Kind        Where                                Title / Memory key / Slug                 Priority
+1  journal     paul-context/journal/                2026-05-03-personal-infra-split.md         —
+2  memory      feedback                             chezmoi-externals-git-repo-vs-archive      —
+3  issue       <current repo>                       Fix pre-commit + terraform fmt hook race   P3 task
+4  issue       pmgledhill102/dotfiles               Document chezmoi-update lag for externals  —
+5  settings    pmgledhill102/agentic-coding-config  Allow `Bash(rg --json *)` (read-only)      —
+6  observation —                                    Session was clean overall                  —
+
+Reply 'yes' to create all, override per-item ('3: priority=2, type=bug'),
+'skip <n>' to drop, or 'cancel' to abort.
+```
+
+Wait for explicit confirmation. Don't proceed on ambiguous input.
+
+### 6. Execute
+
+**Order matters**: write the journal **first** so subsequent issues can reference its path. Then create everything else.
+
+1. **journal** (always first):
+   - **Derive the filename.** `<source-repo-slug>` = sanitised basename of `git remote get-url origin` from the current cwd (lowercase, `[a-z0-9-]+`). If no git remote, use `basename "$PWD"`. `<topic-slug>` = kebab-cased session summary, ≤5 words. `<filename>` = `<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md`.
+   - **Resolve same-project same-day collisions** at write-time: if the target already exists, append `-2`, `-3`, … before `.md` until unique. Filesystem path checks `~/dev/paul-context/_incoming/<filename>`; Issue path checks for an open Issue with the same title (rare in practice — same project, same day, same topic — but the suffix prevents silent merge of two distinct retros).
+   - **Pick the inbox path:**
+     - **Filesystem inbox** (preferred): if `[ -d ~/dev/paul-context/_incoming ] && [ -w ~/dev/paul-context/_incoming ]`, `Write` the journal markdown to `~/dev/paul-context/_incoming/<filename>`. **No git operations against `paul-context`.**
+     - **GitHub Issue fallback** (sandbox / remote VM / no local clone): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Edit(/tmp/**)` is auto-allowed, and `Edit` rules cover the `Write` tool), then file as a labeled Issue:
+
+       Create the issue on `pmgledhill102/paul-context` with the
+       `journal-draft` label and the title `journal: <filename-without-.md>`,
+       body taken from the staged file. Prefer `mcp__github__issue_write`;
+       the `gh` form below is the portable fallback, and matters here because
+       this path fires precisely when the session is in a sandbox:
+
+       ```sh
+       gh issue create --repo pmgledhill102/paul-context \
+           --label journal-draft \
+           --title "journal: <filename-without-.md>" \
+           --body-file /tmp/<filename>
+       ```
+
+       The `journal-draft` label and the `journal:` (with trailing space) title prefix are how `/promote-journal-inbox` finds the draft. Promotion infers the eventual filename by stripping `journal:` (with trailing space) from the Issue title and appending `.md`, so the filename is stable from draft → committed.
+     - **Both unreachable** (rare — offline AND no local clone): print the full draft to the session log with clear `===BEGIN JOURNAL===` / `===END JOURNAL===` delimiters and stop. Don't silently discard content. Tell the user to save it manually.
+   - Capture `paul-context/journal/<filename>` (the eventual post-promotion path) for cross-references in subsequent issues. The path is stable across both inbox paths because both preserve `<filename>` exactly.
+2. **memory**: Write the memory file with proper frontmatter (`name`, `description`, `type` of `user|feedback|project|reference`), then Edit `MEMORY.md` to add a one-line index entry. Follow the conventions in the parent CLAUDE.md auto-memory section.
+3. **issue** (same-repo): create it against the current repo, with a `type:` label and a `P<n>` priority — `mcp__github__issue_write`, else `gh issue create --title="..." --body-file=... --label "type: <type>,P<n>"` from the **current cwd**. Body **MUST** include `From retro: paul-context/journal/<file>.md` near the top. Capture the issue number for the summary.
+4. **issue** (cross-repo): create it against `pmgledhill102/<repo>`, naming the repo explicitly — `mcp__github__issue_write` with `owner`/`repo`, else `gh issue create --repo pmgledhill102/<repo>`. Filed from wherever the retro runs; never `cd` into the target repo (see step 3a). Body **MUST** include `From retro: paul-context/journal/<file>.md`. Capture the URL.
+5. **settings**: file it as an Issue against `pmgledhill102/agentic-coding-config`, by either route — exactly as for any other cross-repo finding. Include the precise rule string, the friction it removes, and whether the command is read-only. **Do not apply the change to any `settings.json`** (see 3b); a single-line permission addition is still an Issue, not an edit.
+
+If any single create fails, surface the error and continue with the rest. Don't roll back successful artifacts on partial failure.
+
+### 6a. Journal entry format
+
+```markdown
+# YYYY-MM-DD — <session summary>
+
+**Project**: <repo or context>
+**Duration**: <approximate>
+**Issues created/closed this session**: <list, or "none">
+
+## Continue
+- <validated patterns — what worked, worth repeating>
+
+## Stop
+- <anti-patterns observed — what to avoid next time>
+- (cite existing memory if already captured: `feedback_xxx.md`)
+
+## Created from this retro
+- Memory: `<slug>.md` — <one-line summary>
+- Issue: <repo> — <issue title> (<priority> / <URL>)
+
+## Observations
+- <session-level notes that don't fit the above — design decisions made,
+  pivots that landed well, things that surprised>
+```
+
+Tight is good — aim for 30-50 lines. Skip sections that are empty (don't write `## Continue\n(none)`, just omit).
+
+### 7. Do NOT write to retros.md
+
+The file is retired. If `~/.claude/retros.md` still exists locally from before, leave it alone — the user can `rm` it. Don't read from it, don't append to it, don't reference it in artifacts.
+
+### 8. Brief summary
+
+Print a compact wrap-up:
+
+```text
+Retrospective complete.
+
+  Journal:                    paul-context/journal/2026-05-03-agentic-coding-config-foo.md (drafted to _incoming/; pending /promote-journal-inbox)
+  Issues created (here):      3 — #41, #42, #43
+  Issues raised cross-repo:   2 — github.com/.../issues/14, github.com/.../issues/15
+  Memories saved:             1 — feedback_xyz.md
+  Settings changes:           1 — filed as agentic-coding-config#<n> (not applied locally)
+
+Next /start-session in the cross-repo'd repos will surface the new Issues as ready work.
+```
+
+## Guidelines
+
+- Be specific and actionable — not "improve error handling" but "add `google_project_service` explicit depends_on to prevent 403 race conditions".
+- Use exact tool patterns for permission recommendations, e.g., `Bash(chezmoi apply)`.
+- For missing tools, include **both** the immediate install command (e.g., `brew install foo`) **and** the dotfiles change needed to provision it everywhere (e.g., "add `foo` to `home/Brewfile.tmpl`"). Recommend the user install the tool now AND raise the dotfiles issue so it persists across machines.
+- For MCP recommendations, explain the **specific friction being solved** (e.g., "spent 5 approval prompts on read-only `gh api` calls"). Include the MCP server name/repo if known, and note whether it should be project-level or user-level config.
+- For Claude addon recommendations, **name the specific skill/plugin/MCP and mark it official vs community**, and cite the manual work or hand-rolled slash command it would replace. Default to suggesting an existing official addon before proposing a new in-house slash command.
+- For new slash command proposals, include the **proposed name**, a **one-sentence description**, and the **most important gotcha or pre-flight check** the command must encode.
+- For slash command improvement recommendations, reference the **command file path** and cite the **specific deviation or failure mode** observed this session.
+- Memory writes should follow the auto-memory conventions in the global CLAUDE.md: lead with the rule/fact, then `**Why:**` and `**How to apply:**` lines for `feedback` and `project` types.
+- For Issue descriptions, cross-reference the relevant decision record or principle in `paul-context` if the action is implementing a decided direction (e.g. "see paul-context/decisions/2026-05-03-...md").
+- If the session was uneventful with no notable friction, say so briefly in step 5's table as a single observation row, and stop. Don't manufacture artifacts.
+- Reference specific errors, file paths, and issue numbers in artifact descriptions where relevant.
+
+## What changed from the previous versions
+
+This command used to append a markdown entry to `~/.claude/retros.md` (the original flow), then was rewritten to output tracker items only without any journal (rev 1 of the new flow), then revised to include a per-session journal in `paul-context` (current). A later revision (2026-05-06) added the **Shell-friction patterns** dimension to Section 2 so each retro proactively surfaces command-shape friction (`$(cat …)`, heredocs, inline JSON) and proposes verified file-flag alternatives. A subsequent revision (2026-05-06) replaced the direct-write-to-`journal/` flow with an **inbox/promote** pattern: drafts land in `paul-context/_incoming/` (or as a `journal-draft`-labeled Issue when the local clone isn't available), and `/promote-journal-inbox` (run from `~/dev/paul-context/`) drains both inboxes into `journal/`. Filename convention gained a `<source-repo-slug>` prefix so cross-project drafts can't clobber each other. The skill no longer performs git operations against `paul-context` from arbitrary projects — see `paul-context/decisions/2026-05-05-journal-inbox-promotion.md` for the rationale. The final shape:
+
+- **Sandbox-agent reachable**: GitHub Issues are network-reachable, and journal drafts fall back to a `journal-draft`-labeled Issue against `paul-context` when the local `_incoming/` directory isn't present. Sandbox runs surface as Issues; local runs surface as filesystem drafts; promotion is invisible to the eventual journal entry.
+- **Per-entry, not single-master**: each retro produces a dated, slugged file in `paul-context/journal/`. The original `retros.md` decayed because it was one file containing everything. Per-entry files survive long-term scrolling.
+- **Privacy gives candour**: `paul-context` is private, so retros can be honest ("got stuck", "almost shipped a broken design") without self-censorship that public agentic-coding-config would force.
+- **Different layers**: agentic-coding-config is *what I configure*; the journal is *how I reflected on using it*. Reflections live with personal context, not tool config.
+- **Cross-repo actions land in the right tracker**: an action surfaced during a `dotfiles` retro that affects `agentic-coding-config` becomes an Issue *there*, with a backlink to the journal entry in `paul-context`.
+- **paul-context has no branch protection**: `/promote-journal-inbox` commits + pushes to `main` directly. No PR overhead per retro.
+
+A 2026-08 revision (§3b) made settings findings route as `agentic-coding-config` Issues only. The previous wording — "invoke `/update-config`; or, if simple, propose the exact edit" — invited applying a globally-managed permission as a local `settings.json` edit, which chezmoi then overwrites; in one session it was nearly redirected into a project's `.claude/settings.json` instead, where it would have been invisible to the a-c-c inbox.
+
+A 2026-07 revision retired the `bd` tracker entirely: same-repo findings now file as GitHub Issues in the current repo, matching the cross-repo path. See `agentic-coding-config` `docs/github-issues-workflow.md` for the work-tracking conventions, and `paul-context/decisions/2026-05-03-personal-infra-public-private-split.md` for the wider three-repo layout this fits into.


### PR DESCRIPTION
Makes `cloud/bootstrap.sh` a config channel rather than a credential one, and puts `/retrospective` down it.

## Why

`bootstrap.sh` fetched exactly two files by name — `home/bin/gcp-credentials` and `home/commands/gcp-credentials.md`. It never cloned the repo and never copied a directory, so despite sourcing its files from `home/`, every other command was invisible in a sandbox.

That is the mechanical cause of #239: a ~9h session ended up reconstructing `/retrospective` from a pasted GitHub URL, and nearly produced the retro in the wrong destination and the wrong format, because the definition specifying both was not on any path the session could read.

## What changed

**`cloud/bootstrap.sh`** — a `SKILLS` whitelist, currently `retrospective`. Each entry is fetched, verified to have frontmatter, installed canonical to `~/.agents/skills/<name>/SKILL.md`, symlinked into `~/.claude/skills/`, and any stale `commands/<name>.md` registration removed. Same canonical/adapter split as the credential skill, for the reason its comment already gives: a symlink cannot drift, a copy can.

**`home/skills/retrospective/SKILL.md`** — new, joining the 16 existing skills under `tests/skills-match-commands.py`. The validator now reports 17.

**`cloud/README.md`** — the whitelist rationale, and `~/.agents/skills/<name>/` plus its symlink added to the "what lands where" table.

## Two decisions worth reviewing

**A whitelist, not a glob over `home/skills/`.** There is no directory listing over `raw.githubusercontent.com`, so a wildcard needs the GitHub API, a token and a JSON parser — three dependencies for a list that changes a few times a year. The better reason is that naming each skill keeps "this reaches every sandbox" a decision someone makes rather than a side effect of adding a file. The 15 `setup-*` skills are held back pending #247; they are repo-scaffolding procedures a sandbox session rarely needs, and they predate this surface.

**These fetch a pre-built `SKILL.md`; `gcp-credentials` still synthesises one.** The skills under `home/skills/` are checked in with frontmatter and guarded against drifting from their source command, so there is nothing to build at install time and the loop just fetches. The credential skill predates that machinery and still lifts its description from the command file at install time. The two paths merge when it moves under `home/skills/`. Deliberately not done here — it changes the credential flow, which deserves its own change.

The skill body was generated by calling `command_as_skill_body` and `strip_command_description` from the validator itself, rather than hand-edited to match. The one transform that applied was `` `/start-session` `` → `` `start-session` ``.

## Verification

Served the working tree over localhost, pointed the modified script at it, and ran it:

```
[bootstrap] skill   -> /root/.agents/skills/retrospective/SKILL.md (+ ~/.claude/skills/retrospective)
```

`/retrospective` then appeared in the running session's available-skills list, without a restart.

That is also, incidentally, the end-to-end evidence #48 has been asking for since July — that a container-created `~/.claude/` is read in a cloud session. The docs' "not available" rows for user scope are about *transfer from your machine*, not about the loader; see the doc review in #245.

Gates, all clean: `shellcheck cloud/bootstrap.sh`, `markdownlint-cli2` on both markdown files, `tests/skills-match-commands.py` (17/17), `tests/plugin-manifests.py`, `tests/retired-paths.sh`. Neither `shellcheck` nor `markdownlint-cli2` is present in a sandbox by default — installed to run them, which is #240's complaint in another colour.

## Scope

Refs #239 rather than closing it. That issue asks for all personal commands, and for the broader rule that a command present on the workstation should either exist in a sandbox or announce its absence. This delivers one command and the mechanism for the rest.

Follow-ups filed: #245 (shared policy — sandboxes get none today, and #238 is blocked on it), #246 (staleness manifest and refresh), #247 (`setup-*` currency review before whitelisting).

## Not done here

- No policy files ship. `~/.claude/CLAUDE.md` does not exist in a sandbox, and `home/CLAUDE.md` cannot ship verbatim because it imports `local-machine.md`, which is false on this surface. That is #245.
- No staleness detection. A sandbox still cannot tell how old its skills are; the ~7-day snapshot means a push does not reach new sessions. That is #246.
- The plugin still ships `commands/retrospective.md` from `home/`, so a session with both channels would have two registrations — the #234 shape. Not triggerable today, since nothing enables the plugin, but it is the reason to settle the channel question rather than let both grow.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFVRa7P4DCJmWJtbXwpLAi)_