### PR TITLE
Record what the bootstrap installed, and check it in start-session

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -137,6 +137,7 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `~/.agents/AGENTS.md` | the composed policy profile |
 | `~/.claude/CLAUDE.md` | the Claude adapter profile (Claude profiles only) |
 | `~/.claude/bin/<script>` | the four session helper scripts |
+| `~/.agents/.bootstrap-manifest` | what this run installed: ref, SHA, profile, skills, helpers |
 | `~/.config/git/hooks/pre-commit` | global git hook, with `--with-precommit` |
 | `/usr/local/bin/pre-commit`, `/usr/bin/shellcheck`, `/usr/local/bin/actionlint` | with `--with-precommit` |
 
@@ -198,6 +199,32 @@ so it needs no agent configuration and covers Claude, Codex and a human typing
 which feeds failures back into the agent's context — is tracked separately
 in #254, and is blocked on whether a container-created
 `~/.claude/settings.json` registers hooks at all.
+
+## Knowing whether a container is stale
+
+The environment re-runs its setup script only when the script text changes, the
+allowed hosts change, or roughly seven days pass — so a push does not reach new
+sessions and a sandbox can be running week-old content with nothing saying so.
+The credential helper solved its half server-side, by sending a version the
+broker can refuse (#182); skills, policy and helper scripts have no server on
+the other end.
+
+So the bootstrap writes `~/.agents/.bootstrap-manifest` recording the ref, the
+resolved SHA, the timestamp, the profile, and what it installed. `start-session`
+reads it in its `bootstrap_currency` section and reports `current`, `behind`,
+`pinned`, `no-manifest` or `unknown`. On `behind` it gives the remedy, which is
+re-running the bootstrap — immediate, no restart.
+
+`git ls-remote` resolves the ref rather than the GitHub API: no token, no JSON
+parsing, and git is already required to be here.
+
+**What this guarantees, precisely.** Not that every session starts fresh. The
+check ships inside the thing it checks, so a container older than the check
+cannot report it — that self-heals after one cache cycle rather than
+immediately. And it runs only when `start-session` runs. It is advisory. The
+automatic version would be a `SessionStart` hook, which is blocked on whether
+hooks in a container-created `~/.claude/settings.json` are honoured at all
+(#254).
 
 ## Which profile
 

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -506,6 +506,51 @@ for skill in $SKILLS; do
     rm -f "$HOME/.claude/commands/$skill.md"
 done
 
+# --- the manifest -------------------------------------------------------------
+#
+# Records what this run installed, so a later session can tell how old its
+# container is. Nothing else knows: a cloud environment re-runs its setup script
+# only when the script text changes, the allowed hosts change, or roughly seven
+# days pass, so pushing to a branch does not reach new sessions -- they keep
+# restoring the snapshot built the first time (#246).
+#
+# The credential helper solved its half server-side, by sending a version the
+# broker can refuse (#182). Skills, policy and helper scripts have no server on
+# the other end, so the skew is silent unless something writes down what it did.
+#
+# `git ls-remote` rather than the GitHub API: no token, no JSON parsing, and git
+# is already required to be here. A REF that is already a commit SHA will not
+# match a ref name, which is not a failure -- it is a pin, and pinned is the
+# recommended state. Recorded as `pin` so a reader can tell "pinned" from
+# "could not resolve".
+
+MANIFEST="$HOME/.agents/.bootstrap-manifest"
+mkdir -p "$HOME/.agents"
+
+resolved=$(git ls-remote "https://github.com/pmgledhill102/agentic-coding-config" "$REF" 2>/dev/null |
+    awk 'NR==1 {print $1}')
+if [ -z "$resolved" ]; then
+    case "$REF" in
+        [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*) resolved="$REF" ; kind=pin ;;
+        *) resolved="unresolved" ; kind=unresolved ;;
+    esac
+else
+    kind=ref
+fi
+
+{
+    echo "ref=$REF"
+    echo "ref_kind=$kind"
+    echo "sha=$resolved"
+    echo "installed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "profile=$PROFILE"
+    echo "skills=$SKILLS"
+    echo "helpers=$BIN_SCRIPTS"
+    echo "precommit=$WITH_PRECOMMIT"
+    echo "gcloud=$WITH_GCLOUD"
+} > "$MANIFEST"
+log "manifst -> $MANIFEST ($kind $(echo "$resolved" | cut -c1-12))"
+
 # --- report -------------------------------------------------------------------
 #
 # The pinned ref is logged because a cached cloud environment can serve an older

--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -202,6 +202,61 @@ run_sh gh_assigned '
 # differs), and silent when everything is current. Lives in its own script
 # because the direction-of-drift logic does not belong inline in a `sh -c`.
 run_section claude_drift "$(dirname "$0")/start-session-claude-drift"
+# Container currency. The sibling of claude_drift: that asks "is deployed config
+# behind the repo?" on a workstation, this asks it of a container. A cloud
+# environment restores a filesystem snapshot and re-runs its setup script only
+# when the script text changes or the cache expires, so a sandbox can be running
+# week-old skills, policy and helpers with nothing in the session saying so
+# (#246).
+#
+# Silent when there is nothing to say, like claude_drift. A workstation has no
+# manifest and reports not-a-container, which is not a problem to solve.
+#
+# shellcheck disable=SC2016
+run_sh bootstrap_currency '
+    manifest="$HOME/.agents/.bootstrap-manifest"
+    repo="https://github.com/pmgledhill102/agentic-coding-config"
+
+    if [ ! -f "$manifest" ]; then
+        # Either a workstation, or a container built before manifests existed.
+        # The second cannot be distinguished from here, and self-heals: once the
+        # snapshot expires, the next build writes one.
+        if [ -d "$HOME/.agents/skills" ]; then
+            echo "state=no-manifest"
+        else
+            echo "state=not-a-container"
+        fi
+        exit 0
+    fi
+
+    ref=$(sed -n "s/^ref=//p" "$manifest")
+    kind=$(sed -n "s/^ref_kind=//p" "$manifest")
+    installed=$(sed -n "s/^sha=//p" "$manifest")
+    at=$(sed -n "s/^installed_at=//p" "$manifest")
+
+    # A pinned SHA cannot be behind — it is what the environment asked for.
+    # Saying so is still useful: it tells a reader the container is frozen by
+    # intent rather than by neglect.
+    if [ "$kind" != "ref" ]; then
+        echo "state=pinned ref=$ref sha=$installed installed_at=$at"
+        exit 0
+    fi
+
+    head=$(git ls-remote "$repo" "$ref" 2>/dev/null | head -1 | cut -f1)
+    if [ -z "$head" ]; then
+        echo "state=unknown ref=$ref installed_at=$at"
+        exit 0
+    fi
+
+    if [ "$head" = "$installed" ]; then
+        echo "state=current ref=$ref installed_at=$at"
+        exit 0
+    fi
+
+    echo "state=behind ref=$ref installed=$installed head=$head installed_at=$at"
+    echo "remedy=re-run the bootstrap; it takes effect immediately and needs no restart"
+'
+
 
 export PRE_FETCH_DEFAULT_SHA
 
@@ -255,6 +310,6 @@ if [ "$FETCH_EXIT" -ne 0 ]; then
 fi
 printf '\n'
 
-for s in local_state main_ci recent_main_commits gh_ready gh_assigned claude_drift; do
+for s in local_state main_ci recent_main_commits gh_ready gh_assigned claude_drift bootstrap_currency; do
     [ -f "$TMP/$s.exit" ] && emit "$s"
 done

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -62,6 +62,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `gh_ready` | 7 | Content `not-github` / `gh-unavailable` / `jq-unavailable` = silent skip. Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
 | `gh_assigned` | 7 | Same skip convention as `gh_ready`. Empty content = nothing in flight. Otherwise pipe-separated rows: `#<n>\|P<pri>\|<title>` for open issues assigned to me (usually 0-3). Same row shape as `gh_ready`. |
 | `claude_drift` | 6b, 7 | `state=absent` (sandbox, no `~/.claude`) or `state=no-source` (not in an a-c-c checkout) = silent skip. `state=compared` gives `behind=<n>` and `modified=<n>`, then one `behind: <path>` / `modified: <path>` line each, plus `remedy_behind=` / `remedy_modified=` when non-zero. Both zero = silent. |
+| `bootstrap_currency` | 6b, 7 | `state=not-a-container` (a workstation) or `state=current` = silent skip. `state=no-manifest` = a container built before manifests existed; silent, and it self-heals when the snapshot next expires. `state=pinned` names the ref the environment froze to — report only if something else looks stale. `state=behind` gives `installed=`, `head=` and a `remedy=` line: surface it, because everything the container ships is that old. `state=unknown` = the ref could not be resolved (no network); mention once, do not retry. |
 
 **On `gh` inside the gather script.** The gather runs as a shell script, so its
 GitHub queries use `gh` and cannot use `mcp__github__*` — an MCP tool is not
@@ -125,6 +126,25 @@ From gather section `recent_main_commits`. The first line is `count=<N>` — com
 This is informational only — no action prompts. The section adds a few lines on busy days and zero on quiet ones.
 
 ### 5b. Deployed-config drift (Tier 1 — surface, never act)
+
+### Is this container running current config?
+
+From gather section `bootstrap_currency`. The container equivalent of the
+drift check below: a cloud environment restores a filesystem snapshot and
+re-runs its setup script only when the script text changes, the allowed hosts
+change, or roughly seven days pass — so pushing to a branch does not reach new
+sessions, and a sandbox can be running week-old skills, policy and helper
+scripts with nothing saying so.
+
+On `state=behind`, say so plainly and give the remedy: re-running the bootstrap
+takes effect immediately and needs no restart. Everything the container
+delivers — skills, policy, helpers — is as old as that SHA, so it is worth
+one line at the top of the brief rather than a footnote.
+
+Two honest limits, worth knowing rather than implying more than it does. The
+check ships inside the thing it checks, so a container older than the check
+cannot report it — that resolves itself after one cache cycle, not immediately.
+And this runs only when start-session runs; it is advisory, not a guarantee.
 
 From gather section `claude_drift`. Answers a question nothing else asks: does
 `~/.claude/` on this machine still match what the repo says it should be?

--- a/home/skills/start-session/SKILL.md
+++ b/home/skills/start-session/SKILL.md
@@ -67,6 +67,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `gh_ready` | 7 | Content `not-github` / `gh-unavailable` / `jq-unavailable` = silent skip. Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
 | `gh_assigned` | 7 | Same skip convention as `gh_ready`. Empty content = nothing in flight. Otherwise pipe-separated rows: `#<n>\|P<pri>\|<title>` for open issues assigned to me (usually 0-3). Same row shape as `gh_ready`. |
 | `claude_drift` | 6b, 7 | `state=absent` (sandbox, no `~/.claude`) or `state=no-source` (not in an a-c-c checkout) = silent skip. `state=compared` gives `behind=<n>` and `modified=<n>`, then one `behind: <path>` / `modified: <path>` line each, plus `remedy_behind=` / `remedy_modified=` when non-zero. Both zero = silent. |
+| `bootstrap_currency` | 6b, 7 | `state=not-a-container` (a workstation) or `state=current` = silent skip. `state=no-manifest` = a container built before manifests existed; silent, and it self-heals when the snapshot next expires. `state=pinned` names the ref the environment froze to — report only if something else looks stale. `state=behind` gives `installed=`, `head=` and a `remedy=` line: surface it, because everything the container ships is that old. `state=unknown` = the ref could not be resolved (no network); mention once, do not retry. |
 
 **On `gh` inside the gather script.** The gather runs as a shell script, so its
 GitHub queries use `gh` and cannot use `mcp__github__*` — an MCP tool is not
@@ -130,6 +131,25 @@ From gather section `recent_main_commits`. The first line is `count=<N>` — com
 This is informational only — no action prompts. The section adds a few lines on busy days and zero on quiet ones.
 
 ### 5b. Deployed-config drift (Tier 1 — surface, never act)
+
+### Is this container running current config?
+
+From gather section `bootstrap_currency`. The container equivalent of the
+drift check below: a cloud environment restores a filesystem snapshot and
+re-runs its setup script only when the script text changes, the allowed hosts
+change, or roughly seven days pass — so pushing to a branch does not reach new
+sessions, and a sandbox can be running week-old skills, policy and helper
+scripts with nothing saying so.
+
+On `state=behind`, say so plainly and give the remedy: re-running the bootstrap
+takes effect immediately and needs no restart. Everything the container
+delivers — skills, policy, helpers — is as old as that SHA, so it is worth
+one line at the top of the brief rather than a footnote.
+
+Two honest limits, worth knowing rather than implying more than it does. The
+check ships inside the thing it checks, so a container older than the check
+cannot report it — that resolves itself after one cache cycle, not immediately.
+And this runs only when start-session runs; it is advisory, not a guarantee.
 
 From gather section `claude_drift`. Answers a question nothing else asks: does
 `~/.claude/` on this machine still match what the repo says it should be?


### PR DESCRIPTION
Closes #246. Two halves, landing together because neither works alone.

## The problem

A cloud environment restores a filesystem snapshot and re-runs its setup script only when the script text changes, the allowed hosts change, or roughly seven days pass. **Pushing to a branch does not reach new sessions** — they keep restoring the snapshot built the first time, and nothing in a session said how old its container was.

The credential helper solved its half server-side, by sending a version the broker can refuse (#182). Skills, policy and helper scripts have **no server** on the other end, so the skew was silent by construction.

## 1. The bootstrap writes a manifest

`~/.agents/.bootstrap-manifest`:

```text
ref=main
ref_kind=ref
sha=698d8cc18deadd0dad6377df4e79296e7b8cb962
installed_at=2026-08-18T11:48:35Z
profile=claude-cloud-sandbox
skills=retrospective start-session end-session
helpers=start-session-gather-state start-session-claude-drift end-session-gather-state end-session-squash-merged
precommit=0
gcloud=0
```

Resolved with `git ls-remote` rather than the GitHub API: no token, no JSON parsing, and git is already required to be present. A `REF` that is already a commit SHA will not match a ref name — that is not a failure but a **pin**, and is recorded as `ref_kind=pin` so a reader can tell "frozen by intent" from "could not resolve".

## 2. `start-session` checks it

A `bootstrap_currency` section in `start-session-gather-state`. It is the sibling of `claude_drift`: that asks *"is deployed config behind the repo?"* on a workstation, this asks it of a container. Same `run_sh` pattern, same silent-when-nothing-to-say convention.

All states driven into existence and verified, rather than reasoned about:

| Scenario | Output |
| --- | --- |
| manifest absent, container | `state=no-manifest` |
| manifest absent, workstation | `state=not-a-container` |
| SHA matches head | `state=current ref=main installed_at=…` |
| doctored older SHA | `state=behind ref=main installed=000… head=698d8cc… ` + `remedy=…` |
| `ref_kind=pin` | `state=pinned ref=main sha=… installed_at=…` |
| ref unresolvable | `state=unknown` |

## What it guarantees, precisely

Written into the skill so nobody reads it as stronger than it is:

- **It ships inside the thing it checks.** A container older than this change has a `start-session` without the check and cannot report its own staleness — #182's "too old to know the state exists". Self-heals after one cache cycle, not immediately.
- **It runs only when `start-session` runs.** Advisory, not a guarantee.

The automatic version is a `SessionStart` hook — and see the note below, because that just became viable.

## Related finding, from the probe planted alongside this

A `~/.claude/settings.json` with `SessionStart` and `PreToolUse` hooks was planted in this container to settle the question behind #254 and this issue's automatic trigger. **The `PreToolUse` hook fired, repeatedly, within minutes and without a session restart.**

```text
2026-08-18T11:47:12Z event=manual-smoke-test
2026-08-18T11:47:20Z event=PreToolUse-Bash
2026-08-18T11:47:23Z event=PreToolUse-Bash
…
```

So hooks in a container-created `~/.claude/settings.json` **are honoured**. That is the third documented-as-unavailable user-scope path to turn out to work from inside the container, after `~/.claude/skills/` and `~/.claude/CLAUDE.md`. Recorded in full on #254; it does not change this PR, but it means the advisory check here can gain an automatic sibling.

Gates green: 70 markdown files, 19/19 skills, composition, shellcheck, 71 + 18 shell assertions, manifests, allowlist, retired-paths. Committed through the pre-commit hook from #256.

## Note

`home/commands/start-session.md` and `home/skills/start-session/SKILL.md` both change, as the drift guard requires — the skill was regenerated with the validator's own transforms rather than hand-edited to match.

Closes #246

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFVRa7P4DCJmWJtbXwpLAi)_