### PR TITLE
Deliver the composed agent policy to cloud sandboxes

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -4,8 +4,8 @@ Everything a vendor's cloud sandbox needs to gain this repo's capabilities,
 without the repo you are working on carrying any of it.
 
 `bootstrap.sh` is the whole mechanism: an environment's setup script fetches it
-by ref and runs it, and it installs the credential helper and a named set of
-skills into the container. See
+by ref and runs it, and it installs the credential helper, a named set of
+skills, and the composed agent policy into the container. See
 [ADR-0016](../adrs/0016-capability-delivery-principles.md) for why the substance
 lives here rather than in the setup script itself.
 
@@ -134,10 +134,38 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `/usr/local/bin/gcloud` | wrapper: prefers the broker token, renews it when stale |
 | `~/.agents/skills/<name>/SKILL.md` | each whitelisted skill, canonical |
 | `~/.claude/skills/<name>` | symlink to the above, for Claude Code |
+| `~/.agents/AGENTS.md` | the composed policy profile |
+| `~/.claude/CLAUDE.md` | the Claude adapter profile (Claude profiles only) |
 
 Whitelisted today: `retrospective`. The 15 `setup-*` skills are held back
 pending a currency review — they are repo-scaffolding procedures a sandbox
 session rarely needs, and they predate this surface.
+
+## Which profile
+
+`--profile <name>` selects the composed context profile, defaulting to
+`claude-cloud-sandbox`. A Codex environment passes `--profile
+codex-cloud-sandbox`:
+
+```sh
+curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh \
+  | sh -s -- <REF> --profile codex-cloud-sandbox
+```
+
+The environment declares which harness it is rather than the script sniffing
+for one. Per ADR-0018 principle 1 surface differences are resolved at delivery,
+and the caller is the only party that knows the answer without guessing.
+
+Profiles are built and verified in CI by `tests/compose-context.py`, which also
+refuses to compose a sandbox profile that includes a workstation fragment. That
+is what stops "run `chezmoi apply`" reaching a container with no chezmoi, so
+this script does not have to check.
+
+Claude profiles ship two files, because Claude Code reads `CLAUDE.md` and not
+`AGENTS.md`. Codex profiles ship `AGENTS.md` only, and it lands in
+`~/.agents/`. **Where Codex actually reads user-level `AGENTS.md` is not yet
+established (#176)** — `~/.agents/` is the vendor-neutral location its skills
+are already read from, not a verified instruction path.
 
 ## Updating a running session
 

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -5,10 +5,16 @@
 # everything of substance stays here, versioned, instead of being pasted into a
 # vendor configuration field (ADR-0016, principle 5):
 #
-#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud]
+#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud] [--profile <name>]
 #
 # --with-gcloud installs the Google Cloud SDK as well. Opt-in, so that the one
 # line an environment carries declares what kind of environment it is.
+#
+# --profile names the composed context profile to install, defaulting to
+# claude-cloud-sandbox. A Codex environment passes --profile codex-cloud-sandbox.
+# The environment declares which harness it is rather than this script sniffing
+# for one: ADR-0018 principle 1 puts surface differences in the delivery, and
+# the caller is the only party that knows the answer without guessing.
 #
 # Pass the same <REF> twice on purpose: the first fetches this script, the
 # second is what it fetches everything else from, so a run cannot straddle two
@@ -24,13 +30,29 @@
 
 set -eu
 
-REF="${1:-main}"
-WITH_GCLOUD=0
-[ "${2:-}" = "--with-gcloud" ] && WITH_GCLOUD=1
-RAW="https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/${REF}"
-
 log() { echo "[bootstrap] $*"; }
 die() { echo "[bootstrap] error: $*" >&2; exit 1; }
+
+REF="${1:-main}"
+[ $# -gt 0 ] && shift
+WITH_GCLOUD=0
+PROFILE=claude-cloud-sandbox
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --with-gcloud) WITH_GCLOUD=1 ;;
+        --profile)
+            shift
+            [ $# -gt 0 ] || die "--profile needs a value"
+            PROFILE="$1"
+            ;;
+        --profile=*) PROFILE="${1#--profile=}" ;;
+        *) die "unknown argument: $1" ;;
+    esac
+    shift
+done
+
+RAW="https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/${REF}"
 
 command -v curl > /dev/null 2>&1 || die "curl is required"
 
