### PR TITLE
Add --with-gh to the cloud bootstrap and explicit -R to the gather scripts

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -33,6 +33,14 @@ exit 0
 Drop `--with-gcloud` for an environment that does no Google Cloud work; it
 saves a ~96 MB download and declares what kind of environment this is.
 
+Add `--with-gh` to install the GitHub CLI from a pinned release. Without it,
+three of `start-session`'s seven gather sections (and `end-session`'s GitHub
+sections) report `gh-unavailable` and every session pays for MCP recovery in
+conversation — the deterministic script path is the point of those gathers
+(#257). The sandbox proxy substitutes a real scoped credential for the
+container's `GH_TOKEN` sentinel, so the installed `gh` authenticates without
+holding a token.
+
 **The `Rev:` comment is load-bearing.** The environment snapshots the setup
 script's result and re-runs it only when the script text changes, the allowed
 domains change, or roughly seven days pass. Because `main` never changes *as a
@@ -142,6 +150,7 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `~/.claude/settings.json` | harness hook wiring, with `--with-hooks` (merged, not replaced) |
 | `~/.claude/bin/*-claude-hook` | the three harness hook scripts, with `--with-hooks` |
 | `/usr/local/bin/pre-commit`, `/usr/bin/shellcheck`, `/usr/local/bin/actionlint` | with `--with-precommit` |
+| `/usr/local/bin/gh` | the GitHub CLI, pinned release, with `--with-gh` |
 
 Whitelisted today: `retrospective`, `start-session`, `end-session`. The 15
 `setup-*` skills are held back pending a currency review — they are

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -5,7 +5,7 @@
 # everything of substance stays here, versioned, instead of being pasted into a
 # vendor configuration field (ADR-0016, principle 5):
 #
-#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud] [--with-precommit] [--with-hooks] [--profile <name>]
+#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud] [--with-precommit] [--with-hooks] [--with-gh] [--profile <name>]
 #
 # --with-gcloud installs the Google Cloud SDK as well. Opt-in, so that the one
 # line an environment carries declares what kind of environment it is.
@@ -20,6 +20,15 @@
 # hooks into ~/.claude/settings.json. Separate from --with-precommit because
 # they are different mechanisms: a git hook blocks the commit, a harness hook
 # returns the failure into the agent's context where it can act on it.
+#
+# --with-gh installs the GitHub CLI from a pinned release tarball. Opt-in like
+# the rest, but it exists for a different reason: the session skills' gather
+# scripts call gh six ways, and without it three of start-session's seven
+# sections report gh-unavailable and push every session into per-conversation
+# MCP recovery — token, latency and determinism costs a script call does not
+# have (#257). On Claude's cloud surface the sandbox proxy substitutes the
+# real credential for the GH_TOKEN sentinel these containers carry, so the
+# installed gh authenticates without ever holding a token.
 #
 # --profile names the composed context profile to install, defaulting to
 # claude-cloud-sandbox. A Codex environment passes --profile codex-cloud-sandbox.
@@ -49,6 +58,7 @@ REF="${1:-main}"
 WITH_GCLOUD=0
 WITH_PRECOMMIT=0
 WITH_HOOKS=0
+WITH_GH=0
 PROFILE=claude-cloud-sandbox
 
 while [ $# -gt 0 ]; do
@@ -56,6 +66,7 @@ while [ $# -gt 0 ]; do
         --with-gcloud) WITH_GCLOUD=1 ;;
         --with-precommit) WITH_PRECOMMIT=1 ;;
         --with-hooks) WITH_HOOKS=1 ;;
