### PR TITLE
Degrade to one gh-unauthorized sentinel when gh is installed but policy-blocked

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -33,13 +33,16 @@ exit 0
 Drop `--with-gcloud` for an environment that does no Google Cloud work; it
 saves a ~96 MB download and declares what kind of environment this is.
 
-Add `--with-gh` to install the GitHub CLI from a pinned release. Without it,
-three of `start-session`'s seven gather sections (and `end-session`'s GitHub
-sections) report `gh-unavailable` and every session pays for MCP recovery in
-conversation — the deterministic script path is the point of those gathers
-(#257). The sandbox proxy substitutes a real scoped credential for the
-container's `GH_TOKEN` sentinel, so the installed `gh` authenticates without
-holding a token.
+`--with-gh` installs the GitHub CLI from a pinned release — but **do not add
+it to Anthropic-hosted environments**. Measured 2026-08-19: the egress proxy
+authenticates `gh` for identity endpoints (`user`, `rate_limit`) yet 403s
+every repo-scoped API path, and GraphQL serves only a pinned PR-review set —
+so the session skills' gather sections come back `gh-unauthorized` rather
+than populated (lane map on #257, cleanup on #273). The flag exists for
+surfaces whose egress genuinely reaches the GitHub API, e.g. self-hosted
+environments. On Anthropic-hosted sandboxes the GitHub MCP server remains the
+only repo-data route, and the skills' documented MCP recovery is the working
+path.
 
 **The `Rev:` comment is load-bearing.** The environment snapshots the setup
 script's result and re-runs it only when the script text changes, the allowed

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -21,14 +21,13 @@
 # they are different mechanisms: a git hook blocks the commit, a harness hook
 # returns the failure into the agent's context where it can act on it.
 #
-# --with-gh installs the GitHub CLI from a pinned release tarball. Opt-in like
-# the rest, but it exists for a different reason: the session skills' gather
-# scripts call gh six ways, and without it three of start-session's seven
-# sections report gh-unavailable and push every session into per-conversation
-# MCP recovery — token, latency and determinism costs a script call does not
-# have (#257). On Claude's cloud surface the sandbox proxy substitutes the
-# real credential for the GH_TOKEN sentinel these containers carry, so the
-# installed gh authenticates without ever holding a token.
+# --with-gh installs the GitHub CLI from a pinned release tarball, for the
+# session skills' gather scripts. NOT for Anthropic-hosted web sandboxes:
+# there the egress proxy authenticates gh for identity endpoints only and
+# 403s every repo-scoped API path, so the gather sections come back
+# gh-unauthorized rather than populated — measured 2026-08-19, lane map on
+# #257, cleanup on #273. The flag exists for surfaces whose egress genuinely
+# reaches the GitHub API, e.g. self-hosted environments.
 #
 # --profile names the composed context profile to install, defaulting to
 # claude-cloud-sandbox. A Codex environment passes --profile codex-cloud-sandbox.
@@ -394,11 +393,13 @@ fi
 # reachability probe against github.com reads as an egress block and is not
 # one.
 #
-# No auth step, deliberately. These containers carry a GH_TOKEN sentinel that
-# the egress proxy substitutes with a real scoped credential on api.github.com
-# requests, so gh authenticates without a token ever existing inside the
-# container (#257, measured 2026-08-19). The gather scripts pass -R explicitly
-# rather than trusting repo inference behind that proxy.
+# No auth step, deliberately. These containers carry a GH_TOKEN sentinel the
+# egress proxy substitutes with a real credential — but on Anthropic-hosted
+# web sandboxes only for identity endpoints (user, rate_limit); every
+# repo-scoped API path 403s by policy, which is why the flag is not for that
+# surface (#257 lane map, #273). The gather scripts probe once and degrade to
+# a gh-unauthorized sentinel there, and pass -R explicitly everywhere rather
+# than trusting repo inference behind a proxy.
 
 if [ "$WITH_GH" -eq 1 ] && ! command -v gh > /dev/null 2>&1; then
     GH_VER=2.97.0

--- a/home/bin/end-session-gather-state
+++ b/home/bin/end-session-gather-state
@@ -38,6 +38,19 @@ progress "fetch exit=$FETCH_EXIT"
 REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -n 's#.*github\.com[:/]##p' | sed 's#\.git$##')
 export REPO_SLUG
 
+# One repo-scoped auth probe for the gh sections below — same reasoning as
+# start-session-gather-state: gh can be installed yet policy-blocked from repo
+# data (the Claude cloud sandbox proxy authenticates identity endpoints but
+# 403s every repo-scoped API path, #273), and one gh-unauthorized sentinel
+# beats three separate 403 dumps. Costs one API round-trip when healthy.
+GH_REPO_API=unavailable
+if command -v gh >/dev/null 2>&1 && [ -n "$REPO_SLUG" ]; then
+    if gh api "repos/$REPO_SLUG" --jq .id >/dev/null 2>&1; then
+        GH_REPO_API=ok
+    fi
+fi
+export GH_REPO_API
+
 # --- Phase 2: parallel fan-out of independent reads ---
 # Each helper runs the command, captures stdout+stderr into <name>.out and
 # the exit code into <name>.exit. The subshell backgrounds with &.
@@ -84,22 +97,30 @@ run_sh merged_brs "
 
 # shellcheck disable=SC2016  # Intentional single quotes: expansion happens inside `sh -c`.
 run_sh main_ci '
-    if command -v gh >/dev/null 2>&1; then
-        gh run list ${REPO_SLUG:+-R "$REPO_SLUG"} --branch main --limit 10 \
-            --json status,conclusion,name,headSha,createdAt,url
-    else
+    if ! command -v gh >/dev/null 2>&1; then
         echo "gh-unavailable"
+        exit 1
     fi
+    if [ "$GH_REPO_API" != "ok" ]; then
+        echo "gh-unauthorized"
+        exit 1
+    fi
+    gh run list ${REPO_SLUG:+-R "$REPO_SLUG"} --branch main --limit 10 \
+        --json status,conclusion,name,headSha,createdAt,url
 '
 
 # shellcheck disable=SC2016  # Intentional single quotes: expansion happens inside `sh -c`.
 run_sh open_prs '
-    if command -v gh >/dev/null 2>&1; then
-        gh pr list ${REPO_SLUG:+-R "$REPO_SLUG"} --author @me --state open \
-            --json number,title,isDraft,mergeable,statusCheckRollup,reviewDecision,url
-    else
+    if ! command -v gh >/dev/null 2>&1; then
         echo "gh-unavailable"
+        exit 1
     fi
+    if [ "$GH_REPO_API" != "ok" ]; then
+        echo "gh-unauthorized"
+        exit 1
+    fi
+    gh pr list ${REPO_SLUG:+-R "$REPO_SLUG"} --author @me --state open \
+        --json number,title,isDraft,mergeable,statusCheckRollup,reviewDecision,url
 '
 
 # shellcheck disable=SC2016
@@ -115,6 +136,10 @@ run_sh gh_assigned '
     fi
     if ! command -v gh >/dev/null 2>&1; then
         echo "gh-unavailable"
+        exit 1
+    fi
+    if [ "$GH_REPO_API" != "ok" ]; then
+        echo "gh-unauthorized"
         exit 1
     fi
     if ! command -v jq >/dev/null 2>&1; then

--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -64,6 +64,22 @@ export DEFAULT_BRANCH
 REPO_SLUG=$(git remote get-url origin 2>/dev/null | sed -n 's#.*github\.com[:/]##p' | sed 's#\.git$##')
 export REPO_SLUG
 
+# One repo-scoped auth probe for the gh sections below, run once. A surface
+# can have gh installed yet policy-blocked from repo data: the Claude cloud
+# sandbox proxy authenticates identity endpoints (user, rate_limit) but 403s
+# every repo-scoped API path — measured 2026-08-19 (#273, lane map on #257).
+# Without this probe each section fails with its own multi-line 403, which
+# reads as three separate problems; with it they emit one gh-unauthorized
+# sentinel that the skill maps to the same MCP recovery as gh-unavailable.
+# Costs one API round-trip on healthy surfaces.
+GH_REPO_API=unavailable
+if command -v gh >/dev/null 2>&1 && [ -n "$REPO_SLUG" ]; then
+    if gh api "repos/$REPO_SLUG" --jq .id >/dev/null 2>&1; then
+        GH_REPO_API=ok
+    fi
+fi
+export GH_REPO_API
+
 # --- Phase 2: parallel fan-out of independent reads ---
 
 run_section() {
@@ -128,6 +144,10 @@ run_sh main_ci '
         echo "gh-unavailable"
         exit 1
     fi
+    if [ "$GH_REPO_API" != "ok" ]; then
+        echo "gh-unauthorized"
+        exit 1
+    fi
     if ! command -v jq >/dev/null 2>&1; then
         echo "jq-unavailable"
         exit 1
@@ -170,6 +190,10 @@ run_sh gh_ready '
         echo "gh-unavailable"
         exit 1
     fi
+    if [ "$GH_REPO_API" != "ok" ]; then
+        echo "gh-unauthorized"
+        exit 1
+    fi
     if ! command -v jq >/dev/null 2>&1; then
         echo "jq-unavailable"
         exit 1
@@ -193,6 +217,10 @@ run_sh gh_assigned '
     fi
     if ! command -v gh >/dev/null 2>&1; then
         echo "gh-unavailable"
+        exit 1
+    fi
+    if [ "$GH_REPO_API" != "ok" ]; then
+        echo "gh-unauthorized"
         exit 1
     fi
     if ! command -v jq >/dev/null 2>&1; then

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -65,9 +65,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `stashes` | 9 | Exit 0 even when empty. |
 | `worktrees` | 13 | Exit 0 even when empty. |
 | `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
-| `main_ci` | 3 | Content `gh-unavailable` = recover via MCP (see exit-code rules). Non-zero with other content = real error. |
+| `main_ci` | 3 | Content `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Non-zero with other content = real error. |
 | `open_prs` | 8 | Same skip convention as `main_ci`. |
-| `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` = recover via MCP (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
+| `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
 | `stale_claude_files` | 11 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
 **On `gh` inside the gather script.** The gather runs as a shell script, so its
@@ -75,7 +75,11 @@ GitHub queries use `gh` and cannot use `mcp__github__*` — an MCP tool is not
 callable from a subprocess. That is a deliberate exception to the MCP-first
 preference, not an oversight. But `gh` is a property of the surface, not a
 constant: present on workstations, **absent from Claude cloud sandboxes**, where
-those sections return `gh-unavailable` and MCP is the only GitHub route. When
+those sections return `gh-unavailable` and MCP is the only GitHub route. A
+surface can also have `gh` installed yet policy-blocked from repo data — the
+sandbox egress proxy authenticates identity endpoints but 403s every
+repo-scoped API path (#273) — in which case the sections return
+`gh-unauthorized`, which means the same thing: MCP is the only route. When
 that happens, recover the data with the MCP equivalents rather than treating the
 gap as empty — see the exit-code rules below. Any GitHub op **this command**
 performs directly, outside the gather, should prefer MCP.
@@ -84,7 +88,7 @@ Rules for interpreting exit codes:
 
 - `exit=0` with empty content: clean result (no stashes, no merged branches, no in-progress issues, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover with the MCP equivalents when connected — `mcp__github__list_pull_requests` for PR state, `mcp__github__list_issues` for assigned issues — else note `n/a (gh absent)` so the walk-away summary shows what was not checked.
+- `exit != 0` with content `gh-unavailable` or `gh-unauthorized`: **not silent.** Recover with the MCP equivalents when connected — `mcp__github__list_pull_requests` for PR state, `mcp__github__list_issues` for assigned issues — else note `n/a (gh absent)` so the walk-away summary shows what was not checked.
 - `exit != 0` with other content: real error — surface it before continuing Phase 1.
 
 ### 1.5. Fast-path when state is fully clean (Tier 1 — narration optimisation)
@@ -97,8 +101,8 @@ Apply when **all** of the following hold (single-pass check over already-collect
 - `local_state.unpushed` is empty (no unpushed commits — covers steps 4 and 7)
 - `merged_brs` is empty
 - `stashes` is empty
-- `gh_assigned` is empty (or content is `not-github` / `gh-unavailable`)
-- `open_prs` is empty (or content is `gh-unavailable`)
+- `gh_assigned` is empty (or content is `not-github` / `gh-unavailable` / `gh-unauthorized`)
+- `open_prs` is empty (or content is `gh-unavailable` / `gh-unauthorized`)
 - `main_ci` has no `failure` / `cancelled` / `timed_out` line (an `in_progress` workflow is allowed — summary still surfaces it)
 - `stale_claude_files` is empty (or content is `chezmoi-unavailable`)
 - `worktrees` has exactly one entry (just the primary)
@@ -128,7 +132,7 @@ From gather section `main_ci`. Parse the most recent run per workflow:
 - **In progress**: list with elapsed time. Means a deploy / long check is mid-flight.
 - **All green**: silent.
 
-If the repo has no remote, skip. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
+If the repo has no remote, skip. On `gh-unavailable` / `gh-unauthorized`, recover via `mcp__github__actions_list` when connected; otherwise carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
 
 ### 4. Handle uncommitted or unpushed work (Tier 3)
 
@@ -184,7 +188,7 @@ If main is ahead of origin/main (shouldn't normally happen, but catches the case
 
 ### 8. Open PRs needing your action (Tier 3 — surface only)
 
-From gather section `open_prs`. If the section content is `gh-unavailable`, either skip or fall back to `mcp__github__list_pull_requests` (state=open, head filter) — the MCP path doesn't need `gh` on PATH.
+From gather section `open_prs`. If the section content is `gh-unavailable` or `gh-unauthorized`, either skip or fall back to `mcp__github__list_pull_requests` (state=open, head filter) — the MCP path doesn't need `gh` on PATH.
 
 Categorise and present:
 

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -57,9 +57,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
-| `main_ci` | 4 | Content `jq-unavailable` = silent skip; `gh-unavailable` = recover via MCP (see exit-code rules). Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
+| `main_ci` | 4 | Content `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |
-| `gh_ready` | 7 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` = recover via MCP (see exit-code rules). Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
+| `gh_ready` | 7 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
 | `gh_assigned` | 7 | Same skip convention as `gh_ready`. Empty content = nothing in flight. Otherwise pipe-separated rows: `#<n>\|P<pri>\|<title>` for open issues assigned to me (usually 0-3). Same row shape as `gh_ready`. |
 | `claude_drift` | 6b, 7 | `state=absent` (sandbox, no `~/.claude`) or `state=no-source` (not in an a-c-c checkout) = silent skip. `state=compared` gives `behind=<n>` and `modified=<n>`, then one `behind: <path>` / `modified: <path>` line each, plus `remedy_behind=` / `remedy_modified=` when non-zero. Both zero = silent. |
 | `bootstrap_currency` | 6b, 7 | `state=not-a-container` (a workstation) or `state=current` = silent skip. `state=no-manifest` = a container built before manifests existed; silent, and it self-heals when the snapshot next expires. `state=pinned` names the ref the environment froze to — report only if something else looks stale. `state=behind` gives `installed=`, `head=` and a `remedy=` line: surface it, because everything the container ships is that old. `state=unknown` = the ref could not be resolved (no network); mention once, do not retry. |
@@ -69,7 +69,11 @@ GitHub queries use `gh` and cannot use `mcp__github__*` — an MCP tool is not
 callable from a subprocess. That is a deliberate exception to the MCP-first
 preference, not an oversight. But `gh` is a property of the surface, not a
 constant: present on workstations, **absent from Claude cloud sandboxes**, where
-those sections return `gh-unavailable` and MCP is the only GitHub route. When
+those sections return `gh-unavailable` and MCP is the only GitHub route. A
+surface can also have `gh` installed yet policy-blocked from repo data — the
+sandbox egress proxy authenticates identity endpoints but 403s every
+repo-scoped API path (#273) — in which case the sections return
+`gh-unauthorized`, which means the same thing: MCP is the only route. When
 that happens, recover the data with the MCP equivalents rather than treating the
 gap as empty — see the exit-code rules below. Any GitHub op **this command**
 performs directly, outside the gather, should prefer MCP.
@@ -79,7 +83,7 @@ Rules for interpreting exit codes:
 - `exit=0` with empty content: clean result (no ready work, nothing assigned, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
 - `exit != 0` with content `not-github` or `jq-unavailable`: silent skip.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
+- `exit != 0` with content `gh-unavailable` or `gh-unauthorized`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
 - `exit != 0` with other content: real error — surface it before continuing.
 
 ### 2. Surface fetch result (Tier 1)
@@ -117,7 +121,7 @@ From gather section `main_ci`. The script has already deduplicated to one most-r
 - **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
 - **All `success`**: silent (the brief reports "green").
 
-If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
+If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable` / `gh-unauthorized`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
 
 ### 5. Recent merges to `<default>` (Tier 1 — surface)
 

--- a/home/skills/end-session/SKILL.md
+++ b/home/skills/end-session/SKILL.md
@@ -70,9 +70,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `stashes` | 9 | Exit 0 even when empty. |
 | `worktrees` | 13 | Exit 0 even when empty. |
 | `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
-| `main_ci` | 3 | Content `gh-unavailable` = recover via MCP (see exit-code rules). Non-zero with other content = real error. |
+| `main_ci` | 3 | Content `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Non-zero with other content = real error. |
 | `open_prs` | 8 | Same skip convention as `main_ci`. |
-| `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` = recover via MCP (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
+| `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
 | `stale_claude_files` | 11 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
 **On `gh` inside the gather script.** The gather runs as a shell script, so its
@@ -80,7 +80,11 @@ GitHub queries use `gh` and cannot use `mcp__github__*` — an MCP tool is not
 callable from a subprocess. That is a deliberate exception to the MCP-first
 preference, not an oversight. But `gh` is a property of the surface, not a
 constant: present on workstations, **absent from Claude cloud sandboxes**, where
-those sections return `gh-unavailable` and MCP is the only GitHub route. When
+those sections return `gh-unavailable` and MCP is the only GitHub route. A
+surface can also have `gh` installed yet policy-blocked from repo data — the
+sandbox egress proxy authenticates identity endpoints but 403s every
+repo-scoped API path (#273) — in which case the sections return
+`gh-unauthorized`, which means the same thing: MCP is the only route. When
 that happens, recover the data with the MCP equivalents rather than treating the
 gap as empty — see the exit-code rules below. Any GitHub op **this command**
 performs directly, outside the gather, should prefer MCP.
@@ -89,7 +93,7 @@ Rules for interpreting exit codes:
 
 - `exit=0` with empty content: clean result (no stashes, no merged branches, no in-progress issues, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover with the MCP equivalents when connected — `mcp__github__list_pull_requests` for PR state, `mcp__github__list_issues` for assigned issues — else note `n/a (gh absent)` so the walk-away summary shows what was not checked.
+- `exit != 0` with content `gh-unavailable` or `gh-unauthorized`: **not silent.** Recover with the MCP equivalents when connected — `mcp__github__list_pull_requests` for PR state, `mcp__github__list_issues` for assigned issues — else note `n/a (gh absent)` so the walk-away summary shows what was not checked.
 - `exit != 0` with other content: real error — surface it before continuing Phase 1.
 
 ### 1.5. Fast-path when state is fully clean (Tier 1 — narration optimisation)
@@ -102,8 +106,8 @@ Apply when **all** of the following hold (single-pass check over already-collect
 - `local_state.unpushed` is empty (no unpushed commits — covers steps 4 and 7)
 - `merged_brs` is empty
 - `stashes` is empty
-- `gh_assigned` is empty (or content is `not-github` / `gh-unavailable`)
-- `open_prs` is empty (or content is `gh-unavailable`)
+- `gh_assigned` is empty (or content is `not-github` / `gh-unavailable` / `gh-unauthorized`)
+- `open_prs` is empty (or content is `gh-unavailable` / `gh-unauthorized`)
 - `main_ci` has no `failure` / `cancelled` / `timed_out` line (an `in_progress` workflow is allowed — summary still surfaces it)
 - `stale_claude_files` is empty (or content is `chezmoi-unavailable`)
 - `worktrees` has exactly one entry (just the primary)
@@ -133,7 +137,7 @@ From gather section `main_ci`. Parse the most recent run per workflow:
 - **In progress**: list with elapsed time. Means a deploy / long check is mid-flight.
 - **All green**: silent.
 
-If the repo has no remote, skip. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
+If the repo has no remote, skip. On `gh-unavailable` / `gh-unauthorized`, recover via `mcp__github__actions_list` when connected; otherwise carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
 
 ### 4. Handle uncommitted or unpushed work (Tier 3)
 
@@ -189,7 +193,7 @@ If main is ahead of origin/main (shouldn't normally happen, but catches the case
 
 ### 8. Open PRs needing your action (Tier 3 — surface only)
 
-From gather section `open_prs`. If the section content is `gh-unavailable`, either skip or fall back to `mcp__github__list_pull_requests` (state=open, head filter) — the MCP path doesn't need `gh` on PATH.
+From gather section `open_prs`. If the section content is `gh-unavailable` or `gh-unauthorized`, either skip or fall back to `mcp__github__list_pull_requests` (state=open, head filter) — the MCP path doesn't need `gh` on PATH.
 
 Categorise and present:
 

--- a/home/skills/start-session/SKILL.md
+++ b/home/skills/start-session/SKILL.md
@@ -62,9 +62,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
-| `main_ci` | 4 | Content `jq-unavailable` = silent skip; `gh-unavailable` = recover via MCP (see exit-code rules). Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
+| `main_ci` | 4 | Content `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |
-| `gh_ready` | 7 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` = recover via MCP (see exit-code rules). Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
+| `gh_ready` | 7 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
 | `gh_assigned` | 7 | Same skip convention as `gh_ready`. Empty content = nothing in flight. Otherwise pipe-separated rows: `#<n>\|P<pri>\|<title>` for open issues assigned to me (usually 0-3). Same row shape as `gh_ready`. |
 | `claude_drift` | 6b, 7 | `state=absent` (sandbox, no `~/.claude`) or `state=no-source` (not in an a-c-c checkout) = silent skip. `state=compared` gives `behind=<n>` and `modified=<n>`, then one `behind: <path>` / `modified: <path>` line each, plus `remedy_behind=` / `remedy_modified=` when non-zero. Both zero = silent. |
 | `bootstrap_currency` | 6b, 7 | `state=not-a-container` (a workstation) or `state=current` = silent skip. `state=no-manifest` = a container built before manifests existed; silent, and it self-heals when the snapshot next expires. `state=pinned` names the ref the environment froze to — report only if something else looks stale. `state=behind` gives `installed=`, `head=` and a `remedy=` line: surface it, because everything the container ships is that old. `state=unknown` = the ref could not be resolved (no network); mention once, do not retry. |
@@ -74,7 +74,11 @@ GitHub queries use `gh` and cannot use `mcp__github__*` — an MCP tool is not
 callable from a subprocess. That is a deliberate exception to the MCP-first
 preference, not an oversight. But `gh` is a property of the surface, not a
 constant: present on workstations, **absent from Claude cloud sandboxes**, where
-those sections return `gh-unavailable` and MCP is the only GitHub route. When
+those sections return `gh-unavailable` and MCP is the only GitHub route. A
+surface can also have `gh` installed yet policy-blocked from repo data — the
+sandbox egress proxy authenticates identity endpoints but 403s every
+repo-scoped API path (#273) — in which case the sections return
+`gh-unauthorized`, which means the same thing: MCP is the only route. When
 that happens, recover the data with the MCP equivalents rather than treating the
 gap as empty — see the exit-code rules below. Any GitHub op **this command**
 performs directly, outside the gather, should prefer MCP.
@@ -84,7 +88,7 @@ Rules for interpreting exit codes:
 - `exit=0` with empty content: clean result (no ready work, nothing assigned, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
 - `exit != 0` with content `not-github` or `jq-unavailable`: silent skip.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
+- `exit != 0` with content `gh-unavailable` or `gh-unauthorized`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
 - `exit != 0` with other content: real error — surface it before continuing.
 
 ### 2. Surface fetch result (Tier 1)
@@ -122,7 +126,7 @@ From gather section `main_ci`. The script has already deduplicated to one most-r
 - **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
 - **All `success`**: silent (the brief reports "green").
 
-If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
+If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable` / `gh-unauthorized`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
 
 ### 5. Recent merges to `<default>` (Tier 1 — surface)
 


### PR DESCRIPTION
The cleanup half of #273 after its verification came back negative. gh 2.97.0 installs and authenticates for identity endpoints (`user`, `rate_limit` → 200), but the Anthropic-hosted sandbox proxy 403s every repo-scoped API path and GraphQL beyond a pinned PR-review set — full lane map on [#257](https://github.com/pmgledhill102/agentic-coding-config/issues/257#issuecomment-5345139265). That's exactly the installed-but-unauthenticated hazard #257 originally predicted: each gather section failed with its own multi-line 403 instead of one sentinel.

## What changed

- **Gather scripts probe once, degrade deterministically**: `start-session-gather-state` and `end-session-gather-state` run one `gh api repos/<slug>` probe per invocation; when it fails, every GitHub section emits a single `gh-unauthorized` line. One extra API round-trip on healthy surfaces; one clean line instead of three different 403 dumps on blocked ones.
- **Both skills map the new sentinel** to the same MCP recovery as `gh-unavailable` (exit-code rules, section tables, end-session's fast-path and CI-gate readings — an unchecked state still reads as unchecked, never clean). Skills regenerated; `skills-match-commands` green.
- **Bootstrap and `cloud/README.md` corrected to the measured truth**: `--with-gh` is for surfaces whose egress genuinely reaches the GitHub API (e.g. self-hosted environments); Anthropic-hosted environments should not carry it, and the README now says so instead of the optimistic pre-verification text.

## Verification

Live in a blocked sandbox (gh installed via the merged #272 bootstrap): all three start-session GitHub sections and all three end-session GitHub sections emit exactly `gh-unauthorized` with exit 1. shellcheck clean on all four scripts; markdownlint clean; `skills-match-commands`, `plugin-manifests`, `allowlist-covers-commands`, `retired-paths` all pass.

Remaining on #273 after this merges: remove `--with-gh` from the environment's setup line (Rev bump), and the durable deterministic path is #265 (P1).

Refs #273, #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Srmh74bGAsF1GTU8m5QhuM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Srmh74bGAsF1GTU8m5QhuM)_