### PR TITLE
Wire the harness hooks into cloud sandboxes

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -139,6 +139,8 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `~/.claude/bin/<script>` | the four session helper scripts |
 | `~/.agents/.bootstrap-manifest` | what this run installed: ref, SHA, profile, skills, helpers |
 | `~/.config/git/hooks/pre-commit` | global git hook, with `--with-precommit` |
+| `~/.claude/settings.json` | harness hook wiring, with `--with-hooks` (merged, not replaced) |
+| `~/.claude/bin/*-claude-hook` | the three harness hook scripts, with `--with-hooks` |
 | `/usr/local/bin/pre-commit`, `/usr/bin/shellcheck`, `/usr/local/bin/actionlint` | with `--with-precommit` |
 
 Whitelisted today: `retrospective`, `start-session`, `end-session`. The 15
@@ -199,6 +201,42 @@ so it needs no agent configuration and covers Claude, Codex and a human typing
 which feeds failures back into the agent's context — is tracked separately
 in #254, and is blocked on whether a container-created
 `~/.claude/settings.json` registers hooks at all.
+
+## Harness hooks
+
+`--with-precommit` gives you a native git hook, which blocks a bad commit.
+`--with-hooks` adds the harness layer, which runs inside the agent loop and
+returns the failure into its context — so the agent reads the message and fixes
+the cause rather than simply being stopped. Both are worth having; neither
+replaces the other.
+
+```sh
+  | sh -s -- <REF> --with-precommit --with-hooks
+```
+
+Viable because a container-created `~/.claude/settings.json` **is** honoured —
+measured 2026-08-18 by planting one and watching a `PreToolUse` hook fire eight
+seconds later, with no session restart. That is the third
+documented-as-unavailable user-scope path to work from inside a container, after
+`~/.claude/skills/` and `~/.claude/CLAUDE.md`.
+
+The wiring is taken from `home/settings.json` rather than restated in the
+script. That file is the workstation's, and it already invokes
+`~/.claude/bin/<hook>` directly — the same paths the bootstrap installs to — so
+both surfaces run identical hooks from one source instead of a copy that drifts.
+It is deliberately **not** routed through `plugin-hook-dispatch`: that dispatcher
+exists to stand down when a `~/.claude/bin` copy is present, and here that copy
+is the only one.
+
+**Merged, not overwritten.** A container may already have a `settings.json`, and
+replacing it wholesale would silently drop whatever else it holds. Note
+`~/.claude/launcher-settings.json` is a different file with its own hooks,
+written by the harness; nothing here touches it, and both are read.
+
+Two of the three degrade to no-ops in a sandbox rather than failing:
+`prepush-guard-claude-hook` needs `gh`, which is absent (#257), and
+`precommit-claude-hook` needs the pre-commit framework, so it does nothing
+without `--with-precommit`.
 
 ## Knowing whether a container is stale
 

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -5,7 +5,7 @@
 # everything of substance stays here, versioned, instead of being pasted into a
 # vendor configuration field (ADR-0016, principle 5):
 #
-#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud] [--with-precommit] [--profile <name>]
+#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud] [--with-precommit] [--with-hooks] [--profile <name>]
 #
 # --with-gcloud installs the Google Cloud SDK as well. Opt-in, so that the one
 # line an environment carries declares what kind of environment it is.
@@ -15,6 +15,11 @@
 # container is covered. Opt-in for the same reason, and one more: it is the only
 # part of this script that needs the Ubuntu archives, so an environment that
 # cannot reach them keeps working by not asking for it.
+#
+# --with-hooks wires this estate's PreToolUse guards and PostToolUse terraform
+# hooks into ~/.claude/settings.json. Separate from --with-precommit because
+# they are different mechanisms: a git hook blocks the commit, a harness hook
+# returns the failure into the agent's context where it can act on it.
 #
 # --profile names the composed context profile to install, defaulting to
 # claude-cloud-sandbox. A Codex environment passes --profile codex-cloud-sandbox.
@@ -43,12 +48,14 @@ REF="${1:-main}"
 [ $# -gt 0 ] && shift
 WITH_GCLOUD=0
 WITH_PRECOMMIT=0
+WITH_HOOKS=0
 PROFILE=claude-cloud-sandbox
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --with-gcloud) WITH_GCLOUD=1 ;;
         --with-precommit) WITH_PRECOMMIT=1 ;;
