### PR TITLE
ADR-0018: composing agent context per surface, and why cloud-first

### DIFF
--- a/adrs/0018-composing-agent-context-per-surface.md
+++ b/adrs/0018-composing-agent-context-per-surface.md
@@ -1,0 +1,275 @@
+# ADR-0018: Composing agent context per surface — profiles, tiers, one mechanism
+
+- **Status**: Proposed (2026-08-18)
+- **Date**: 2026-08-18
+- **Tags**: architecture, portability, context, skills, claude-code, codex
+- **Scope**: user (applies to all personal repos and agent surfaces)
+
+## Context
+
+[ADR-0016](0016-capability-delivery-principles.md) settled *where* a
+capability should live. It did not say how the **content** that reaches a
+session is assembled, and the estate has since accumulated three
+symptoms of that gap.
+
+**Cloud sandboxes get no policy at all.** Verified 2026-08-17: `ls
+~/.claude/*.md` is empty in a sandbox. The 221 lines of portable policy
+in `home/AGENTS.md` and `home/ephemeral-first.md` reach workstations via
+chezmoi and nothing else. Sessions on what is now the primary surface run
+with whatever the opened repo happens to commit.
+
+**Content branches at runtime on which surface it is running.** The
+session commands ask `command -v chezmoi` and route on the answer:
+
+```text
+home/commands/start-session.md     8 surface conditionals
+home/commands/end-session.md      11
+home/commands/retrospective.md    16
+```
+
+Each branch is text that every session reads and most sessions cannot
+use. A sandbox pays context for workstation instructions and then has to
+correctly decide to ignore them — a decision it can get wrong, and
+[#239](https://github.com/pmgledhill102/agentic-coding-config/issues/239)
+is what that looks like when it does.
+
+**Two mechanisms carry the same payload.** `home/commands/*.md` and
+`home/skills/*/SKILL.md` both register `/name` and behave identically —
+`cloud/bootstrap.sh` says so in a comment and deletes the duplicate
+registration it would otherwise create. 17 of 21 commands already have a
+skill twin, kept in step by a test that documents its own retirement.
+
+Underneath all three is one question this ADR answers: **when a statement
+must hold on some surfaces and not others, what resolves the
+difference — the agent at runtime, or the delivery at build time?**
+
+One fact makes the answer available. ADR-0016 established that a
+container-created `~/.claude/skills` is read, symlinks included, on both
+Claude Code and Codex. A canary on 2026-08-18 extended that to policy: a
+`~/.claude/CLAUDE.md` written 37 minutes after session start was loaded
+on resume, announced as *"user's private global instructions for all
+projects"*. Per-surface policy delivery is therefore possible, which is
+what makes per-surface composition worth designing.
+
+## Decision
+
+Adopt seven principles for composing and delivering agent context.
+
+### 1. Determinism over conditionals
+
+**Environment differences are resolved when content is delivered, not
+when it is read.** A sandbox receives text that is true in a sandbox. A
+workstation receives text that is true on a workstation. Neither receives
+a conditional describing the other.
+
+This is binding for always-loaded policy and strong for everything else.
+The reasoning differs by tier, which is why they are separated:
+
+- In policy, a conditional costs context on **every turn of every session
+  for the rest of time**, and the surface it does not apply to pays that
+  cost permanently.
+- In a procedure, the cost is smaller but the risk is larger: a branch is
+  a decision the agent can take wrongly, and a wrong branch on a
+  destructive step is worse than a missing instruction.
+
+The corollary is that runtime surface-detection — `command -v chezmoi`
+and its relatives — is a smell in content. It is legitimate in a
+*script*, which is code and has no context cost; it is not legitimate in
+prose the model reads.
+
+### 2. Tier every statement by what it costs to load
+
+There are three tiers, and they differ by an order of magnitude in cost:
+
+| Tier | Loaded | Cost |
+| ---- | ------ | ---- |
+| Policy (`AGENTS.md` / `CLAUDE.md`) | in full, every session | highest — permanent |
+| Skill description | one line, every session | low, but multiplied by skill count |
+| Skill body | only when the skill is used | ~zero until used |
+
+**A statement's tier is chosen deliberately.** Policy is for what must
+hold every turn regardless of task. Anything procedural belongs in a
+skill body, where it costs nothing until needed.
+
+This reframes the usual question. "Which file does this go in" is
+downstream of "how often must this be true", and getting the second right
+makes the first mechanical. It is also the answer to the context budget:
+Claude Code targets under 200 lines of always-loaded policy, and the
+portable core plus principles already exceeds it — not because the
+content is wrong, but because some of it is procedure sitting in the
+policy tier.
+
+### 3. One mechanism: skills
+
+**Skills are the unit. `home/commands/` is retired.** Slash commands and
+skills register identically; skills additionally carry frontmatter that
+lets the model invoke them unprompted, bundle adjacent files, and are the
+cross-provider standard rather than a per-vendor directory.
+
+Keeping both means every content change is made twice — which is exactly
+why `tests/skills-match-commands.py` exists, and that test is scaffolding
+for a migration, not a permanent fixture.
+
+### 4. Fragments are the source; delivered artefacts are derived
+
+Content is authored as **fragments** — a portable core, a provider
+fragment, an environment fragment. What lands on a surface is
+**composed** from them by a single generator, committed, and checked in
+CI.
+
+The generator is one program. Composition must not live in the
+installers: `cloud/bootstrap.sh` and the chezmoi path would then hold two
+implementations of the same logic, delivered by different routes, drifting
+independently. That is the failure this repo keeps meeting, one level up.
+
+Committing the composed output rather than assembling at install time
+also means **the artefact a surface receives is readable in the repo**,
+which matters when the question is "why did the agent believe that".
+
+### 5. Profiles compose from axes, not from names
+
+Surfaces vary along two independent axes:
+
+- **provider** — Claude Code, Codex, OpenCode: tool names, MCP servers,
+  invocation spellings
+- **environment** — workstation, cloud sandbox: whether chezmoi manages
+  `~/.claude`, whether a credential broker exists, what is on `PATH`
+
+A profile is a **point** in that space, not a hand-written file. One core
+plus two provider fragments plus two environment fragments composes four
+profiles; adding a provider costs one fragment, not one file per
+environment. Naming profiles directly — `agents-claude-sandbox.md`,
+`agents-codex-sandbox.md` — restates the environment half once per
+provider and grows multiplicatively.
+
+`home/local-machine.md` is already an environment fragment. It is only
+reachable through `home/CLAUDE.md`, which is why shipping that file
+verbatim to a sandbox would inject chezmoi instructions into the one
+surface with no chezmoi. The axis split makes that structurally
+impossible rather than a thing to remember.
+
+### 6. No delivery assumptions in portable text
+
+Restated from ADR-0016 principle 3 and now load-bearing: content names
+what it needs, never where the delivery put it. The `~/.claude/bin/...`
+paths in the broker skill are the standing example, and
+[#234](https://github.com/pmgledhill102/agentic-coding-config/issues/234)
+is the cost.
+
+Under principle 1 this gets sharper. Deterministic delivery removes the
+excuse for a path conditional: if a path genuinely differs by surface, it
+belongs in the environment fragment, resolved at composition.
+
+### 7. Every profile is built and verified in CI
+
+Deterministic delivery trades runtime adaptability for build-time
+correctness. **That is only a good trade if something checks the build.**
+
+A conditional, for all its cost, degrades visibly — the wrong branch runs
+and someone notices. A profile that was composed wrongly, or from a stale
+fragment, is silent: it is only wrong on a surface, and a surface nobody
+used this week is a surface nobody is watching.
+
+So CI composes **every** profile on every change and asserts the
+committed outputs match. Additionally, and specifically:
+
+- every committed profile matches what the generator produces from the
+  current fragments
+- no sandbox profile transitively includes a workstation-only fragment
+- every composed policy artefact is reported with its line count, so the
+  always-loaded budget is a number in the build rather than a surprise
+
+This principle is the price of the other six. Without it, principle 1
+converts loud failures into quiet ones.
+
+## Consequences
+
+### Positive
+
+- A sandbox session reads only statements that are true in a sandbox.
+  Context spent on the other surface's instructions goes to zero.
+- The single biggest reliability gap closes: `start-session`,
+  `end-session` and `retrospective` become deliverable, in a form
+  appropriate to each surface, rather than one text hedging across all of
+  them.
+- Adding a provider is one fragment and a CI row.
+- The always-loaded budget becomes measurable and enforced rather than
+  discovered when adherence degrades.
+- Retiring `home/commands/` halves the edit surface for every content
+  change and removes a test that exists only to police duplication.
+
+### Negative / trade-offs
+
+- **This reverses part of [#139](https://github.com/pmgledhill102/agentic-coding-config/issues/139).**
+  The surface-aware rework of the session commands — `command -v
+  chezmoi`, the `chezmoi-unavailable` sentinel, the silent-skip states —
+  is the runtime-detection pattern principle 1 replaces. That work was
+  correct under the constraint that one text had to serve every surface.
+  Removing the constraint makes it unnecessary, not wrong, and it should
+  be unwound deliberately rather than left as two overlapping mechanisms.
+- **Generated files in the tree.** Composed artefacts are committed, so
+  reviewers see machine-written diffs alongside fragment edits. Mitigated
+  by CI failing on a stale artefact, which makes the diff mandatory
+  rather than optional.
+- **Profiles multiply.** Four today, more as providers and environments
+  appear. The axes bound the growth but do not stop it, and ADR-0016
+  already flagged environment proliferation as a thing to watch.
+- **A fragment used by one profile is exercised by one surface.** Rot is
+  invisible without principle 7, and principle 7 checks composition, not
+  truth: CI can prove the sandbox profile was built correctly and cannot
+  prove its contents are still accurate. That remains a human review.
+- **The content review is unavoidable and is not small.** Splitting
+  content by surface requires deciding, line by line, which surface each
+  line is true on. Much of `home/` predates the cloud surface entirely.
+
+### Explicitly not decided here
+
+Whether the AGENTS.md format supports any import mechanism, and where a
+user-level `AGENTS.md` lives for Codex, are unverified — `agents.md` is
+blocked by the sandbox egress policy
+([#241](https://github.com/pmgledhill102/agentic-coding-config/issues/241)).
+This ADR is written so the answer does not matter: composition produces
+complete files, so no consumer needs import support. If it turns out
+imports are available, they are an optimisation, not a change of shape.
+
+## Alternatives considered
+
+**Compose by import (`@fragment.md`).** Claude Code expands `@path`
+imports at launch, four hops deep, so a three-line `CLAUDE.md` could pull
+in core plus fragments with no generator at all. Rejected as the general
+mechanism because it is, as far as is known, Claude-only: an `AGENTS.md`
+containing `@agents-core.md` reaches Codex as literal text, and fails
+silently rather than loudly. Retained as a possible Claude-side
+simplification once the AGENTS.md question above is answered.
+
+**Assemble at install time in each installer.** `bootstrap.sh` and the
+chezmoi path each concatenate fragments. Rejected: two implementations of
+one logic, on two delivery routes, with no shared test — and the obvious
+fix, a shared script, has to be delivered to both, which is the problem
+it was meant to solve.
+
+**Symlink `AGENTS.md` and `CLAUDE.md` to one master.** Works only while
+the two files are byte-identical. `CLAUDE.md` carries the GitHub MCP
+mapping table, which is meaningless to other providers, so they diverge
+immediately. Symlinks remain the right tool *within* a profile — one file
+serving several vendor paths, as ADR-0016 confirmed for skills.
+
+**Keep runtime conditionals; do nothing.** Rejected. It is the current
+state, it costs context on every surface permanently, and it has already
+produced one failure where a session could not tell which half of a
+document applied to it.
+
+## References
+
+- [ADR-0014](0014-portable-agent-config-architecture.md) — the mechanisms
+  being composed
+- [ADR-0015](0015-tiered-adrs.md) — tier conventions; this is a user-tier
+  decision
+- [ADR-0016](0016-capability-delivery-principles.md) — where capability
+  lives; principle 6 here restates its principle 3, and its container-created
+  `~/.claude` findings are what make this feasible
+- #238, #239, #245 — the delivery gaps this is the framework for
+- #246 — staleness; principle 7 is build-time correctness, #246 is
+  deployed-time freshness, and they are different problems
+- #247, #142, #48 — content review, chezmoi shrink, and the commands
+  retirement that principle 3 completes

--- a/docs/reviews/strategic-review-2026-08-09.md
+++ b/docs/reviews/strategic-review-2026-08-09.md
@@ -42,6 +42,58 @@ with any coding agent, on any surface** — a provider-neutral content core
 (policy, skills, hooks) plus thin per-provider adapters — with a small,
 explicitly machine-local residue still delivered by chezmoi/dotfiles.
 
+## 2a. Why cloud-first at all (addendum, 2026-08-18)
+
+This review treats "most work now happens in cloud sandboxes" as an
+observed fact and never says why. The premise is load-bearing — every
+delivery decision since follows from it — so the reasons are recorded
+here rather than left implicit.
+
+- **Resilience to a dropped connection.** A cloud session is not running
+  on the laptop, so losing wifi or cellular does not lose the work. It
+  keeps going while disconnected and is still there on reconnect. This
+  matters most on trains and tethered connections, and most of all during
+  a long setup script: a 10–15 minute environment build that a local
+  session would abandon at the first drop simply continues.
+
+  This is not an edge case here. Regular travel is roughly **three hours
+  most weeks** — 40 minutes each way to Manchester, two or three times a
+  week — plus a **four-hour round trip every three to four weeks**. That
+  is a standing fraction of working time spent on connections that drop
+  by design, in tunnels and between masts. A surface that loses a session
+  when the signal goes cannot be used for that time at all; a cloud
+  session merely stops being watched.
+
+  It is the reason easiest to overlook when comparing the two at a desk
+  with good wifi, and the one that decides it in practice.
+- **Blast radius.** The session runs in an isolated, single-tenant,
+  disposable VM. A destructive mistake costs a container, not a
+  workstation, and credentials are handled by a proxy rather than sitting
+  in the sandbox.
+- **A different, and lower, permissions risk model.** §4.5 demotes the
+  granular allowlist honestly: it is bypassed in cloud sessions, and the
+  reason that is acceptable is that the thing it protects — a durable
+  machine with the user's own files and keys — is not what the agent is
+  running on.
+- **Parallelism, and not tying up the machine.** Several sessions run at
+  once, none of them competing for the laptop's CPU, network, or
+  attention.
+- **Monitorable from anywhere.** A session can be checked and steered
+  from a phone, which only makes sense because it is not tied to a
+  terminal.
+
+The costs are real and tracked, not hidden: sandboxes have no user-level
+config (#245), miss tools the work needs (#240), and sit behind an egress
+policy that blocks documentation and registries (#241). The first two of
+those are what this repo exists to close.
+
+**Where this is recorded, and why not in `home/`.** This is rationale, not
+policy — it explains a choice rather than instructing an agent. Under
+ADR-0018 principle 2 it therefore belongs in repo-meta documentation,
+which never deploys and costs no context, rather than in
+`home/ephemeral-first.md` where it would load on every turn of every
+session forever without changing what any agent does.
+
 ## 3. What changed since January (evidence)
 
 Full research is in #136 and its comments; the load-bearing facts:


### PR DESCRIPTION
Two documents, no code. Records the framework decision behind #249 and the premise that framework rests on.

## ADR-0018 — composing agent context per surface

The decision behind the delivery work in #238 / #239 / #245: **when a statement holds on some surfaces and not others, the difference is resolved at delivery time, not by the agent at runtime.**

Seven principles — determinism over conditionals; tier every statement by what it costs to load; one mechanism (skills, retiring `home/commands/`); fragments are source and delivered artefacts are derived and committed; profiles compose from provider × environment axes; no delivery assumptions in portable text; and every profile built and verified in CI.

Three things it is deliberately honest about:

**Status is Proposed, not Accepted.** ADR-0016 earned "Accepted" because it had been run on two vendors. This has not been built, so claiming validation would be false.

**It reverses part of #139.** The surface-aware rework of the session commands — `command -v chezmoi`, the `chezmoi-unavailable` sentinel, the silent-skip states — is the runtime-detection pattern principle 1 replaces. That work was correct under the constraint that one text had to serve every surface; removing the constraint makes it unnecessary, not wrong. Recorded as a reversal so it is not re-derived in six months.

**Principle 7 checks composition, not truth.** CI can prove a profile was built correctly and cannot prove its contents are still accurate. The ADR says so, and #250 exists to make that residual human review cheaper.

The measured problem it responds to:

```text
home/commands/start-session.md     8 surface conditionals
home/commands/end-session.md      11
home/commands/retrospective.md    16
```

Alternatives considered records why imports-only was rejected (Claude-only; an `AGENTS.md` containing `@agents-core.md` reaches Codex as literal text and fails silently), why assembling in each installer was rejected (two implementations, two delivery routes, no shared test), and why symlinking `AGENTS.md` to `CLAUDE.md` only works while the two are byte-identical — which stops the moment `CLAUDE.md` carries the MCP mapping table.

Written so the unresolved AGENTS.md import question does not matter: composition emits complete files, so no consumer needs import support. That question is unverified because `agents.md` is blocked by the sandbox egress policy (#241), which is the issue biting on the check that would have answered it.

## Strategic review §2a — why cloud-first at all

The review asserts *"most work now happens in cloud sandboxes"* in §1 and never says why. That premise is load-bearing — ADR-0016, ADR-0018 and all of #249 follow from it — so the reasons are now recorded rather than left implicit.

The one that decides it in practice is also the one missing from the usual list: **a cloud session survives a dropped connection, because it is not running on the laptop.** Regular travel is around three hours most weeks plus a four-hour round trip monthly, on connections that drop by design. A surface that loses a session when the signal goes cannot be used for that time at all — and a 10–15 minute setup script is exactly what a drop destroys, so the surface that needs long builds is the one that cannot tolerate them locally.

Also recorded: blast radius, the lower permissions risk model that §4.5's demotion of the allowlist already depends on, parallelism, and phone monitoring. And the costs, since a rationale section listing only upsides would be dishonest — no user config (#245), missing tools (#240), egress blocks (#241).

**Filed in `docs/` rather than `home/`, and the addendum says why.** This is rationale, not policy: it explains a choice rather than instructing an agent. Under ADR-0018 principle 2 it belongs in repo-meta that never deploys, instead of always-loaded context that would cost tokens on every turn without changing any behaviour. First application of the tiering principle, and it pushed content *out* of the deployed set.

## Verification

Full gate suite, all green:

| Gate | Result |
| --- | --- |
| `markdownlint-cli2 "**/*.md"` | 60 files, 0 issues |
| `tests/gcp-credentials-test.sh` | 71 passed, 0 failed |
| `tests/precommit-hook-test.sh` | 18 passed, 0 failed |
| `tests/retired-paths.sh` + validator | passed; 12 passed, 0 failed |
| `tests/skills-match-commands.py` | 17/17 match |
| `tests/plugin-manifests.py` | valid |
| `tests/allowlist-covers-commands.py` | 5 invocations covered, 5 exempt |

One note on ShellCheck: locally it reports SC2015 (info) on `home/bin/gcp-credentials:606`. That file is untouched here, the same job passed on #248, and the flagged construct — `[ -n "$a" ] && [ -n "$b" ] || die` — has "C may run when A is true" as its intent. Pre-existing and benign; called out so it is not mistaken for something this branch introduced.

## Scope

Documentation only, 327 insertions across two files, no behaviour change. Refs #249, which links ADR-0018 at a `main` path that resolves once this lands.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFVRa7P4DCJmWJtbXwpLAi)_