### PR TITLE
Install pre-commit and its linters in cloud sandboxes

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -136,10 +136,54 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `~/.claude/skills/<name>` | symlink to the above, for Claude Code |
 | `~/.agents/AGENTS.md` | the composed policy profile |
 | `~/.claude/CLAUDE.md` | the Claude adapter profile (Claude profiles only) |
+| `~/.config/git/hooks/pre-commit` | global git hook, with `--with-precommit` |
+| `/usr/local/bin/pre-commit`, `/usr/bin/shellcheck`, `/usr/local/bin/actionlint` | with `--with-precommit` |
 
 Whitelisted today: `retrospective`. The 15 `setup-*` skills are held back
 pending a currency review — they are repo-scaffolding procedures a sandbox
 session rarely needs, and they predate this surface.
+
+## Pre-commit enforcement
+
+Sandboxes bypassed the pre-commit framework entirely until `--with-precommit`:
+the binary was absent and no `.git/hooks/pre-commit` existed, so a repo's
+committed `.pre-commit-config.yaml` did nothing here (#254).
+
+```sh
+  | sh -s -- <REF> --with-precommit
+```
+
+It installs `pre-commit`, plus `shellcheck` and `actionlint`, which this
+estate's config runs as `language: system` hooks — they use the binary on
+`PATH` so the hook and CI cannot drift to different versions, which only works
+if the binaries are present. Installing them is the point; the config's `SKIP=`
+escape is for a laptop missing one, and normalising it would leave enforcement
+that is routinely skipped.
+
+Opt-in for two reasons: it is the only part of this script needing the Ubuntu
+archives, so an environment that cannot reach them keeps working by not asking;
+and the one line an environment carries should declare what kind of environment
+it is.
+
+**The hook is global, via `core.hooksPath`, not `pre-commit install` per repo.**
+This script runs from an environment setup script whose ordering against the
+session's clone it cannot rely on — the repository may not exist yet, and may
+not be the only one. A global hook is set once and applies however and whenever
+a repo arrives. The trade-off is real and worth knowing: `core.hooksPath`
+*replaces* a repo's own `.git/hooks` rather than adding to it, and
+`pre-commit install` will warn that it is being overridden. In this estate
+hooks come from pre-commit anyway.
+
+The hook exits 0 in a repo with no `.pre-commit-config.yaml`. Such a repo is
+not opting out of anything — it has no configuration to run, and blocking its
+commits would be the container inventing policy the repo never asked for.
+
+This is the vendor-neutral half of enforcement: git runs `.git/hooks` itself,
+so it needs no agent configuration and covers Claude, Codex and a human typing
+`git commit` identically. The harness-hook half — `home/hooks/hooks.json`,
+which feeds failures back into the agent's context — is tracked separately
+in #254, and is blocked on whether a container-created
+`~/.claude/settings.json` registers hooks at all.
 
 ## Which profile
 

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -5,10 +5,16 @@
 # everything of substance stays here, versioned, instead of being pasted into a
 # vendor configuration field (ADR-0016, principle 5):
 #
-#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud] [--profile <name>]
+#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud] [--with-precommit] [--profile <name>]
 #
 # --with-gcloud installs the Google Cloud SDK as well. Opt-in, so that the one
 # line an environment carries declares what kind of environment it is.
+#
+# --with-precommit installs the pre-commit framework and the binaries this
+# estate's hooks need, and points git at a global hook so every repo in the
+# container is covered. Opt-in for the same reason, and one more: it is the only
+# part of this script that needs the Ubuntu archives, so an environment that
+# cannot reach them keeps working by not asking for it.
 #
 # --profile names the composed context profile to install, defaulting to
 # claude-cloud-sandbox. A Codex environment passes --profile codex-cloud-sandbox.
@@ -36,11 +42,13 @@ die() { echo "[bootstrap] error: $*" >&2; exit 1; }
 REF="${1:-main}"
 [ $# -gt 0 ] && shift
 WITH_GCLOUD=0
+WITH_PRECOMMIT=0
 PROFILE=claude-cloud-sandbox
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --with-gcloud) WITH_GCLOUD=1 ;;
+        --with-precommit) WITH_PRECOMMIT=1 ;;
         --profile)
             shift
             [ $# -gt 0 ] || die "--profile needs a value"
@@ -75,6 +83,12 @@ log "installing from ${REF}"
 # archives reachable, and bakes an assumption into a snapshot where nobody will
 # revisit it. A task that genuinely needs a package can install it, having
 # established that it is missing.
+#
+# --with-precommit does apt-get, which is not a reversal of that. The objection
+# above is to installing on a *guess*; a hook declared in a repo's committed
+# .pre-commit-config.yaml that cannot run without shellcheck is a demonstrated
+# dependency. It stays behind a flag so the archive requirement is opted into
+# rather than imposed on every environment.
 
 # --- gcloud, on request -------------------------------------------------------
 #
@@ -264,6 +278,94 @@ log "adapter -> $HOME/.claude/skills/gcp-credentials"
 # skill that already works from the neutral path. Remove it rather than leave
 # two sources for one command.
 rm -f "$HOME/.claude/commands/gcp-credentials.md"
+
+# --- pre-commit, on request ---------------------------------------------------
+#
+# Sandboxes bypassed the pre-commit framework entirely: the binary was absent
+# and no `.git/hooks/pre-commit` existed, so a repo's committed
+# .pre-commit-config.yaml did nothing here (#254). Four consecutive PRs on
+# 2026-08-18 were committed with markdownlint, shellcheck and actionlint
+# unenforced -- they passed only because a human-equivalent ran them by hand.
+#
+# This is the vendor-neutral half of enforcement, and the reason it is worth
+# doing before the harness-hook half: git runs .git/hooks itself, so nothing
+# here depends on agent configuration, on which harness is running, or on the
+# unsettled question of whether a container-created ~/.claude/settings.json is
+# honoured. It covers Codex, Claude, and a human typing `git commit`, all the
+# same way.
+
+if [ "$WITH_PRECOMMIT" -eq 1 ]; then
+    # Both linters are `language: system` hooks in this estate's config -- they
+    # run the binary on PATH rather than a pinned mirror, so the hook and CI
+    # cannot drift to different versions.
+    #
+    # (Written as "both linters" rather than naming the first one at the start
+    # of a comment line: `# shellcheck ...` is parsed as a shellcheck directive
+    # and fails the lint, which this script is itself subject to.) That only works if the
+    # binaries are here. Installing them is the whole point; SKIP= exists for a
+    # laptop missing one, and normalising it would leave enforcement that is
+    # routinely skipped, which is not enforcement.
+    if ! command -v shellcheck > /dev/null 2>&1; then
+        if ! apt-get update -qq > /dev/null 2>&1; then
+            die "apt-get update failed — are the Ubuntu archives reachable?"
+        fi
+        if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq shellcheck > /dev/null 2>&1; then
+            die "could not install shellcheck"
+        fi
+    fi
+    log "shellck -> $(command -v shellcheck)"
+
+    # actionlint is not packaged in Ubuntu, so it comes from a pinned release.
+    # Note github.com answers 403 to this sandbox's curl while the release asset
+    # itself resolves fine through the redirect -- a naive reachability probe
+    # against github.com reads as an egress block and is not one.
+    if ! command -v actionlint > /dev/null 2>&1; then
+        AL_VER=1.7.7
+        curl -sSfL -o "$TMP/actionlint.tar.gz" \
+            "https://github.com/rhysd/actionlint/releases/download/v${AL_VER}/actionlint_${AL_VER}_linux_amd64.tar.gz" ||
+            die "could not download actionlint ${AL_VER}"
+        tar -xzf "$TMP/actionlint.tar.gz" -C "$TMP" actionlint || die "could not unpack actionlint"
+        install -m 0755 "$TMP/actionlint" /usr/local/bin/actionlint || die "could not install actionlint"
+    fi
+    log "actionl -> $(command -v actionlint)"
+
+    command -v pre-commit > /dev/null 2>&1 ||
+        pip install --quiet --no-input pre-commit > /dev/null 2>&1 ||
+        die "could not install pre-commit from PyPI"
+    log "precmit -> $(command -v pre-commit) ($(pre-commit --version))"
+
+    # A GLOBAL hook via core.hooksPath, not `pre-commit install` per repo.
+    #
+    # `pre-commit install` writes into an existing clone's .git/hooks, and this
+    # script runs from an environment setup script whose ordering against the
+    # session's clone is not something it can rely on -- the repository may not
+    # exist yet, and may not be the only one. core.hooksPath is set once and
+    # applies to every repo in the container however and whenever it arrives.
+    #
+    # The trade-off, stated because it is real: core.hooksPath REPLACES a repo's
+    # own .git/hooks rather than adding to it, and `pre-commit install` will warn
+    # that it is being overridden. In this estate hooks come from pre-commit
+    # anyway, so nothing is lost; a container that needed bespoke per-repo hooks
+    # would want the other mechanism.
+    HOOK_DIR="$HOME/.config/git/hooks"
+    mkdir -p "$HOOK_DIR"
+    cat > "$HOOK_DIR/pre-commit" << 'HOOK'
+#!/bin/sh
+# Installed by agentic-coding-config cloud/bootstrap.sh.
+#
+# Global pre-commit hook: runs the repo's own pre-commit configuration when it
+# has one, and gets out of the way when it does not. A repo with no
+# .pre-commit-config.yaml is not opting out of anything -- it simply has no
+# configuration to run, and blocking its commits would be this container
+# inventing policy the repo never asked for.
+[ -f .pre-commit-config.yaml ] || exit 0
+command -v pre-commit > /dev/null 2>&1 || exit 0
+exec pre-commit run --hook-stage pre-commit
+HOOK
+    chmod 0755 "$HOOK_DIR/pre-commit"
+    git config --global core.hooksPath "$HOOK_DIR"
+    log "githook -> $HOOK_DIR/pre-commit (core.hooksPath, all repos)"
+fi
 
 # --- the agent policy ---------------------------------------------------------
 #

--- a/home/bin/gcp-credentials
+++ b/home/bin/gcp-credentials
@@ -603,7 +603,12 @@ cmd_request() {
     req_id=$(jq -r '.request_id // ""' < "$req_resp")
     phrase=$(jq -r '.phrase // ""' < "$req_resp")
     req_expires=$(jq -r '.expires_at // ""' < "$req_resp")
-    [ -n "$req_id" ] && [ -n "$phrase" ] || die 1 "broker returned an incomplete request response"
+    # Spelled as an explicit `if` rather than `A && B || C`: the latter reads as
+    # if-then-else and is not one, and shellcheck flags it (SC2015). The intent
+    # is "die unless both are present", which this says without ambiguity.
+    if [ -z "$req_id" ] || [ -z "$phrase" ]; then
+        die 1 "broker returned an incomplete request response"
+    fi
 
     # The phrase is the entire session-binding mechanism: the human approves only
     # if the card matches what is on screen here. It gets its own block, at the


### PR DESCRIPTION
One commit against `main`. It was written stacked on #255, which merged while this was being finished, so the dependency is now simply history.

## The gap

```console
$ command -v pre-commit
(absent)
$ ls .git/hooks/pre-commit
(no such file)
```

`.pre-commit-config.yaml` is committed and configures `markdownlint-cli2`, `shellcheck` and `actionlint`. **None of them ran.** Four PRs on 2026-08-18 — #248, #251, #253, #255 — were committed with all three unenforced. They passed only because the gates were run by hand each time. A control that exists on paper and not in the container.

## Why this half first

`pre-commit install` writes `.git/hooks/pre-commit` and **git runs it natively**. Nothing depends on agent configuration, on which harness is running, or on the unsettled question of whether a container-created `~/.claude/settings.json` is honoured. Claude, Codex, and a human typing `git commit` are covered identically.

The harness-hook half — `home/hooks/hooks.json`, which feeds failures back into the agent's *context* — stays in #254 and is genuinely blocked on that question.

## Linters installed, not skipped

`shellcheck` and `actionlint` are `language: system` hooks here — they run the binary on `PATH` rather than a pinned mirror, so the hook and CI cannot drift to different versions. That only works if the binaries exist. The config's `SKIP=` escape is for a laptop missing one; normalising it in sandboxes would leave enforcement that is routinely skipped, which is not enforcement.

## Two design points worth review

**Global hook via `core.hooksPath`, not `pre-commit install` per repo.** This runs from a setup script whose ordering against the session's clone it cannot rely on — the repository may not exist yet, and may not be the only one. The trade-off is documented rather than glossed: `core.hooksPath` *replaces* a repo's own `.git/hooks` instead of adding to it, and `pre-commit install` warns it is being overridden. In this estate hooks come from pre-commit anyway.

The hook exits 0 where there is no `.pre-commit-config.yaml`. Such a repo is not opting out of anything — it has no configuration to run, and blocking it would be the container inventing policy the repo never asked for.

**Opt-in, mirroring `--with-gcloud`.** It is the only part of the script needing the Ubuntu archives, so an environment that cannot reach them keeps working by not asking. The "deliberately no apt step" paragraph is **amended rather than left contradicted**: it objects to installing on a *guess*, and a declared hook that cannot run without `shellcheck` is a demonstrated dependency.

## A real defect the hooks caught immediately

`shellcheck` flags SC2015 on `home/bin/gcp-credentials:606` — and **CI had been passing it**. The pre-commit hook runs bare `shellcheck`, which exits non-zero on info; `ludeeus/action-shellcheck` tolerates it. Same binary, different invocation — exactly the drift that config comment claims to prevent.

Rewritten as an explicit `if`; the intent ("die unless both are present") is now unambiguous. The 71-test helper suite still passes.

I had dismissed this finding as "pre-existing, CI is happy" in three previous PRs. It was a real divergence between the local gate and CI, and only turning the hook on surfaced it.

## Verification, on a torn-down container

Testing against the container I had hand-primed would have proved nothing — the "works only because of what you typed into it" failure `ephemeral-first.md` warns about. So: uninstalled `pre-commit`, `shellcheck` and `actionlint`, unset `core.hooksPath`, cleared the cache, then ran the bootstrap.

```text
[bootstrap] shellck -> /usr/bin/shellcheck
[bootstrap] actionl -> /usr/local/bin/actionlint
[bootstrap] precmit -> /usr/local/bin/pre-commit (pre-commit 4.6.2)
[bootstrap] githook -> /root/.config/git/hooks/pre-commit (core.hooksPath, all repos)
```

Both directions then checked:

| Case | `git commit` exit | Commit created? |
| --- | --- | --- |
| MD012 violation | 1 | no |
| clean file | 0 | yes |

**This PR's own commit was made through that hook** — `markdownlint-cli2 Passed`, `shellcheck Passed`.

Full gate suite green: 68 markdown files, 71 + 18 shell-test assertions, composition, manifests, allowlist, retired-paths.

## Note for whoever probes this next

`github.com` answers **403** to the sandbox's `curl`, while the release asset resolves fine through the redirect to `objects.githubusercontent.com`. A naive reachability check against `github.com` reads as an egress block and is not one. `git ls-remote` against github.com works, so pre-commit can clone its hook repos.

Refs #254

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFVRa7P4DCJmWJtbXwpLAi)_