+        --with-hooks) WITH_HOOKS=1 ;;
         --profile)
             shift
             [ $# -gt 0 ] || die "--profile needs a value"
@@ -505,6 +512,72 @@ for skill in $SKILLS; do
     # /name a second time. Same reasoning as gcp-credentials above.
     rm -f "$HOME/.claude/commands/$skill.md"
 done
+
+# --- harness hooks, on request ------------------------------------------------
+#
+# The other half of enforcement. #256 ships the pre-commit framework and a
+# native git hook, which blocks a bad commit; these run inside the agent loop
+# and return the failure into its context, where it can read the message and
+# fix the cause rather than just being stopped. Both are worth having.
+#
+# Viable because a container-created ~/.claude/settings.json IS honoured --
+# measured 2026-08-18 by planting one and watching a PreToolUse hook fire eight
+# seconds later, with no session restart (#254). That is the third
+# documented-as-unavailable user-scope path to work from inside the container,
+# after ~/.claude/skills and ~/.claude/CLAUDE.md.
+#
+# The wiring is taken from home/settings.json rather than restated here. That
+# file is the workstation's, and it already invokes ~/.claude/bin/<hook>
+# directly -- the same paths this script installs to -- so the two surfaces run
+# identical hooks from one source instead of a copy that drifts.
+#
+# NOT via plugin-hook-dispatch. That dispatcher exists to stand down when a
+# ~/.claude/bin copy is present, because a plugin-enabled workstation would
+# otherwise run every hook twice. Here the bootstrap-written copy is the only
+# copy, so the settings file names it directly, exactly as chezmoi's does.
+
+if [ "$WITH_HOOKS" -eq 1 ]; then
+    command -v jq > /dev/null 2>&1 || die "--with-hooks needs jq to merge settings.json"
+
+    for script in prchecks-wait-claude-hook prepush-guard-claude-hook precommit-claude-hook; do
+        curl -sSfL "$RAW/home/bin/$script" -o "$TMP/$script" ||
+            die "could not fetch hook script $script from $REF"
+        head -1 "$TMP/$script" | grep -q '^#!' || die "fetched $script is not a script"
+        install -m 0755 "$TMP/$script" "$HOME/.claude/bin/$script"
+    done
+
+    curl -sSfL "$RAW/home/settings.json" -o "$TMP/settings.json" ||
+        die "could not fetch home/settings.json from $REF"
+    jq -e '.hooks' "$TMP/settings.json" > "$TMP/hooks.json" ||
+        die "home/settings.json has no .hooks block"
+
+    # Merge rather than overwrite. A container may already have a settings.json
+    # -- this script's own earlier run, or something the environment put there
+    # -- and replacing it wholesale would silently drop whatever else it holds.
+    # `*` deep-merges objects and replaces arrays, so the hook lists this repo
+    # owns are replaced while any other key survives untouched.
+    #
+    # Note ~/.claude/launcher-settings.json is a DIFFERENT file with its own
+    # hooks, written by the harness. Nothing here touches it, and both are read.
+    SETTINGS="$HOME/.claude/settings.json"
+    if [ -f "$SETTINGS" ]; then
+        jq -s '.[0] * {hooks: .[1]}' "$SETTINGS" "$TMP/hooks.json" > "$TMP/merged.json" ||
+            die "could not merge into existing $SETTINGS"
+        mv "$TMP/merged.json" "$SETTINGS"
+        log "hooks   -> $SETTINGS (merged into existing)"
+    else
+        jq -n --slurpfile h "$TMP/hooks.json" '{hooks: $h[0]}' > "$SETTINGS" ||
+            die "could not write $SETTINGS"
+        log "hooks   -> $SETTINGS (created)"
+    fi
+
+    # prepush-guard needs gh, which these containers do not have (#257), so it
+    # exits 0 here. precommit-claude-hook needs the pre-commit framework and is
+    # a no-op without --with-precommit. Both degrade rather than failing, which
+    # is why this flag has no hard dependency on that one -- but the pair is
+    # what makes it worth having.
+    log "hooks   :  prchecks-wait, prepush-guard (needs gh), precommit (needs --with-precommit)"
+fi
 
 # --- the manifest -------------------------------------------------------------
 #


### PR DESCRIPTION
The other half of enforcement, and the half #254 was blocked on until this morning. Rebased onto `main` now that #259 has merged; one commit, two files.

## What it adds

`--with-precommit` (#256) ships a **native git hook**, which blocks a bad commit. `--with-hooks` adds the **harness layer**, which runs inside the agent loop and returns the failure into the agent's context — so it reads the message and fixes the cause rather than simply being stopped.

Both are worth having, and the difference is visible in one line of output:

```text
PreToolUse:Bash hook error: [~/.claude/bin/precommit-claude-hook]:
pre-commit (pre-commit) failed — blocked. Fix these and re-run:

markdownlint-cli2........................................................Failed
ISO2.md:3 error MD012/no-multiple-blanks …
```

## Why it is viable at all

A container-created `~/.claude/settings.json` **is** honoured. Measured by planting one and watching a `PreToolUse` hook fire eight seconds later, with no session restart. That is the third documented-as-unavailable user-scope path to work from inside a container:

| Path | Documented | Measured |
| --- | --- | --- |
| `~/.claude/skills/` | unavailable | works (ADR-0016) |
| `~/.claude/CLAUDE.md` | unavailable | works (#245) |
| `~/.claude/settings.json` hooks | enumerated as not-run | **works** (#254) |

## Three design points

**Wiring taken from `home/settings.json`, not restated.** That file is the workstation's, and it already invokes `~/.claude/bin/<hook>` directly — the same paths this script installs to. So both surfaces run identical hooks from one source rather than a copy that drifts.

**Deliberately not via `plugin-hook-dispatch`.** That dispatcher exists to stand down when a `~/.claude/bin` copy is present, because a plugin-enabled workstation would otherwise run every hook twice. Here the bootstrap-written copy is the only one, so the settings file names it directly, exactly as chezmoi's does.

**Merged, not overwritten.** A container may already have a `settings.json`, and replacing it wholesale would silently drop whatever else it holds. Verified against a real one: an unrelated top-level key and an unrelated hook event both survived, while the hook lists this repo owns were replaced. `~/.claude/launcher-settings.json` is a different file with its own hooks, written by the harness — untouched, and both are read.

## Flag separation

Separate from `--with-precommit`, with no hard dependency, because all three scripts degrade to `exit 0` when their dependency is missing:

- `prepush-guard-claude-hook` needs `gh`, absent here (#257)
- `precommit-claude-hook` needs the pre-commit framework, so it is a no-op without `--with-precommit`

The pair is what makes this worth having, but neither breaks without the other.

## Verification, and two false negatives worth recording

With the native git hook disabled **for this repo only** — a local `core.hooksPath` override, global untouched — a lint-violating commit was blocked by the harness hook alone.

Getting there took three attempts, and the first two each produced a *confident wrong answer*:

1. The test `cd`'d into a scratch repo — but the hook resolves the repository from the payload's `cwd`, not the shell's, so it linted the session's project instead and passed.
2. The test staged the offending file in the **same tool call** as the commit — and `PreToolUse` fires before the command runs, so the hook correctly saw an empty staged set. The hook's own comments warn about exactly this.

Both looked like "the harness hook does not work". Neither was. Stage in one call, commit in the next.

That experience is the strongest argument in #260, filed today: a conformance suite that gets this wrong is worse than none, because a false negative on a load-bearing assumption invites someone to rip out a working mechanism.

Gates green: 70 markdown files, 19/19 skills, composition, shellcheck, 71 + 18 shell assertions, manifests, allowlist, retired-paths. Committed through the pre-commit hook from #256.

Refs #254

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFVRa7P4DCJmWJtbXwpLAi)_