@@ -242,6 +264,66 @@ log "adapter -> $HOME/.claude/skills/gcp-credentials"
 # skill that already works from the neutral path. Remove it rather than leave
 # two sources for one command.
 rm -f "$HOME/.claude/commands/gcp-credentials.md"
+
+# --- the agent policy ---------------------------------------------------------
+#
+# Until now a sandbox got no policy at all: `ls ~/.claude/*.md` was empty, and
+# the 200-odd lines of working policy reached workstations through chezmoi and
+# nowhere else. Every session on this surface ran on whatever the opened repo
+# happened to commit (#245).
+#
+# What lands here is a COMPOSED PROFILE, not the raw fragments. ADR-0018
+# resolves surface differences at delivery: the sandbox profile is built from
+# the portable core, the sandbox environment fragment, and the provider
+# fragment, and it deliberately excludes the workstation fragment. That is what
+# stops "run chezmoi apply" reaching a container with no chezmoi -- confidently
+# wrong policy, which is worse than none. CI fails the build if a workstation
+# fragment ever reaches a sandbox profile, so this fetch does not have to
+# check.
+#
+# The file is complete, with no @imports to resolve. That matters for Codex,
+# which rejects @file templating: an import here would arrive as literal text
+# and the content it named would be lost silently.
+
+PROFILE_DIR="$HOME/.agents"
+mkdir -p "$PROFILE_DIR"
+
+curl -sSfL "$RAW/profiles/$PROFILE/AGENTS.md" -o "$TMP/AGENTS.md" ||
+    die "could not fetch profile '$PROFILE' from $REF — check the name against profiles/ in the repo"
+
+# Same 404-as-content guard as everything else here: a bad ref or a mistyped
+# profile can return an HTML error page with a 200 from some proxies, and
+# policy whose first line is <!DOCTYPE reads as a broken agent rather than a
+# broken fetch.
+head -1 "$TMP/AGENTS.md" | grep -q "^<!-- GENERATED" ||
+    die "fetched profile is not a composed artefact — check that $REF and profile '$PROFILE' exist"
+
+cp "$TMP/AGENTS.md" "$PROFILE_DIR/AGENTS.md"
+log "policy  -> $PROFILE_DIR/AGENTS.md (profile: $PROFILE)"
+
+# Claude Code reads CLAUDE.md and does not read AGENTS.md, so the Claude
+# profiles ship a second composed file for it. A container-created
+# ~/.claude/CLAUDE.md is read: verified 2026-08-18 by planting a marker
+# mid-session and finding it in context on resume, announced as the user's
+# global instructions. The cloud docs list user-scope CLAUDE.md as
+# unavailable, but that is about your laptop's copy not being transferred,
+# which is a different claim -- the same distinction ADR-0016 already
+# established for ~/.claude/skills.
+#
+# Codex profiles ship AGENTS.md only. Where Codex reads user-level AGENTS.md is
+# still unestablished (#176), so ~/.agents/ is where it goes and nothing here
+# claims that path is the one Codex reads.
+case "$PROFILE" in
+    claude-*)
+        curl -sSfL "$RAW/profiles/$PROFILE/CLAUDE.md" -o "$TMP/CLAUDE.md" ||
+            die "could not fetch the Claude adapter for profile '$PROFILE' from $REF"
+        head -1 "$TMP/CLAUDE.md" | grep -q "^<!-- GENERATED" ||
+            die "fetched Claude adapter is not a composed artefact"
+        mkdir -p "$HOME/.claude"
+        cp "$TMP/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+        log "adapter -> $HOME/.claude/CLAUDE.md"
+        ;;
+esac
 
 # --- the workflow skills ------------------------------------------------------
 #


