### PR TITLE
Correct claims the retrospective and the core make about this surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,8 @@ restructure that introduced `home/` is on top of that history.
 │   └── README.md              #   per-environment setup (script, domains, vars)
 └── home/                      # ← mounts at ~/.claude/ AND is the plugin root
     ├── .claude-plugin/        #   plugin.json — the plugin manifest
-    ├── AGENTS.md              → ~/.claude/AGENTS.md  (portable policy core — every provider)
-    ├── CLAUDE.md              → ~/.claude/CLAUDE.md  (Claude adapter; imports the other two)
-    ├── local-machine.md       → ~/.claude/local-machine.md  (workstation-only guidance)
+    ├── AGENTS.md              → ~/.claude/AGENTS.md  (GENERATED — composed from context/fragments/)
+    ├── CLAUDE.md              → ~/.claude/CLAUDE.md  (GENERATED — composed from context/fragments/)
     ├── settings.json          → ~/.claude/settings.json
     ├── settings.json.md       → ~/.claude/settings.json.md  (annotated companion, kept alongside)
     ├── commands/              → ~/.claude/commands/  (Claude slash commands)
@@ -339,7 +338,7 @@ deploys shrinks to the part a plugin structurally cannot carry:
 
 | Stays deployed | Why |
 | --- | --- |
-| `CLAUDE.md`, `AGENTS.md`, `ephemeral-first.md`, `local-machine.md` | Policy prose can't ride a plugin |
+| `CLAUDE.md`, `AGENTS.md` | Policy prose can't ride a plugin. Both are generated from `context/fragments/` — edit the fragment, run `python3 tests/compose-context.py --write` |
 | `settings.json`, `settings.json.md` | Permission allowlists can't ride a plugin |
 | `retired-paths` | Read by the pruner at `~/.claude/retired-paths` |
 | `bin/claude-prune-retired` | Invoked by dotfiles after each apply |

--- a/context/fragments/core.md
+++ b/context/fragments/core.md
@@ -68,7 +68,7 @@ stated rather than inferred from where it sits.
 ## Changing agent config
 
 - **To request a change to agent configuration, open a GitHub issue against `pmgledhill102/agentic-coding-config`.** Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the source actually lives
-- This is the route from **any** surface. A cloud sandbox has no agent config on disk to edit, and a local machine's copy is generated (see `local-machine.md`), so in both cases the issue is the change
+- This is the route from **any** surface. Whatever config is on disk here is *generated* — composed from fragments and delivered by chezmoi or the bootstrap — so editing it in place is lost on the next apply. The issue is the change
 
 ## Commit & PR Style
 
@@ -101,5 +101,5 @@ stated rather than inferred from where it sits.
 - **Where BSD and GNU differ, try both rather than picking one.** The established idiom here is GNU first with a BSD fallback: `stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null`. The same care applies to `sed -i`, `readlink -f`, `date`, and `grep -P`
 - **If `bash` is genuinely required, it must run on bash 3.2**, which is what macOS ships. Prefer `#!/usr/bin/env bash` over `#!/bin/bash` so a newer interpreter is used when one is on `PATH`, but do not rely on one being there
 - **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your own call or in the user's terminal after you suggest them
-- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on this workstation
+- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently, and the traps are surface-specific — the environment fragment composed into this file names the ones that apply here
 - **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use a surgical edit tool for source changes

--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -76,7 +76,7 @@ stated rather than inferred from where it sits.
 ### Changing agent config
 
 - **To request a change to agent configuration, open a GitHub issue against `pmgledhill102/agentic-coding-config`.** Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the source actually lives
-- This is the route from **any** surface. A cloud sandbox has no agent config on disk to edit, and a local machine's copy is generated (see `local-machine.md`), so in both cases the issue is the change
+- This is the route from **any** surface. Whatever config is on disk here is *generated* — composed from fragments and delivered by chezmoi or the bootstrap — so editing it in place is lost on the next apply. The issue is the change
 
 ### Commit & PR Style
 
@@ -109,7 +109,7 @@ stated rather than inferred from where it sits.
 - **Where BSD and GNU differ, try both rather than picking one.** The established idiom here is GNU first with a BSD fallback: `stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null`. The same care applies to `sed -i`, `readlink -f`, `date`, and `grep -P`
 - **If `bash` is genuinely required, it must run on bash 3.2**, which is what macOS ships. Prefer `#!/usr/bin/env bash` over `#!/bin/bash` so a newer interpreter is used when one is on `PATH`, but do not rely on one being there
 - **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your own call or in the user's terminal after you suggest them
-- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on this workstation
+- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently, and the traps are surface-specific — the environment fragment composed into this file names the ones that apply here
 - **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use a surgical edit tool for source changes
 
 ## Ephemeral-first engineering

--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -76,7 +76,7 @@ stated rather than inferred from where it sits.
 ### Changing agent config
 
 - **To request a change to agent configuration, open a GitHub issue against `pmgledhill102/agentic-coding-config`.** Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the source actually lives
-- This is the route from **any** surface. A cloud sandbox has no agent config on disk to edit, and a local machine's copy is generated (see `local-machine.md`), so in both cases the issue is the change
+- This is the route from **any** surface. Whatever config is on disk here is *generated* — composed from fragments and delivered by chezmoi or the bootstrap — so editing it in place is lost on the next apply. The issue is the change
 
 ### Commit & PR Style
 
@@ -109,7 +109,7 @@ stated rather than inferred from where it sits.
 - **Where BSD and GNU differ, try both rather than picking one.** The established idiom here is GNU first with a BSD fallback: `stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null`. The same care applies to `sed -i`, `readlink -f`, `date`, and `grep -P`
 - **If `bash` is genuinely required, it must run on bash 3.2**, which is what macOS ships. Prefer `#!/usr/bin/env bash` over `#!/bin/bash` so a newer interpreter is used when one is on `PATH`, but do not rely on one being there
 - **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your own call or in the user's terminal after you suggest them
-- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on this workstation
+- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently, and the traps are surface-specific — the environment fragment composed into this file names the ones that apply here
 - **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use a surgical edit tool for source changes
 
 ## Ephemeral-first engineering