+        --with-gh) WITH_GH=1 ;;
         --profile)
             shift
             [ $# -gt 0 ] || die "--profile needs a value"
@@ -374,6 +385,35 @@ HOOK
     log "githook -> $HOOK_DIR/pre-commit (core.hooksPath, all repos)"
 fi
 
+# --- gh, on request -----------------------------------------------------------
+#
+# From a pinned release tarball, exactly like actionlint above: no
+# Ubuntu-archive dependency, so an environment that cannot reach the archives
+# can still have it, and the version is a decision rather than whatever the
+# distro froze. The same 403-vs-redirect note as actionlint applies — a naive
+# reachability probe against github.com reads as an egress block and is not
+# one.
+#
+# No auth step, deliberately. These containers carry a GH_TOKEN sentinel that
+# the egress proxy substitutes with a real scoped credential on api.github.com
+# requests, so gh authenticates without a token ever existing inside the
+# container (#257, measured 2026-08-19). The gather scripts pass -R explicitly
+# rather than trusting repo inference behind that proxy.
+
+if [ "$WITH_GH" -eq 1 ] && ! command -v gh > /dev/null 2>&1; then
+    GH_VER=2.97.0
+    curl -sSfL -o "$TMP/gh.tar.gz" \
+        "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz" ||
+        die "could not download gh ${GH_VER}"
+    tar -xzf "$TMP/gh.tar.gz" -C "$TMP" "gh_${GH_VER}_linux_amd64/bin/gh" ||
+        die "could not unpack gh"
+    install -m 0755 "$TMP/gh_${GH_VER}_linux_amd64/bin/gh" /usr/local/bin/gh ||
+        die "could not install gh"
+    log "gh      -> $(gh --version 2> /dev/null | head -1 || echo 'installed')"
+elif [ "$WITH_GH" -eq 1 ]; then
+    log "gh      : already present, left alone"
+fi
+
 # --- the agent policy ---------------------------------------------------------
 #
 # Until now a sandbox got no policy at all: `ls ~/.claude/*.md` was empty, and
@@ -571,12 +611,12 @@ if [ "$WITH_HOOKS" -eq 1 ]; then
         log "hooks   -> $SETTINGS (created)"
     fi
 
-    # prepush-guard needs gh, which these containers do not have (#257), so it
-    # exits 0 here. precommit-claude-hook needs the pre-commit framework and is
-    # a no-op without --with-precommit. Both degrade rather than failing, which
-    # is why this flag has no hard dependency on that one -- but the pair is
-    # what makes it worth having.
-    log "hooks   :  prchecks-wait, prepush-guard (needs gh), precommit (needs --with-precommit)"
+    # prepush-guard needs gh, which these containers lack unless --with-gh was
+    # given (#257), so without it it exits 0 here. precommit-claude-hook needs
+    # the pre-commit framework and is a no-op without --with-precommit. Both
+    # degrade rather than failing, which is why this flag has no hard
+    # dependency on those -- but the trio is what makes it worth having.
+    log "hooks   :  prchecks-wait, prepush-guard (needs --with-gh), precommit (needs --with-precommit)"
 fi
 
 # --- the manifest -------------------------------------------------------------
@@ -621,6 +661,7 @@ fi
     echo "helpers=$BIN_SCRIPTS"
     echo "precommit=$WITH_PRECOMMIT"
     echo "gcloud=$WITH_GCLOUD"
+    echo "gh=$WITH_GH"
 } > "$MANIFEST"
 log "manifst -> $MANIFEST ($kind $(echo "$resolved" | cut -c1-12))"
 

--- a/home/bin/end-session-gather-state
+++ b/home/bin/end-session-gather-state
@@ -30,6 +30,14 @@ git fetch --all --prune --tags >"$TMP/fetch.out" 2>&1
 FETCH_EXIT=$?
 progress "fetch exit=$FETCH_EXIT"
 
+# Owner/repo slug for explicit `gh -R` flags — same reasoning as
+# start-session-gather-state: repo inference is unreliable behind the cloud
+# sandbox's egress proxy (#257), and an explicit -R is deterministic
+# everywhere. Empty on a non-GitHub remote; the ${REPO_SLUG:+...} expansions
+# then collapse and gh falls back to inference.
+REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -n 's#.*github\.com[:/]##p' | sed 's#\.git$##')
+export REPO_SLUG
+
 # --- Phase 2: parallel fan-out of independent reads ---
 # Each helper runs the command, captures stdout+stderr into <name>.out and
 # the exit code into <name>.exit. The subshell backgrounds with &.