### PR DESCRIPTION
Phase 2 of #249. Closes the gap #245 measured, and gives #238's fix somewhere to land.

## The gap

```console
$ ls ~/.claude/*.md
ls: cannot access '/root/.claude/*.md': No such file or directory
```

200-odd lines of working policy reached workstations through chezmoi and nowhere else. Every session on what is now the primary surface ran on whatever the opened repo happened to commit.

## What changed

`bootstrap.sh` fetches a **composed profile** — not the raw fragments — into `~/.agents/AGENTS.md`, plus `~/.claude/CLAUDE.md` for Claude profiles, since Claude Code reads `CLAUDE.md` and not `AGENTS.md`.

Adds `--profile`, defaulting to `claude-cloud-sandbox`:

```sh
curl -sSL .../cloud/bootstrap.sh | sh -s -- <REF> --profile codex-cloud-sandbox
```

**The environment declares which harness it is rather than the script sniffing for one.** ADR-0018 principle 1 puts surface differences in delivery, and the caller is the only party that knows the answer without guessing. Argument parsing becomes a proper loop; `log`/`die` move above it, since the loop calls `die`.

## What this deliberately does not do

**It does not check that the sandbox profile excludes workstation content.** CI already refuses to compose one that does not, so the installer just installs. That is the division principle 7 asks for — the build proves the property, the delivery trusts it.

The composed file is also complete, with no `@imports` to resolve. That is what makes it safe for Codex, whose rejection of `@file` templating is the reason composition emits whole files at all.

## #238 lands with this

`env-cloud-sandbox.md` already carries the line about requesting brokered GCP access when `CREDENTIAL_BROKER_URL` is set — including the trigger that session actually missed:

> the trigger is not "I need to change something in GCP" but **"I am about to assert something about live GCP state"**

It had nowhere to be delivered until now.

## Verification

End to end against a local server, all three paths:

```console
=== default (claude) profile ===
[bootstrap] policy  -> /root/.agents/AGENTS.md (profile: claude-cloud-sandbox)
[bootstrap] adapter -> /root/.claude/CLAUDE.md

=== codex profile ===
[bootstrap] policy  -> /root/.agents/AGENTS.md (profile: codex-cloud-sandbox)
      (no CLAUDE.md — correct, Codex profiles ship AGENTS.md only)

=== bad profile ===
[bootstrap] error: could not fetch profile 'nope' from main —
            check the name against profiles/ in the repo
```

**The sandbox running this session now has the composed profile at `~/.claude/CLAUDE.md`**, replacing the canary planted to prove that path was read at all.

| Gate | Result |
| --- | --- |
| `markdownlint-cli2 "**/*.md"` | 68 files, 0 issues |
| `tests/compose-context.py` | all outputs match |
| `shellcheck cloud/bootstrap.sh` | clean |
| `tests/gcp-credentials-test.sh` | 71 passed |
| `tests/precommit-hook-test.sh` | 18 passed |
| `tests/retired-paths.sh` + validator | passed; 12 passed |
| `tests/skills-match-commands.py` | 17/17 |
| `tests/plugin-manifests.py` | valid |
| `tests/allowlist-covers-commands.py` | 5 covered, 5 exempt |

## Known limits

- **Where Codex reads user-level `AGENTS.md` is still unestablished (#176).** `~/.agents/` is where its *skills* are read from, which is not the same claim. The README says so rather than implying the path is verified.
- **Existing environments will not pick this up until their setup script re-runs** — bump the `Rev:` comment, or re-run the bootstrap in a live session, which takes effect immediately.
- **Pre-commit hooks still do not reach sandboxes.** Filed as #254: the scripts could ship trivially, but whether a container-created `~/.claude/settings.json` registers hooks is unverified, and that doc passage enumerates what *does* run rather than explaining an absence — a materially different claim from the two we have now disproved.

Closes #245
Closes #238
Refs #249

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFVRa7P4DCJmWJtbXwpLAi)_