--- a/home/commands/retrospective.md
+++ b/home/commands/retrospective.md
@@ -8,12 +8,12 @@ Run a retrospective on this session: draft a per-session journal entry into `pau
 - **Current branch + state**: `git status` (branch name, dirty/clean).
 - **Issue state**: list open issues assigned to me, so the retro knows what was already in flight — `mcp__github__list_issues` when connected, else `gh issue list --assignee @me --state open`.
 - **Memory dir**: list `~/.claude/projects/<project>/memory/` (path matches the cwd-derived project key) and read `MEMORY.md` so you know what's already captured and don't propose duplicates.
-- **Settings**: read `~/.claude/settings.json` for permission-related observations.
-- **Surface**: `command -v chezmoi`. Present = workstation; absent = cloud sandbox. This decides which dimensions run in step 2.
+- **Settings**: read `~/.claude/settings.json` for permission- and hook-related observations. **Present on both surfaces.** chezmoi writes it on a workstation; `cloud/bootstrap.sh --with-hooks` writes it in a sandbox, where hooks declared in it are honoured (measured 2026-08-18).
+- **Surface**: `command -v chezmoi`. Present = workstation; absent = cloud sandbox. Used to interpret findings, not to skip dimensions.
 
-**The last two reads are workstation-only.** A cloud sandbox has no `~/.claude/settings.json` and no `projects/<project>/memory/` — nothing is wrong, that state simply lives on the machine the session is not running on.
+**Only the memory dir is workstation-only.** Auto-memory is machine-local by design and is not shared into cloud environments, so `projects/<project>/memory/` is normally absent in a sandbox — note that `projects/<project>/` itself may well exist, so the presence of that directory proves nothing.
 
-**Degrade explicitly, don't skip silently.** When either is absent, say so in the retro output — `settings: n/a (sandbox)`, `memory: n/a (sandbox)` — and carry on. A retro that quietly omits a dimension reads identically to one that ran it and found nothing, and the difference matters: the first means "not checked here", the second means "checked, all good".
+**Degrade explicitly, don't skip silently.** When something is genuinely absent, say so in the retro output — `memory: n/a (sandbox)` — and carry on. A retro that quietly omits a dimension reads identically to one that ran it and found nothing, and the difference matters: the first means "not checked here", the second means "checked, all good".
 
 If we're not inside a git repo, treat the retro as cross-repo by default — every action becomes an Issue against `pmgledhill102/paul-context`.
 
@@ -23,10 +23,10 @@ Review the full conversation history and evaluate each of these dimensions. Skip
 
 **Two dimensions are surface-specific** — run whichever matches the surface detected in step 1, not both:
 
-- **Approval friction** — *workstation only*. Skip in a sandbox: the permission model there is the environment's, `~/.claude/settings.json` is not readable, and a recommendation to add an allow rule has nowhere to land.
+- **Approval friction** — *both surfaces*. It used to be workstation-only, on the belief that a sandbox has no readable `~/.claude/settings.json` and nowhere for an allow rule to land. Both halves of that are now false: the file is present and readable in a sandbox, and the bootstrap writes it. Interpret findings by surface rather than skipping the dimension.
 - **Missing sandbox config** — *sandbox only*. See below.
 
-- **Approval friction** (workstation only): Which tool calls required manual approval? Were any repeatedly approved and should be added to `allowedTools` in settings? Note the specific tool patterns.
+- **Approval friction** (both surfaces): Which tool calls required manual approval? Were any repeatedly approved and should be added to `allowedTools` in settings? Note the specific tool patterns. Also note **enforcement** that fired or was bypassed — a pre-commit hook, a `PreToolUse` guard — since both now exist in sandboxes and a bypass is worth recording.
 - **Missing sandbox config** (sandbox only): **what config, context or credentials were missing from this sandbox session?** This is the feedback loop that catches capability gaps, and it is the dimension most worth getting right, because a sandbox is the surface where a gap is invisible until it blocks something. Look for:
   - **Tools absent** that the work needed — was `gcloud`, a linter, a language runtime missing because the environment's setup script does not install it? Name the tool and the setup-script change.
   - **Credentials unavailable** — was GCP access needed and absent? The answer is the credential broker (`/gcp-credentials`), so the finding is usually "the broker was not configured for this environment", naming which of the request key, broker URL or allowed-domains entry was missing.
@@ -75,7 +75,7 @@ Review the full conversation history and evaluate each of these dimensions. Skip
   - A back-out/retry happened because a step was performed in the wrong order.
   - Investigation took disproportionate time relative to the eventual fix.
 
-  For each candidate, propose: a command name (kebab-case), a one-line description, the key pre-flight checks, and the gotchas the prompt must surface. Existing commands live in `agentic-coding-config/home/commands/` (deployed to `~/.claude/commands/`) — check there first to avoid duplicates.
+  For each candidate, propose: a command name (kebab-case), a one-line description, the key pre-flight checks, and the gotchas the prompt must surface. Existing ones live in `agentic-coding-config/home/skills/` — check there first to avoid duplicates. Note `home/commands/` still exists but is being retired in favour of skills (ADR-0018 principle 3), so propose a skill. In a sandbox they arrive as skills via the bootstrap whitelist; there is no `~/.claude/commands/`.
 
 - **Slash command improvements**: Did this session invoke any existing slash command (or manually perform work that an existing one should have handled)? For each:
   - Was a step missing, wrong, or stale?
@@ -104,13 +104,13 @@ For each finding, decide what kind of artifact it should produce:
 
 Both routes satisfy this, because both take the repo as an argument rather than inferring it from the working directory: `mcp__github__issue_write` with an explicit `owner`/`repo`, or `gh issue create --repo pmgledhill102/<target>`. Either works identically from a sandbox or a laptop.
 
-Prefer MCP when it is connected. Keep `gh` in mind for headless or sandbox runs, where a `gh` token is more reliably present than an interactively-authenticated MCP server — that portability is the reason the `gh` forms are still written out here.
+Prefer MCP when it is connected, and fall back to `gh` where it is not and `gh` is present. Which of the two exists is a property of the surface: **`gh` is absent from Claude cloud sandboxes**, where MCP is the only route, so the `gh` forms here are for workstations and headless runs that have it. They are written out because the *operation* is what matters, not the tool.
 
 ### 3b. Never edit settings.json — file an a-c-c Issue
 
-Permissions, hooks, env vars and everything else in `~/.claude/settings.json` are **managed centrally** by `pmgledhill102/agentic-coding-config` and applied to each machine by chezmoi. A retro's job is to *route* a settings finding, not to apply it:
+Permissions, hooks, env vars and everything else in `~/.claude/settings.json` are **managed centrally** by `pmgledhill102/agentic-coding-config` and delivered per surface — by chezmoi on a workstation, by `cloud/bootstrap.sh` in a sandbox. A retro's job is to *route* a settings finding, not to apply it:
 
-- **Do not edit `~/.claude/settings.json`.** chezmoi overwrites it on the next apply and the change is silently lost.
+- **Do not edit `~/.claude/settings.json`.** It is generated on both surfaces: chezmoi overwrites it on the next apply, and the bootstrap rewrites it on the next run. Either way the change is silently lost.
 - **Do not "helpfully" redirect the change into the current project's `.claude/settings.json` or `.claude/settings.local.json` instead.** A globally-useful permission parked in one project repo only works in that repo, is invisible to the a-c-c inbox, and diverges from the managed set. This substitution is the specific failure this section exists to prevent.
 - **Do not invoke `/update-config`** for managed settings — that skill edits settings files in place, which is exactly the wrong outcome here. (It remains the right tool when the user is deliberately configuring a project-local harness setting, unrelated to a retro finding.)
 - **Do** file an Issue against `pmgledhill102/agentic-coding-config` with the exact rule (e.g. `Bash(rg --json *)`), the friction observed this session, and whether it's read-only. Same body requirements as any other cross-repo Issue, including the journal cross-reference.
@@ -122,7 +122,7 @@ Permissions, hooks, env vars and everything else in `~/.claude/settings.json` ar
 When a finding clearly mentions a target, route there. Otherwise apply this default split:
 
 - **Brewfile / package lists / shell config / OS bootstrap / chezmoi machinery** → `dotfiles`
-- **Slash commands / hooks / `~/.claude/settings.json` / MCP server config / the policy files (`home/AGENTS.md` portable, `home/CLAUDE.md` Claude-specific, `home/local-machine.md` workstation-only)** → `agentic-coding-config`
+- **Skills / hooks / `~/.claude/settings.json` / MCP server config / agent policy** → `agentic-coding-config`. Policy now lives in `context/fragments/` (`core.md` portable, `provider-*.md` per provider, `env-*.md` per environment) and is composed into `home/AGENTS.md`, `home/CLAUDE.md` and `profiles/`. **Those outputs are generated — name the fragment, never the composed file.**
 - **Engineering principles / personal direction / repo registry / archive list / decisions** → `paul-context`
 - **Genuinely unsorted / "I had a thought"** → `paul-context` (default fallback)
 

--- a/home/skills/retrospective/SKILL.md
+++ b/home/skills/retrospective/SKILL.md
@@ -13,12 +13,12 @@ description: 'Run an end-of-session retrospective: draft a per-session journal e
 - **Current branch + state**: `git status` (branch name, dirty/clean).
 - **Issue state**: list open issues assigned to me, so the retro knows what was already in flight — `mcp__github__list_issues` when connected, else `gh issue list --assignee @me --state open`.
 - **Memory dir**: list `~/.claude/projects/<project>/memory/` (path matches the cwd-derived project key) and read `MEMORY.md` so you know what's already captured and don't propose duplicates.
-- **Settings**: read `~/.claude/settings.json` for permission-related observations.
-- **Surface**: `command -v chezmoi`. Present = workstation; absent = cloud sandbox. This decides which dimensions run in step 2.
+- **Settings**: read `~/.claude/settings.json` for permission- and hook-related observations. **Present on both surfaces.** chezmoi writes it on a workstation; `cloud/bootstrap.sh --with-hooks` writes it in a sandbox, where hooks declared in it are honoured (measured 2026-08-18).
+- **Surface**: `command -v chezmoi`. Present = workstation; absent = cloud sandbox. Used to interpret findings, not to skip dimensions.
 
-**The last two reads are workstation-only.** A cloud sandbox has no `~/.claude/settings.json` and no `projects/<project>/memory/` — nothing is wrong, that state simply lives on the machine the session is not running on.
+**Only the memory dir is workstation-only.** Auto-memory is machine-local by design and is not shared into cloud environments, so `projects/<project>/memory/` is normally absent in a sandbox — note that `projects/<project>/` itself may well exist, so the presence of that directory proves nothing.
 
-**Degrade explicitly, don't skip silently.** When either is absent, say so in the retro output — `settings: n/a (sandbox)`, `memory: n/a (sandbox)` — and carry on. A retro that quietly omits a dimension reads identically to one that ran it and found nothing, and the difference matters: the first means "not checked here", the second means "checked, all good".
+**Degrade explicitly, don't skip silently.** When something is genuinely absent, say so in the retro output — `memory: n/a (sandbox)` — and carry on. A retro that quietly omits a dimension reads identically to one that ran it and found nothing, and the difference matters: the first means "not checked here", the second means "checked, all good".
 
 If we're not inside a git repo, treat the retro as cross-repo by default — every action becomes an Issue against `pmgledhill102/paul-context`.
 
@@ -28,10 +28,10 @@ Review the full conversation history and evaluate each of these dimensions. Skip
 
 **Two dimensions are surface-specific** — run whichever matches the surface detected in step 1, not both:
 
-- **Approval friction** — *workstation only*. Skip in a sandbox: the permission model there is the environment's, `~/.claude/settings.json` is not readable, and a recommendation to add an allow rule has nowhere to land.
+- **Approval friction** — *both surfaces*. It used to be workstation-only, on the belief that a sandbox has no readable `~/.claude/settings.json` and nowhere for an allow rule to land. Both halves of that are now false: the file is present and readable in a sandbox, and the bootstrap writes it. Interpret findings by surface rather than skipping the dimension.
 - **Missing sandbox config** — *sandbox only*. See below.
 
-- **Approval friction** (workstation only): Which tool calls required manual approval? Were any repeatedly approved and should be added to `allowedTools` in settings? Note the specific tool patterns.
+- **Approval friction** (both surfaces): Which tool calls required manual approval? Were any repeatedly approved and should be added to `allowedTools` in settings? Note the specific tool patterns. Also note **enforcement** that fired or was bypassed — a pre-commit hook, a `PreToolUse` guard — since both now exist in sandboxes and a bypass is worth recording.
 - **Missing sandbox config** (sandbox only): **what config, context or credentials were missing from this sandbox session?** This is the feedback loop that catches capability gaps, and it is the dimension most worth getting right, because a sandbox is the surface where a gap is invisible until it blocks something. Look for:
   - **Tools absent** that the work needed — was `gcloud`, a linter, a language runtime missing because the environment's setup script does not install it? Name the tool and the setup-script change.
   - **Credentials unavailable** — was GCP access needed and absent? The answer is the credential broker (`/gcp-credentials`), so the finding is usually "the broker was not configured for this environment", naming which of the request key, broker URL or allowed-domains entry was missing.
@@ -80,7 +80,7 @@ Review the full conversation history and evaluate each of these dimensions. Skip
   - A back-out/retry happened because a step was performed in the wrong order.
   - Investigation took disproportionate time relative to the eventual fix.
 
-  For each candidate, propose: a command name (kebab-case), a one-line description, the key pre-flight checks, and the gotchas the prompt must surface. Existing commands live in `agentic-coding-config/home/commands/` (deployed to `~/.claude/commands/`) — check there first to avoid duplicates.
+  For each candidate, propose: a command name (kebab-case), a one-line description, the key pre-flight checks, and the gotchas the prompt must surface. Existing ones live in `agentic-coding-config/home/skills/` — check there first to avoid duplicates. Note `home/commands/` still exists but is being retired in favour of skills (ADR-0018 principle 3), so propose a skill. In a sandbox they arrive as skills via the bootstrap whitelist; there is no `~/.claude/commands/`.
 
 - **Slash command improvements**: Did this session invoke any existing slash command (or manually perform work that an existing one should have handled)? For each:
   - Was a step missing, wrong, or stale?
@@ -109,13 +109,13 @@ For each finding, decide what kind of artifact it should produce:
 
 Both routes satisfy this, because both take the repo as an argument rather than inferring it from the working directory: `mcp__github__issue_write` with an explicit `owner`/`repo`, or `gh issue create --repo pmgledhill102/<target>`. Either works identically from a sandbox or a laptop.
 
-Prefer MCP when it is connected. Keep `gh` in mind for headless or sandbox runs, where a `gh` token is more reliably present than an interactively-authenticated MCP server — that portability is the reason the `gh` forms are still written out here.
+Prefer MCP when it is connected, and fall back to `gh` where it is not and `gh` is present. Which of the two exists is a property of the surface: **`gh` is absent from Claude cloud sandboxes**, where MCP is the only route, so the `gh` forms here are for workstations and headless runs that have it. They are written out because the *operation* is what matters, not the tool.
 
 ### 3b. Never edit settings.json — file an a-c-c Issue
 
-Permissions, hooks, env vars and everything else in `~/.claude/settings.json` are **managed centrally** by `pmgledhill102/agentic-coding-config` and applied to each machine by chezmoi. A retro's job is to *route* a settings finding, not to apply it:
+Permissions, hooks, env vars and everything else in `~/.claude/settings.json` are **managed centrally** by `pmgledhill102/agentic-coding-config` and delivered per surface — by chezmoi on a workstation, by `cloud/bootstrap.sh` in a sandbox. A retro's job is to *route* a settings finding, not to apply it:
 
-- **Do not edit `~/.claude/settings.json`.** chezmoi overwrites it on the next apply and the change is silently lost.
+- **Do not edit `~/.claude/settings.json`.** It is generated on both surfaces: chezmoi overwrites it on the next apply, and the bootstrap rewrites it on the next run. Either way the change is silently lost.
 - **Do not "helpfully" redirect the change into the current project's `.claude/settings.json` or `.claude/settings.local.json` instead.** A globally-useful permission parked in one project repo only works in that repo, is invisible to the a-c-c inbox, and diverges from the managed set. This substitution is the specific failure this section exists to prevent.
 - **Do not invoke `/update-config`** for managed settings — that skill edits settings files in place, which is exactly the wrong outcome here. (It remains the right tool when the user is deliberately configuring a project-local harness setting, unrelated to a retro finding.)
 - **Do** file an Issue against `pmgledhill102/agentic-coding-config` with the exact rule (e.g. `Bash(rg --json *)`), the friction observed this session, and whether it's read-only. Same body requirements as any other cross-repo Issue, including the journal cross-reference.
@@ -127,7 +127,7 @@ Permissions, hooks, env vars and everything else in `~/.claude/settings.json` ar
 When a finding clearly mentions a target, route there. Otherwise apply this default split:
 
 - **Brewfile / package lists / shell config / OS bootstrap / chezmoi machinery** → `dotfiles`
-- **Slash commands / hooks / `~/.claude/settings.json` / MCP server config / the policy files (`home/AGENTS.md` portable, `home/CLAUDE.md` Claude-specific, `home/local-machine.md` workstation-only)** → `agentic-coding-config`
+- **Skills / hooks / `~/.claude/settings.json` / MCP server config / agent policy** → `agentic-coding-config`. Policy now lives in `context/fragments/` (`core.md` portable, `provider-*.md` per provider, `env-*.md` per environment) and is composed into `home/AGENTS.md`, `home/CLAUDE.md` and `profiles/`. **Those outputs are generated — name the fragment, never the composed file.**
 - **Engineering principles / personal direction / repo registry / archive list / decisions** → `paul-context`
 - **Genuinely unsorted / "I had a thought"** → `paul-context` (default fallback)
 

--- a/profiles/claude-cloud-sandbox/AGENTS.md
+++ b/profiles/claude-cloud-sandbox/AGENTS.md
@@ -76,7 +76,7 @@ stated rather than inferred from where it sits.
 ### Changing agent config
 
 - **To request a change to agent configuration, open a GitHub issue against `pmgledhill102/agentic-coding-config`.** Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the source actually lives
-- This is the route from **any** surface. A cloud sandbox has no agent config on disk to edit, and a local machine's copy is generated (see `local-machine.md`), so in both cases the issue is the change
+- This is the route from **any** surface. Whatever config is on disk here is *generated* — composed from fragments and delivered by chezmoi or the bootstrap — so editing it in place is lost on the next apply. The issue is the change
 
 ### Commit & PR Style
 
@@ -109,7 +109,7 @@ stated rather than inferred from where it sits.
 - **Where BSD and GNU differ, try both rather than picking one.** The established idiom here is GNU first with a BSD fallback: `stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null`. The same care applies to `sed -i`, `readlink -f`, `date`, and `grep -P`
 - **If `bash` is genuinely required, it must run on bash 3.2**, which is what macOS ships. Prefer `#!/usr/bin/env bash` over `#!/bin/bash` so a newer interpreter is used when one is on `PATH`, but do not rely on one being there
 - **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your own call or in the user's terminal after you suggest them
-- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on this workstation
+- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently, and the traps are surface-specific — the environment fragment composed into this file names the ones that apply here
 - **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use a surgical edit tool for source changes
 
 ## Ephemeral-first engineering

--- a/profiles/claude-cloud-sandbox/CLAUDE.md
+++ b/profiles/claude-cloud-sandbox/CLAUDE.md
@@ -76,7 +76,7 @@ stated rather than inferred from where it sits.
 ### Changing agent config
 
 - **To request a change to agent configuration, open a GitHub issue against `pmgledhill102/agentic-coding-config`.** Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the source actually lives
-- This is the route from **any** surface. A cloud sandbox has no agent config on disk to edit, and a local machine's copy is generated (see `local-machine.md`), so in both cases the issue is the change
+- This is the route from **any** surface. Whatever config is on disk here is *generated* — composed from fragments and delivered by chezmoi or the bootstrap — so editing it in place is lost on the next apply. The issue is the change
 
 ### Commit & PR Style
 
@@ -109,7 +109,7 @@ stated rather than inferred from where it sits.
 - **Where BSD and GNU differ, try both rather than picking one.** The established idiom here is GNU first with a BSD fallback: `stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null`. The same care applies to `sed -i`, `readlink -f`, `date`, and `grep -P`
 - **If `bash` is genuinely required, it must run on bash 3.2**, which is what macOS ships. Prefer `#!/usr/bin/env bash` over `#!/bin/bash` so a newer interpreter is used when one is on `PATH`, but do not rely on one being there
 - **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your own call or in the user's terminal after you suggest them
-- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on this workstation
+- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently, and the traps are surface-specific — the environment fragment composed into this file names the ones that apply here
 - **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use a surgical edit tool for source changes
 
 ## Ephemeral-first engineering

--- a/profiles/codex-cloud-sandbox/AGENTS.md
+++ b/profiles/codex-cloud-sandbox/AGENTS.md
@@ -76,7 +76,7 @@ stated rather than inferred from where it sits.
 ### Changing agent config
 
 - **To request a change to agent configuration, open a GitHub issue against `pmgledhill102/agentic-coding-config`.** Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the source actually lives
-- This is the route from **any** surface. A cloud sandbox has no agent config on disk to edit, and a local machine's copy is generated (see `local-machine.md`), so in both cases the issue is the change
+- This is the route from **any** surface. Whatever config is on disk here is *generated* — composed from fragments and delivered by chezmoi or the bootstrap — so editing it in place is lost on the next apply. The issue is the change
 
 ### Commit & PR Style
 
@@ -109,7 +109,7 @@ stated rather than inferred from where it sits.
 - **Where BSD and GNU differ, try both rather than picking one.** The established idiom here is GNU first with a BSD fallback: `stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null`. The same care applies to `sed -i`, `readlink -f`, `date`, and `grep -P`
 - **If `bash` is genuinely required, it must run on bash 3.2**, which is what macOS ships. Prefer `#!/usr/bin/env bash` over `#!/bin/bash` so a newer interpreter is used when one is on `PATH`, but do not rely on one being there
 - **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your own call or in the user's terminal after you suggest them
-- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on this workstation
+- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently, and the traps are surface-specific — the environment fragment composed into this file names the ones that apply here
 - **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use a surgical edit tool for source changes
 
 ## Ephemeral-first engineering

--- a/profiles/codex-workstation/AGENTS.md
+++ b/profiles/codex-workstation/AGENTS.md
@@ -76,7 +76,7 @@ stated rather than inferred from where it sits.
 ### Changing agent config
 
 - **To request a change to agent configuration, open a GitHub issue against `pmgledhill102/agentic-coding-config`.** Describe what should change and why; add acceptance criteria if useful. The user works the GH-issue inbox directly in a-c-c sessions, where the source actually lives
-- This is the route from **any** surface. A cloud sandbox has no agent config on disk to edit, and a local machine's copy is generated (see `local-machine.md`), so in both cases the issue is the change
+- This is the route from **any** surface. Whatever config is on disk here is *generated* — composed from fragments and delivered by chezmoi or the bootstrap — so editing it in place is lost on the next apply. The issue is the change
 
 ### Commit & PR Style
 
@@ -109,7 +109,7 @@ stated rather than inferred from where it sits.
 - **Where BSD and GNU differ, try both rather than picking one.** The established idiom here is GNU first with a BSD fallback: `stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null`. The same care applies to `sed -i`, `readlink -f`, `date`, and `grep -P`
 - **If `bash` is genuinely required, it must run on bash 3.2**, which is what macOS ships. Prefer `#!/usr/bin/env bash` over `#!/bin/bash` so a newer interpreter is used when one is on `PATH`, but do not rely on one being there
 - **Verify CLI flags before using them — for both commands you run AND advice you give the user**: Run `<tool> --help` or `<tool> help <subcommand>` locally before committing or before recommending a flag in chat. `--no-lock`-style hallucinations waste a round-trip whether they fire in your own call or in the user's terminal after you suggest them
-- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on this workstation
+- **Multi-step probe loops go in a script file, not inline**: For anything that loops over hosts/endpoints/cases, write a script to a scratch directory and run it, rather than composing the loop in a single shell call. Interactive shells differ from `sh` in ways that fail silently, and the traps are surface-specific — the environment fragment composed into this file names the ones that apply here
 - **Raw strings when patching file content via `python3` heredocs**: a regular triple-quoted payload turns `\n` in the *target* file's source (e.g. a Go or JSON string literal) into a real newline, producing a syntax error that surfaces a couple of tool calls later. Use `r'''…'''`, or better, use a surgical edit tool for source changes
 
 ## Ephemeral-first engineering


### PR DESCRIPTION
A content review of `/retrospective` before running it. It is structurally sound and its ways of working hold — but **six claims had been falsified by this week's work**, and three would have corrupted the retro's own output.

This is #249 phase 3 in miniature, on the one skill we happened to need next.

## False, and load-bearing

**1. "A cloud sandbox has no `~/.claude/settings.json`"**

```console
$ ls -l /root/.claude/settings.json
-rw-r--r-- 1 root root 1440 Aug 18 19:38
```

It has one, and since #261 the bootstrap writes it deliberately.

**2. "Approval friction — *workstation only*. Skip in a sandbox: `settings.json` is not readable, and an allow rule has nowhere to land."**

Wrong on both counts, and the worst of the six: it instructed the retro to **skip an entire dimension** on this surface, so a sandbox session would silently lose its permissions observations. Now applies on both surfaces — and gains enforcement (hooks that fired or were bypassed), since that exists here now too.

**3. "A `gh` token is more reliably present than an interactively-authenticated MCP server"**

This is the **same sentence** corrected in `provider-claude.md` earlier today, sitting in a second file. `gh` is absent from these containers; MCP has worked throughout. Fixing one instance without grepping for the others is how a correction half-lands — I have now grepped, and there are no more.

## Stale rather than false

**4.** Names `home/local-machine.md`, which no longer exists, and treats `home/AGENTS.md` / `home/CLAUDE.md` as files to edit. Both are generated; editing them fails CI.

**5.** Says commands deploy to `~/.claude/commands/`. No such directory in a sandbox — skills are the channel — and `home/commands/` is being retired under ADR-0018 principle 3.

**6.** Attributes `settings.json` to chezmoi alone. True on a workstation, meaningless in a container. The conclusion — never edit it, file an issue — survives; the reason did not.

## The two worth more than the six

The review turned up the same defect in **`context/fragments/core.md`**, which matters more because that is the *portable core* and ships into every profile:

> Interactive shells differ from `sh` in ways that fail silently — see `local-machine.md` for the specific traps on **this workstation**

A dead path **and** a surface leak into sandbox profiles, in one line — exactly what ADR-0018 principle 1 exists to stop, sitting in the file the principle governs. Plus a second reference in the "changing agent config" section.

`README.md`'s layout section is updated for the same reason: it still described the pre-composition file set, including `local-machine.md` as a deployed file and `CLAUDE.md` as importing "the other two".

The only surviving mention of `local-machine.md` is in ADR-0018, where it is historically correct.

## Verification

Every claim checked against this container rather than reasoned about — `settings.json` present, `projects/<project>/` present but `memory/` absent (so the old text was wrong about *why*), no `~/.claude/commands/`, `home/local-machine.md` gone, `home/AGENTS.md` carrying its GENERATED banner.

Skill regenerated with the validator's own transforms; 19/19 match. Gates green: 70 markdown files, composition, shellcheck, 71 + 18 shell assertions, manifests, allowlist, retired-paths.

## What this says about the other skills

Six defects in 258 lines, found only because we happened to need this skill next. There are 18 others that have not had this treatment, and #247 covers only the `setup-*` subset. Worth reading as a rate rather than an anecdote.

Refs #249

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFVRa7P4DCJmWJtbXwpLAi)_