### PR TITLE
start-session: verified MCP recovery for gh-unavailable sections

### DIFF
--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -79,7 +79,12 @@ Rules for interpreting exit codes:
 - `exit=0` with empty content: clean result (no ready work, nothing assigned, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
 - `exit != 0` with content `not-github` or `jq-unavailable`: silent skip.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
+- `exit != 0` with content `gh-unavailable`: **not silent.** Recover each section with its MCP equivalent when the GitHub MCP server is connected. These mappings are verified, not aspirational — measured on a live cloud sandbox 2026-08-19 (see [#257](https://github.com/pmgledhill102/agentic-coding-config/issues/257)):
+  - `main_ci` → `mcp__github__actions_list`, method `list_workflow_runs`, `workflow_runs_filter` `{"branch": "<default>"}`. **Size hazard**: the unfiltered response for even a modest repo measured ~417KB, which the harness saves to a file instead of returning inline — expect to parse the saved result. Always pass a small `perPage` (5 is plenty; step 4 only needs the most recent run per workflow).
+  - `gh_ready` → `mcp__github__list_issues` with `state: OPEN` and `fields: ["number","title","labels","state"]` — verified to work cleanly. One gap: the tool cannot express `-is:blocked`, so the recovered list is **unfiltered for blocked issues**. The brief must say so (see step 7) rather than presenting it as the ready list.
+  - `gh_assigned` → **no MCP recovery exists**: `mcp__github__list_issues` cannot filter by assignee. Report `n/a (assignee filter not available via MCP)` in the brief — an honest gap, never an empty "nothing in flight".
+
+  Use recovered data as if the gather had produced it, caveats included. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
 - `exit != 0` with other content: real error — surface it before continuing.
 
 ### 2. Surface fetch result (Tier 1)
@@ -117,7 +122,7 @@ From gather section `main_ci`. The script has already deduplicated to one most-r
 - **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
 - **All `success`**: silent (the brief reports "green").
 
-If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
+If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` (method `list_workflow_runs`, branch-filtered, small `perPage` — details and the response-size hazard are in the exit-code rules above) when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
 
 ### 5. Recent merges to `<default>` (Tier 1 — surface)
 
@@ -239,8 +244,8 @@ Needs attention:
 Rules:
 
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
-- "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work.
-- "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items).
+- "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work. When the section was MCP-recovered, no blocked filter was applied at all — retitle it `Open issues (blocked filter unavailable):` so the reader knows some rows may be blocked.
+- "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items). When the gather reported `gh-unavailable`, this line is `n/a (assignee filter not available via MCP)` — MCP cannot recover this section.
 - "Recent merges" is sourced from gather section `recent_main_commits`. Omit the entire section when `count=0`.
 - If the repo has no GitHub origin (`gh_ready` / `gh_assigned` report `not-github` or are skipped), drop both issue sections silently (the brief still shows git/CI lines).
 - Truncate any title to ~78 columns to keep rows on one line.

--- a/home/skills/start-session/SKILL.md
+++ b/home/skills/start-session/SKILL.md
@@ -84,7 +84,12 @@ Rules for interpreting exit codes:
 - `exit=0` with empty content: clean result (no ready work, nothing assigned, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
 - `exit != 0` with content `not-github` or `jq-unavailable`: silent skip.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
+- `exit != 0` with content `gh-unavailable`: **not silent.** Recover each section with its MCP equivalent when the GitHub MCP server is connected. These mappings are verified, not aspirational — measured on a live cloud sandbox 2026-08-19 (see [#257](https://github.com/pmgledhill102/agentic-coding-config/issues/257)):
+  - `main_ci` → `mcp__github__actions_list`, method `list_workflow_runs`, `workflow_runs_filter` `{"branch": "<default>"}`. **Size hazard**: the unfiltered response for even a modest repo measured ~417KB, which the harness saves to a file instead of returning inline — expect to parse the saved result. Always pass a small `perPage` (5 is plenty; step 4 only needs the most recent run per workflow).
+  - `gh_ready` → `mcp__github__list_issues` with `state: OPEN` and `fields: ["number","title","labels","state"]` — verified to work cleanly. One gap: the tool cannot express `-is:blocked`, so the recovered list is **unfiltered for blocked issues**. The brief must say so (see step 7) rather than presenting it as the ready list.
+  - `gh_assigned` → **no MCP recovery exists**: `mcp__github__list_issues` cannot filter by assignee. Report `n/a (assignee filter not available via MCP)` in the brief — an honest gap, never an empty "nothing in flight".
+
+  Use recovered data as if the gather had produced it, caveats included. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
 - `exit != 0` with other content: real error — surface it before continuing.
 
 ### 2. Surface fetch result (Tier 1)
@@ -122,7 +127,7 @@ From gather section `main_ci`. The script has already deduplicated to one most-r
 - **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
 - **All `success`**: silent (the brief reports "green").
 
-If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
+If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` (method `list_workflow_runs`, branch-filtered, small `perPage` — details and the response-size hazard are in the exit-code rules above) when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
 
 ### 5. Recent merges to `<default>` (Tier 1 — surface)
 
@@ -244,8 +249,8 @@ Needs attention:
 Rules:
 
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
-- "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work.
-- "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items).
+- "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work. When the section was MCP-recovered, no blocked filter was applied at all — retitle it `Open issues (blocked filter unavailable):` so the reader knows some rows may be blocked.
+- "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items). When the gather reported `gh-unavailable`, this line is `n/a (assignee filter not available via MCP)` — MCP cannot recover this section.
 - "Recent merges" is sourced from gather section `recent_main_commits`. Omit the entire section when `count=0`.
 - If the repo has no GitHub origin (`gh_ready` / `gh_assigned` report `not-github` or are skipped), drop both issue sections silently (the brief still shows git/CI lines).
 - Truncate any title to ~78 columns to keep rows on one line.


### PR DESCRIPTION
## What

Upgrades `/start-session`'s `gh-unavailable` recovery guidance from aspirational to verified-accurate, per the measurements recorded in the [#257 findings comment](https://github.com/pmgledhill102/agentic-coding-config/issues/257#issuecomment-5344077418) (live cloud sandbox, 2026-08-19). Touches `home/commands/start-session.md` (source of truth) and regenerates `home/skills/start-session/SKILL.md` via the transform `tests/skills-match-commands.py` asserts.

## Why

The old exit-code rule named the MCP equivalents in one sentence — `actions_list` for `main_ci`, `list_issues` for `gh_ready` / `gh_assigned` — and left the agent to discover per session that the mapping is only two-thirds real:

- **`main_ci`** → `mcp__github__actions_list` works (method `list_workflow_runs`, branch-filtered), but the unfiltered response measured ~417KB and gets saved to a file rather than returned inline. The text now says to pass a small `perPage` (5) and expect to parse a saved oversized result.
- **`gh_ready`** → `mcp__github__list_issues` works cleanly with a `fields` subset, but cannot express `-is:blocked`. The recovered list is unfiltered for blocked issues, and the brief now retitles the section (`Open issues (blocked filter unavailable):`) so it never reads as the ready list.
- **`gh_assigned`** → no MCP recovery exists: `list_issues` cannot filter by assignee. The brief reports `n/a (assignee filter not available via MCP)` — an honest gap, never an empty "nothing in flight".

Step 4's recovery sentence and step 7's brief rules carry the same caveats, so the honesty requirement reaches the user-facing output, not just the parsing rules.

## Scope

Single concern: #257's start-session recovery story. Deliberately not fixed here:

- The durable fix — surface-specific skill-body composition under ADR-0018 — is scoped as #265 (sub-issue of epic #249), since option 1 (install `gh` in the bootstrap) is established dead on this surface.
- Two remaining inline `gh` suggestions in the command that fail on cloud sandboxes (`gh run list` in step 4's elapsed-time note, `gh issue list --label journal-draft` in step 6's note) are filed as #267.

## Quality gates

- `markdownlint-cli2 "**/*.md"` — 0 issues in 70 files
- `python3 tests/skills-match-commands.py` — all 19 skill bodies match their source commands

Refs #257. See also #265, #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Srmh74bGAsF1GTU8m5QhuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Srmh74bGAsF1GTU8m5QhuM)_