@@ -74,18 +82,20 @@ run_sh merged_brs "
       | grep -vE '^(main|master|HEAD)\$' || true
 "
 
+# shellcheck disable=SC2016  # Intentional single quotes: expansion happens inside `sh -c`.
 run_sh main_ci '
     if command -v gh >/dev/null 2>&1; then
-        gh run list --branch main --limit 10 \
+        gh run list ${REPO_SLUG:+-R "$REPO_SLUG"} --branch main --limit 10 \
             --json status,conclusion,name,headSha,createdAt,url
     else
         echo "gh-unavailable"
     fi
 '
 
+# shellcheck disable=SC2016  # Intentional single quotes: expansion happens inside `sh -c`.
 run_sh open_prs '
     if command -v gh >/dev/null 2>&1; then
-        gh pr list --author @me --state open \
+        gh pr list ${REPO_SLUG:+-R "$REPO_SLUG"} --author @me --state open \
             --json number,title,isDraft,mergeable,statusCheckRollup,reviewDecision,url
     else
         echo "gh-unavailable"
@@ -111,7 +121,7 @@ run_sh gh_assigned '
         echo "jq-unavailable"
         exit 1
     fi
-    gh issue list --assignee @me --state open --limit 20 \
+    gh issue list ${REPO_SLUG:+-R "$REPO_SLUG"} --assignee @me --state open --limit 20 \
         --json number,title \
       | jq -r '\''.[] | "#\(.number) \(.title)"'\''
 '

--- a/home/bin/end-session-squash-merged
+++ b/home/bin/end-session-squash-merged
@@ -25,13 +25,20 @@
 
 set -uo pipefail
 
+# Owner/repo slug for an explicit `gh -R` flag — repo inference is unreliable
+# behind the cloud sandbox's egress proxy (#257). Empty on a non-GitHub
+# remote, where no merged-PR record can exist anyway, so the gh fallback
+# below declines rather than guessing.
+REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -n 's#.*github\.com[:/]##p' | sed 's#\.git$##')
+
 # Returns 0 if GitHub records a merged PR whose head branch is $1.
 # Returns non-zero on no-match, missing gh, auth failure, or network error.
 gh_has_merged_pr() {
     local branch=$1
     command -v gh >/dev/null 2>&1 || return 1
+    [ -n "$REPO_SLUG" ] || return 1
     local count
-    count=$(gh pr list --state merged --head "$branch" --json number --jq 'length' 2>/dev/null) || return 1
+    count=$(gh pr list -R "$REPO_SLUG" --state merged --head "$branch" --json number --jq 'length' 2>/dev/null) || return 1
     [ "${count:-0}" -gt 0 ]
 }
 

--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -55,6 +55,15 @@ if [ -z "$DEFAULT_BRANCH" ]; then
 fi
 export DEFAULT_BRANCH
 
+# Owner/repo slug for explicit `gh -R` flags. gh normally infers the repo from
+# the git remote, but behind the cloud sandbox's egress proxy that inference is
+# unreliable (#257), and an explicit -R is deterministic on every surface —
+# which is the property this script exists to provide. Empty on a non-GitHub
+# remote, which makes the ${REPO_SLUG:+...} expansions below collapse to
+# nothing and gh fall back to its own inference.
+REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -n 's#.*github\.com[:/]##p' | sed 's#\.git$##')
+export REPO_SLUG
+
 # --- Phase 2: parallel fan-out of independent reads ---
 
 run_section() {
@@ -130,7 +139,7 @@ run_sh main_ci '
     #   <name>=<conclusion>@<short-sha> <url>                (failure / cancelled / timed_out)
     # The URL on failing runs lets the brief link the failing job inline; on
     # clean-and-green sessions this is still 1-3 lines instead of a JSON dump.
-    gh run list --branch "$DEFAULT_BRANCH" --limit 20 \
+    gh run list ${REPO_SLUG:+-R "$REPO_SLUG"} --branch "$DEFAULT_BRANCH" --limit 20 \
         --json status,conclusion,name,headSha,createdAt,url \
       | jq -r '\''
           group_by(.name)
@@ -165,7 +174,7 @@ run_sh gh_ready '
         echo "jq-unavailable"
         exit 1
     fi
-    gh issue list --search "is:open -is:blocked" --limit 10 \
+    gh issue list ${REPO_SLUG:+-R "$REPO_SLUG"} --search "is:open -is:blocked" --limit 10 \
         --json number,title,labels \
       | jq -r '\''
           .[] | "#\(.number)|\([(.labels // [])[].name]
@@ -190,7 +199,7 @@ run_sh gh_assigned '
         echo "jq-unavailable"
         exit 1
     fi
-    gh issue list --assignee @me --state open --limit 20 \
+    gh issue list ${REPO_SLUG:+-R "$REPO_SLUG"} --assignee @me --state open --limit 20 \
         --json number,title,labels \
       | jq -r '\''
           .[] | "#\(.number)|\([(.labels // [])[].name]


### PR DESCRIPTION
The deterministic half of #257, motivated by the session-cost principle: scripts that run at every session start/end should succeed in-script, not degrade into per-conversation MCP recovery — that fallback costs tokens, latency and determinism every single session, where a working `gh` call costs one tool invocation. The MCP guidance in #268/#269 remains the safety net; this makes it the rarely-exercised path instead of the working one.

## What changed

- **`cloud/bootstrap.sh` gains `--with-gh`**: installs gh **2.97.0** (latest, 2026-07-31) from a pinned release tarball, exactly the actionlint pattern — no Ubuntu-archive dependency, version is a decision not a distro accident. No auth step by design: per the [#257 findings](https://github.com/pmgledhill102/agentic-coding-config/issues/257#issuecomment-5344814511), the sandbox proxy substitutes a real scoped credential for the container's `GH_TOKEN` sentinel, so gh authenticates without a token ever existing in the container. The manifest records `gh=0/1`; the `--with-hooks` prepush-guard note now points at the flag.
- **Explicit `-R owner/repo` on every gh call** in `start-session-gather-state`, `end-session-gather-state`, and `end-session-squash-merged`, derived once from the origin remote — repo inference behind the sandbox proxy is unreliable, and an explicit flag is deterministic on every surface. Empty slug (non-GitHub remote) collapses the expansion; behaviour there is unchanged. In `end-session-squash-merged` an empty slug now declines the gh fallback outright, which is correct: no GitHub remote, no merged-PR record.
- **`cloud/README.md`**: documents the flag and adds `gh` to the what-lands-where table.

## Verification

- shellcheck clean on all four scripts; markdownlint clean; `skills-match-commands`, `allowlist-covers-commands`, `plugin-manifests`, `retired-paths` all pass.
- The modified start-session gather ran end-to-end in this (gh-less) sandbox: the three sections still degrade to `gh-unavailable` exactly as before, so the change is strictly additive.
- **Not yet verified (needs a fresh environment):** the install itself and the authenticated calls — #257 criterion 2. After merge, the environment's setup script one-liner needs `--with-gh` added and its `Rev:` bumped, then a fresh session should confirm the three sections populate. Two things to watch there: whether the release-asset download resolves in the setup phase (the actionlint precedent says yes), and what identity `@me` resolves to under the substituted credential — if it's the App rather than the user, the `--assignee @me`/`--author @me` filters need a follow-up.

Refs #257 (criterion 2; closure once verified). Complements #268/#269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Srmh74bGAsF1GTU8m5QhuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Srmh74bGAsF1GTU8m5QhuM)_