### PR TITLE
Consolidate session-gather GitHub handling: on-demand CI + MCP-recovery honesty (#273, #268, #269)

### DIFF
--- a/docs/end-session-design.md
+++ b/docs/end-session-design.md
@@ -66,7 +66,6 @@ fixed commands, so parallelising it would buy nothing.
     │                        ├── stashes
     │                        ├── worktrees
     │                        ├── merged_brs
-    │                        ├── main_ci       (gh run list)
     │                        ├── open_prs      (gh pr list)
     │                        ├── gh_assigned   (gh issue list)
     │                        └── stale_claude_files (~/.claude drift scan)
@@ -87,7 +86,9 @@ fixed commands, so parallelising it would buy nothing.
 <section stdout+stderr>
 ```
 
-Sections, in emission order: `fetch`, `local_state`, `stashes`, `worktrees`, `merged_brs`, `main_ci`, `open_prs`, `gh_assigned`, `stale_claude_files`.
+Sections, in emission order: `fetch`, `local_state`, `stashes`, `worktrees`, `merged_brs`, `open_prs`, `gh_assigned`, `stale_claude_files`.
+
+CI status is deliberately absent from the gather (#273): eager repo-wide CI cost ~104K tokens via the `actions_list` MCP fallback (no server-side reduction, overflows context) to answer a question `/end-session` rarely acts on. It is now queried on demand, scoped to the PR(s) actually touched, via `pull_request_read` `get_check_runs` — see step 3 in the command.
 
 Progress pings go to stderr (`[gather] …`) so a human watching sees something move without polluting the parseable stream on stdout.
 

--- a/home/bin/end-session-gather-state
+++ b/home/bin/end-session-gather-state
@@ -95,19 +95,11 @@ run_sh merged_brs "
       | grep -vE '^(main|master|HEAD)\$' || true
 "
 
-# shellcheck disable=SC2016  # Intentional single quotes: expansion happens inside `sh -c`.
-run_sh main_ci '
-    if ! command -v gh >/dev/null 2>&1; then
-        echo "gh-unavailable"
-        exit 1
-    fi
-    if [ "$GH_REPO_API" != "ok" ]; then
-        echo "gh-unauthorized"
-        exit 1
-    fi
-    gh run list ${REPO_SLUG:+-R "$REPO_SLUG"} --branch main --limit 10 \
-        --json status,conclusion,name,headSha,createdAt,url
-'
+# NOTE: main_ci was removed here deliberately (#273). Eager repo-wide CI
+# status cost ~104K tokens via the MCP fallback and answered a question
+# /end-session rarely acts on. CI now belongs on-demand, scoped to the PR(s)
+# actually touched this session, via the harness's GitHub tools. See
+# docs/end-session-design.md.
 
 # shellcheck disable=SC2016  # Intentional single quotes: expansion happens inside `sh -c`.
 run_sh open_prs '
@@ -192,6 +184,6 @@ printf '===fetch (exit=%s)===\n' "$FETCH_EXIT"
 cat "$TMP/fetch.out"
 printf '\n'
 
-for s in local_state stashes worktrees merged_brs main_ci open_prs gh_assigned stale_claude_files; do
+for s in local_state stashes worktrees merged_brs open_prs gh_assigned stale_claude_files; do
     [ -f "$TMP/$s.exit" ] && emit "$s"
 done

--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -138,42 +138,14 @@ run_sh local_state '
     git remote get-url origin 2>&1
 '
 
-# shellcheck disable=SC2016
-run_sh main_ci '
-    if ! command -v gh >/dev/null 2>&1; then
-        echo "gh-unavailable"
-        exit 1
-    fi
-    if [ "$GH_REPO_API" != "ok" ]; then
-        echo "gh-unauthorized"
-        exit 1
-    fi
-    if ! command -v jq >/dev/null 2>&1; then
-        echo "jq-unavailable"
-        exit 1
-    fi
-    # Parse to most-recent run per workflow on $DEFAULT_BRANCH.
-    # Output:
-    #   workflows=<N>
-    #   <name>=<conclusion-or-status>@<short-sha>           (success / in_progress / queued)
-    #   <name>=<conclusion>@<short-sha> <url>                (failure / cancelled / timed_out)
-    # The URL on failing runs lets the brief link the failing job inline; on
-    # clean-and-green sessions this is still 1-3 lines instead of a JSON dump.
-    gh run list ${REPO_SLUG:+-R "$REPO_SLUG"} --branch "$DEFAULT_BRANCH" --limit 20 \
-        --json status,conclusion,name,headSha,createdAt,url \
-      | jq -r '\''
-          group_by(.name)
-          | map(sort_by(.createdAt) | last)
-          | sort_by(.name) as $w
-          | "workflows=\($w | length)",
-            ($w[] | (
-                if (.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out")
-                then "\(.name)=\(.conclusion)@\(.headSha[0:7]) \(.url)"
-                else "\(.name)=\(.conclusion // .status)@\(.headSha[0:7])"
-                end
-            ))
-        '\''
-'
+# NOTE: main_ci was removed here deliberately (#273). Eager CI status cost
+# ~104K tokens via the MCP fallback (`actions_list` dumps every run unreduced
+# and overflows context), to answer "is the default branch red before I
+# branch?" — the least-actionable line in the brief, since a gated default
+# branch is rarely red and a push surfaces it anyway. CI is now queried
+# on-demand, scoped to the PR actually being worked, via the harness's GitHub
+# tools (a single PR's check runs, ~50-2500 tokens). See start-session.md
+# step 4 and docs/end-session-design.md.
 
 # shellcheck disable=SC2016
 run_sh gh_ready '
@@ -347,6 +319,6 @@ if [ "$FETCH_EXIT" -ne 0 ]; then
 fi
 printf '\n'
 
-for s in local_state main_ci recent_main_commits gh_ready gh_assigned claude_drift bootstrap_currency; do
+for s in local_state recent_main_commits gh_ready gh_assigned claude_drift bootstrap_currency; do
     [ -f "$TMP/$s.exit" ] && emit "$s"
 done

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -50,7 +50,7 @@ lost rather than waiting. Surface it as usual, and say so.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
-Run the parallel gather script. It does `git fetch --all --prune --tags` first, then fans out all read-only queries (status/branch/log, stashes, worktrees, merged branches, `main` CI, open PRs, assigned GitHub issues) in parallel.
+Run the parallel gather script. It does `git fetch --all --prune --tags` first, then fans out all read-only queries (status/branch/log, stashes, worktrees, merged branches, open PRs, assigned GitHub issues) in parallel. Default-branch CI is deliberately not gathered — see step 3.
 
 ```sh
 ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/end-session-gather-state
@@ -65,8 +65,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `stashes` | 9 | Exit 0 even when empty. |
 | `worktrees` | 13 | Exit 0 even when empty. |
 | `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
-| `main_ci` | 3 | Content `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Non-zero with other content = real error. |
-| `open_prs` | 8 | Same skip convention as `main_ci`. |
+| `open_prs` | 8 | Content `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = no open PRs. |
 | `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
 | `stale_claude_files` | 11 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
@@ -103,7 +102,6 @@ Apply when **all** of the following hold (single-pass check over already-collect
 - `stashes` is empty
 - `gh_assigned` is empty (or content is `not-github` / `gh-unavailable` / `gh-unauthorized`)
 - `open_prs` is empty (or content is `gh-unavailable` / `gh-unauthorized`)
-- `main_ci` has no `failure` / `cancelled` / `timed_out` line (an `in_progress` workflow is allowed — summary still surfaces it)
 - `stale_claude_files` is empty (or content is `chezmoi-unavailable`)
 - `worktrees` has exactly one entry (just the primary)
 
@@ -124,15 +122,17 @@ If **any** predicate fails, run every step as before — a messy session's narra
 
 Folded into step 1's gather. The `fetch` section contains the output. If its exit code is non-zero, stop and surface before proceeding.
 
-### 3. Check `main` CI status (Tier 1 — surface)
+### 3. Check CI on the PRs you touched — on demand (Tier 1 — surface)
 
-From gather section `main_ci`. Parse the most recent run per workflow:
+**Repo-wide default-branch CI is deliberately not gathered (#273):** the only route without `gh` is `mcp__github__actions_list`, which dumps every run unreduced (~104K tokens, overflows context), to answer a question `/end-session` rarely acts on. What matters at walk-away is whether the PR(s) you pushed this session are green — a scoped, cheap query.
 
-- **Failed**: flag loudly with `<workflow name>: <full run URL>` on its own line so the user can click straight through. The gather script already returns the URL in `main_ci` — print it inline; don't make the user chase it with a follow-up `gh run view`. A red `main` is the loudest "not clean" signal.
-- **In progress**: list with elapsed time. Means a deploy / long check is mid-flight.
-- **All green**: silent.
+For each PR you created or pushed to this run, check it with `mcp__github__pull_request_read` method `get_check_runs` (Actions report as check runs; `get_status` returns `total_count: 0` and is the wrong call). Summarise to pass/fail:
 
-If the repo has no remote, skip. On `gh-unavailable` / `gh-unauthorized`, recover via `mcp__github__actions_list` when connected; otherwise carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
+- **Failed**: flag loudly with `<workflow name>: <run URL>` on its own line. This gates the Phase 2 prompt and the walk-away summary — a red PR you own is unfinished work, not a clean exit.
+- **In progress**: note it as running; the PR isn't confirmed green yet.
+- **All green**: say so.
+
+If no PR was touched this session, skip. Never carry an unchecked CI state forward as clean — an unqueried PR reads as **unknown**, not green.
 
 ### 4. Handle uncommitted or unpushed work (Tier 3)
 
@@ -251,7 +251,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Branches pruned (squash-merged): `<list or "none">`
 - Stashed/committed work this run: `<describe or "none">`
 - Main rebased: `<yes/no, behind/ahead counts>`
-- `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow name + run URL>>`
+- CI on PRs touched this run: `<per-PR: green / running / FAILED: <workflow name + run URL>, or "no PR touched">`
 - Open PRs needing action: `<count by category, or "none">`
 - Stashes outstanding: `<count, or "none">`
 - Open issues assigned to you: `<count, or "none">`

--- a/home/commands/end-session.md
+++ b/home/commands/end-session.md
@@ -67,7 +67,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
 | `main_ci` | 3 | Content `gh-unavailable` = recover via MCP (see exit-code rules). Non-zero with other content = real error. |
 | `open_prs` | 8 | Same skip convention as `main_ci`. |
-| `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` = recover via MCP (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
+| `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` = no MCP recovery exists — report `n/a` (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
 | `stale_claude_files` | 11 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
 **On `gh` inside the gather script.** The gather runs as a shell script, so its
@@ -84,7 +84,7 @@ Rules for interpreting exit codes:
 
 - `exit=0` with empty content: clean result (no stashes, no merged branches, no in-progress issues, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover with the MCP equivalents when connected — `mcp__github__list_pull_requests` for PR state, `mcp__github__list_issues` for assigned issues — else note `n/a (gh absent)` so the walk-away summary shows what was not checked.
+- `exit != 0` with content `gh-unavailable`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected, and use the recovered data as if the gather had produced it — `mcp__github__actions_list` for `main_ci` (step 3 has the exact call shape), `mcp__github__list_pull_requests` for `open_prs` (step 8 names the one filter it cannot express). `gh_assigned` has **no MCP equivalent** — `mcp__github__list_issues` cannot filter by assignee — so that section is an honest `n/a (gh absent)`, never an empty list. Wherever MCP is also unavailable, note `n/a (gh absent)` so the walk-away summary shows what was not checked.
 - `exit != 0` with other content: real error — surface it before continuing Phase 1.
 
 ### 1.5. Fast-path when state is fully clean (Tier 1 — narration optimisation)
@@ -98,14 +98,14 @@ Apply when **all** of the following hold (single-pass check over already-collect
 - `merged_brs` is empty
 - `stashes` is empty
 - `gh_assigned` is empty (or content is `not-github` / `gh-unavailable`)
-- `open_prs` is empty (or content is `gh-unavailable`)
+- `open_prs` is empty (or content is `gh-unavailable` **and** MCP recovery per step 1's exit-code rules also came back empty or unavailable — run the recovery before evaluating this predicate)
 - `main_ci` has no `failure` / `cancelled` / `timed_out` line (an `in_progress` workflow is allowed — summary still surfaces it)
 - `stale_claude_files` is empty (or content is `chezmoi-unavailable`)
 - `worktrees` has exactly one entry (just the primary)
 
 If the predicate holds:
 
-1. Emit step 14's summary directly. Every actionable line says "none"; static lines (main rebased) reflect the already-clean state.
+1. Emit step 14's summary directly. Every actionable line says "none"; static lines (main rebased) reflect the already-clean state. A line whose section was `gh-unavailable` with no MCP recovery says `n/a (gh absent)` instead — the fast-path is a narration optimisation, not permission to report an unchecked section as clean.
 2. Do **not** narrate steps 2–13 individually. No "Step 4 — pass", no "Step 6 — nothing to prune", no per-step status lines. The summary IS the output.
 3. Phase 2's retrospective prompt still fires as today.
 
@@ -128,7 +128,7 @@ From gather section `main_ci`. Parse the most recent run per workflow:
 - **In progress**: list with elapsed time. Means a deploy / long check is mid-flight.
 - **All green**: silent.
 
-If the repo has no remote, skip. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
+If the repo has no remote, skip. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected: method `list_workflow_runs` with `workflow_runs_filter: {"branch": "main"}` and a **small `per_page` (e.g. 5)** — the default page size returns a very large payload for no extra signal. If MCP is also unavailable, carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
 
 ### 4. Handle uncommitted or unpushed work (Tier 3)
 
@@ -170,7 +170,9 @@ For each batch:
 
 If a `[gone]` branch has a non-empty diff vs `main` AND no merged PR is found via `gh`, surface it by name ("`feat/x` — upstream gone but diffs against `main` and no merged PR found, left alone") so the user can decide manually. Don't roll it into Batch B — the safety net protects the auto-delete path too.
 
-For remote-tracking refs, `git fetch --prune` in step 2 already handled stale `origin/*` refs. Don't delete anything on the remote itself.
+Where `gh` is absent (cloud sandbox), the script's merged-PR fallback silently never fires, so a squash-merged branch with post-squash drift lands in that surfaced pile instead of Batch B. Before presenting it as unresolved, check the same signal via MCP: `mcp__github__list_pull_requests` with `state: "closed"` and `head: "<owner>:<branch>"`, treating a returned PR with `merged_at` set as the merged-PR signal. On a hit, the branch joins Batch B under the usual single y/n; on a miss (or MCP unavailable), surface it by name as above.
+
+For remote-tracking refs, `git fetch --prune` in step 2 already handled stale `origin/*` refs. Don't delete anything on the remote itself — prefer deletion to happen server-side at merge time (`delete_branch: true` on the merge call), so no session ever pushes a ref deletion. In a cloud sandbox that preference is a hard limit: **the git proxy refuses remote ref deletion** — `git push origin --delete <branch>` dies with a generic `unexpected disconnect` that looks like a network blip, and the GitHub MCP server has no delete-branch tool either (see [pmgledhill102/agentic-coding-config#252](https://github.com/pmgledhill102/agentic-coding-config/issues/252)). If a remote branch genuinely needs deleting on that surface, put it in the step 14 summary as "could not prune: `<branch>` — ref deletion refused by sandbox git proxy (#252)" and leave it for the user. Never retry until it "works", and never report the prune as done.
 
 ### 7. Push main if ahead (Tier 2 — prompt)
 
@@ -184,7 +186,7 @@ If main is ahead of origin/main (shouldn't normally happen, but catches the case
 
 ### 8. Open PRs needing your action (Tier 3 — surface only)
 
-From gather section `open_prs`. If the section content is `gh-unavailable`, either skip or fall back to `mcp__github__list_pull_requests` (state=open, head filter) — the MCP path doesn't need `gh` on PATH.
+From gather section `open_prs`. On `gh-unavailable`, recover via `mcp__github__list_pull_requests` (`state: "open"`) when the GitHub MCP server is connected — the MCP path doesn't need `gh` on PATH. One honest difference: the gather filters to `--author @me`, and `list_pull_requests` has no author filter, so the recovery lists **all** open PRs on the repo — equivalent on a personal repo, worth a caveat line anywhere it isn't. If MCP is also unavailable, report `n/a (gh absent)` rather than skipping silently.
 
 Categorise and present:
 
@@ -202,9 +204,9 @@ From gather section `stashes`. If non-empty, surface count + entries. Don't drop
 
 ### 10. Open issues assigned to you (Tier 3 — surface)
 
-From gather section `gh_assigned` (silently skipped when the repo has no github.com origin or `gh` / `jq` is unavailable). Each line is `#<n> <title>` — an open GitHub issue assigned to you. Surface count + numbers/titles. User decides which to close — common forgetfulness pattern.
+From gather section `gh_assigned` (silently skipped when the repo has no github.com origin or `jq` is unavailable). On `gh-unavailable` there is **no MCP recovery**: `mcp__github__list_issues` cannot filter by assignee, so this line is an honest `n/a (gh absent)` — an unchecked list must never read as "nothing assigned". Otherwise each line is `#<n> <title>` — an open GitHub issue assigned to you. Surface count + numbers/titles. User decides which to close — common forgetfulness pattern.
 
-Issues whose work merged this session via a `Closes #<n>` reference in the PR body are closed automatically by GitHub on merge, so they won't appear here. Anything listed is genuinely still outstanding — if a listed issue actually shipped without the `Closes #<n>` trailer, suggest `gh issue close <n> --comment "Shipped in #<pr>"`.
+Issues whose work merged this session via a `Closes #<n>` reference in the PR body are closed automatically by GitHub on merge, so they won't appear here. Anything listed is genuinely still outstanding — if a listed issue actually shipped without the `Closes #<n>` trailer, suggest closing it: `gh issue close <n> --comment "Shipped in #<pr>"`, or where `gh` is absent, `mcp__github__add_issue_comment` followed by `mcp__github__issue_write` (method `update`, `state: "closed"`, `state_reason: "completed"`).
 
 ### 11. Stale Claude commands/bin files (Tier 1 — surface)
 
@@ -247,10 +249,10 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Branches pruned (squash-merged): `<list or "none">`
 - Stashed/committed work this run: `<describe or "none">`
 - Main rebased: `<yes/no, behind/ahead counts>`
-- `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow name + run URL>>`
-- Open PRs needing action: `<count by category, or "none">`
+- `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow name + run URL> / unknown (gh absent)>`
+- Open PRs needing action: `<count by category, "none", or "n/a (gh absent)">`
 - Stashes outstanding: `<count, or "none">`
-- Open issues assigned to you: `<count, or "none">`
+- Open issues assigned to you: `<count, "none", or "n/a (gh absent)">`
 - Stale `~/.claude/` files: `<count, or "none" / "n/a (no chezmoi)">`
 - Other worktrees: `<count, or "none">`
 - Background processes (reaped): `<count>`
@@ -275,7 +277,7 @@ On `n`: stop. The session is tidied; the user can run `/retrospective` later if 
 
 ## Guardrails
 
-- **`-D` (force delete) is allowed only for Batch B of step 6** — branches that are `[upstream: gone]` AND have an empty `git diff` against `main` (or a merged PR via `gh`). Everywhere else: always `-d`. If `-d` refuses, that's signal — surface it, don't override.
+- **`-D` (force delete) is allowed only for Batch B of step 6** — branches that are `[upstream: gone]` AND have an empty `git diff` against `main` (or a merged PR, found via `gh` in the script or via the step 6 MCP recovery). Everywhere else: always `-d`. If `-d` refuses, that's signal — surface it, don't override.
 - **Never `git push --force` or `git reset --hard`.** Those aren't session-tidy operations; if they're needed, the user should drive them.
 - **Never auto-merge PRs, auto-close issues, or auto-drop stashes.** Per-item judgment lives with the user (Tier 3).
 - **Ask before every Tier 2 destructive action** (branch deletes, force-pushing). One y/n per batch is fine — don't ask per-branch if a single list is presented. There is no way to skip the prompt: a repo that wants different behaviour states it in its own `CLAUDE.md`.

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -79,7 +79,12 @@ Rules for interpreting exit codes:
 - `exit=0` with empty content: clean result (no ready work, nothing assigned, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
 - `exit != 0` with content `not-github` or `jq-unavailable`: silent skip.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
+- `exit != 0` with content `gh-unavailable`: **not silent.** Recover each section with its MCP equivalent when the GitHub MCP server is connected. These mappings are verified, not aspirational — measured on a live cloud sandbox 2026-08-19 (see [#257](https://github.com/pmgledhill102/agentic-coding-config/issues/257)):
+  - `main_ci` → `mcp__github__actions_list`, method `list_workflow_runs`, `workflow_runs_filter` `{"branch": "<default>"}`. **Size hazard**: the unfiltered response for even a modest repo measured ~417KB, which the harness saves to a file instead of returning inline — expect to parse the saved result. Always pass a small `perPage` (5 is plenty; step 4 only needs the most recent run per workflow).
+  - `gh_ready` → `mcp__github__list_issues` with `state: OPEN` and `fields: ["number","title","labels","state"]` — verified to work cleanly. One gap: the tool cannot express `-is:blocked`, so the recovered list is **unfiltered for blocked issues**. The brief must say so (see step 7) rather than presenting it as the ready list.
+  - `gh_assigned` → **no MCP recovery exists**: `mcp__github__list_issues` cannot filter by assignee. Report `n/a (assignee filter not available via MCP)` in the brief — an honest gap, never an empty "nothing in flight".
+
+  Use recovered data as if the gather had produced it, caveats included. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
 - `exit != 0` with other content: real error — surface it before continuing.
 
 ### 2. Surface fetch result (Tier 1)
@@ -117,7 +122,7 @@ From gather section `main_ci`. The script has already deduplicated to one most-r
 - **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
 - **All `success`**: silent (the brief reports "green").
 
-If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
+If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` (method `list_workflow_runs`, branch-filtered, small `perPage` — details and the response-size hazard are in the exit-code rules above) when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
 
 ### 5. Recent merges to `<default>` (Tier 1 — surface)
 
@@ -239,8 +244,8 @@ Needs attention:
 Rules:
 
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
-- "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work.
-- "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items).
+- "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work. When the section was MCP-recovered, no blocked filter was applied at all — retitle it `Open issues (blocked filter unavailable):` so the reader knows some rows may be blocked.
+- "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items). When the gather reported `gh-unavailable`, this line is `n/a (assignee filter not available via MCP)` — MCP cannot recover this section.
 - "Recent merges" is sourced from gather section `recent_main_commits`. Omit the entire section when `count=0`.
 - If the repo has no GitHub origin (`gh_ready` / `gh_assigned` report `not-github` or are skipped), drop both issue sections silently (the brief still shows git/CI lines).
 - Truncate any title to ~78 columns to keep rows on one line.

--- a/home/commands/start-session.md
+++ b/home/commands/start-session.md
@@ -44,7 +44,7 @@ this command makes **no standalone Bash calls before the gather**.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
-Run the parallel gather script. It does `git fetch --all --prune --tags` first, resolves the repo's default branch, then fans out all read-only queries (local branch state, `main` CI, ready/assigned GitHub issues) in parallel. The script compacts each section's output to keep model-visible context cost low: `fetch`'s body is suppressed on success, and `main_ci` is parsed in-script to one line per workflow.
+Run the parallel gather script. It does `git fetch --all --prune --tags` first, resolves the repo's default branch, then fans out all read-only queries (local branch state, ready/assigned GitHub issues) in parallel. The script compacts each section's output to keep model-visible context cost low: `fetch`'s body is suppressed on success. Default-branch CI is deliberately **not** gathered here — see step 4 for why, and for the on-demand alternative.
 
 ```sh
 ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/start-session-gather-state
@@ -57,7 +57,6 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
-| `main_ci` | 4 | Content `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |
 | `gh_ready` | 7 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
 | `gh_assigned` | 7 | Same skip convention as `gh_ready`. Empty content = nothing in flight. Otherwise pipe-separated rows: `#<n>\|P<pri>\|<title>` for open issues assigned to me (usually 0-3). Same row shape as `gh_ready`. |
@@ -83,7 +82,7 @@ Rules for interpreting exit codes:
 - `exit=0` with empty content: clean result (no ready work, nothing assigned, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
 - `exit != 0` with content `not-github` or `jq-unavailable`: silent skip.
-- `exit != 0` with content `gh-unavailable` or `gh-unauthorized`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
+- `exit != 0` with content `gh-unavailable` or `gh-unauthorized`: **not silent.** Recover the section with `mcp__github__list_issues` (for `gh_ready` / `gh_assigned`) when the GitHub MCP server is connected, and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
 - `exit != 0` with other content: real error — surface it before continuing.
 
 ### 2. Surface fetch result (Tier 1)
@@ -113,15 +112,14 @@ Read `local_state`, including the `upstream_status` line (`alive` / `gone` / `no
 
 Don't switch branches outside of the auto-switch case above.
 
-### 4. `main` CI status (Tier 1 — surface)
+### 4. CI status — on demand, not gathered (Tier 1)
 
-From gather section `main_ci`. The script has already deduplicated to one most-recent run per workflow on `<default>` and emitted compact lines: `<workflow-name>=<conclusion-or-status>@<short-sha>`. Failing runs include the URL on the same line: `<workflow-name>=<conclusion>@<short-sha> <url>`.
+**Default-branch CI is deliberately not fetched at session start (#273).** It was the least-actionable line in the brief — a gated default branch is rarely red, and a push surfaces a break within one cycle anyway — yet the most expensive to gather: the only route on a surface without `gh` is `mcp__github__actions_list`, which dumps every workflow run unreduced (~104K tokens, enough to overflow context) because it has no server-side field selection. Paying that every session to pre-answer a question nobody usually acts on is the opposite of what this gather is for.
 
-- **Any line where `<conclusion-or-status>` is `failure` / `cancelled` / `timed_out`**: flag in the session brief with workflow name + short-sha + run URL (the URL is on the same line — surface it inline so the user can click straight through). A red default branch is the loudest "not clean" signal — call it out before the user starts new work.
-- **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
-- **All `success`**: silent (the brief reports "green").
+So the brief carries no CI line. When CI status actually matters — you are about to build on the default branch and want to know it is green, or you are checking a PR you just pushed — query it **scoped, on demand**:
 
-If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable` / `gh-unauthorized`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
+- **A specific PR** (the common case): `mcp__github__pull_request_read` with method `get_check_runs` (GitHub Actions report as check runs, not the legacy combined status, so `get_status` shows `total_count: 0` and is the wrong call here). One PR's check runs are a few KB — summarise to pass/fail counts and surface only failures.
+- **The default branch with no PR**: the head commit's checks via the same tool against the relevant PR, or `mcp__github__actions_list` filtered to a single workflow if you genuinely need the repo-wide picture — but reach for that only when asked, given its cost.
 
 ### 5. Recent merges to `<default>` (Tier 1 — surface)
 
@@ -215,7 +213,6 @@ Always print, even when everything is clean. This is the user-facing payoff — 
 Repo:     <repo>             Branch: <branch> (<clean|dirty>)
 Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
-CI:       <green / N failing / N in-progress / n/a>
 
 Recent merges:                                      (omit when count=0)
   <short-sha>  <commit subject>
@@ -230,7 +227,6 @@ Ready to pick up next:
 
 Needs attention:
   • <pending journal drafts: N>    (omit when 0 / not paul-context)
-  • <main CI red on workflow X>    (omit when green)
   • <feature branch behind main by N>          (omit when on default, even, or auto-switched)
   • <branch upstream gone but tree dirty>      (omit unless that case fires)
   • ~/.claude is behind the repo on N file(s): <paths> — run `chezmoi apply --refresh-externals`

--- a/home/skills/end-session/SKILL.md
+++ b/home/skills/end-session/SKILL.md
@@ -72,7 +72,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
 | `main_ci` | 3 | Content `gh-unavailable` = recover via MCP (see exit-code rules). Non-zero with other content = real error. |
 | `open_prs` | 8 | Same skip convention as `main_ci`. |
-| `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` = recover via MCP (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
+| `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` = no MCP recovery exists — report `n/a` (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
 | `stale_claude_files` | 11 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
 **On `gh` inside the gather script.** The gather runs as a shell script, so its
@@ -89,7 +89,7 @@ Rules for interpreting exit codes:
 
 - `exit=0` with empty content: clean result (no stashes, no merged branches, no in-progress issues, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover with the MCP equivalents when connected — `mcp__github__list_pull_requests` for PR state, `mcp__github__list_issues` for assigned issues — else note `n/a (gh absent)` so the walk-away summary shows what was not checked.
+- `exit != 0` with content `gh-unavailable`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected, and use the recovered data as if the gather had produced it — `mcp__github__actions_list` for `main_ci` (step 3 has the exact call shape), `mcp__github__list_pull_requests` for `open_prs` (step 8 names the one filter it cannot express). `gh_assigned` has **no MCP equivalent** — `mcp__github__list_issues` cannot filter by assignee — so that section is an honest `n/a (gh absent)`, never an empty list. Wherever MCP is also unavailable, note `n/a (gh absent)` so the walk-away summary shows what was not checked.
 - `exit != 0` with other content: real error — surface it before continuing Phase 1.
 
 ### 1.5. Fast-path when state is fully clean (Tier 1 — narration optimisation)
@@ -103,14 +103,14 @@ Apply when **all** of the following hold (single-pass check over already-collect
 - `merged_brs` is empty
 - `stashes` is empty
 - `gh_assigned` is empty (or content is `not-github` / `gh-unavailable`)
-- `open_prs` is empty (or content is `gh-unavailable`)
+- `open_prs` is empty (or content is `gh-unavailable` **and** MCP recovery per step 1's exit-code rules also came back empty or unavailable — run the recovery before evaluating this predicate)
 - `main_ci` has no `failure` / `cancelled` / `timed_out` line (an `in_progress` workflow is allowed — summary still surfaces it)
 - `stale_claude_files` is empty (or content is `chezmoi-unavailable`)
 - `worktrees` has exactly one entry (just the primary)
 
 If the predicate holds:
 
-1. Emit step 14's summary directly. Every actionable line says "none"; static lines (main rebased) reflect the already-clean state.
+1. Emit step 14's summary directly. Every actionable line says "none"; static lines (main rebased) reflect the already-clean state. A line whose section was `gh-unavailable` with no MCP recovery says `n/a (gh absent)` instead — the fast-path is a narration optimisation, not permission to report an unchecked section as clean.
 2. Do **not** narrate steps 2–13 individually. No "Step 4 — pass", no "Step 6 — nothing to prune", no per-step status lines. The summary IS the output.
 3. Phase 2's retrospective prompt still fires as today.
 
@@ -133,7 +133,7 @@ From gather section `main_ci`. Parse the most recent run per workflow:
 - **In progress**: list with elapsed time. Means a deploy / long check is mid-flight.
 - **All green**: silent.
 
-If the repo has no remote, skip. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
+If the repo has no remote, skip. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected: method `list_workflow_runs` with `workflow_runs_filter: {"branch": "main"}` and a **small `per_page` (e.g. 5)** — the default page size returns a very large payload for no extra signal. If MCP is also unavailable, carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
 
 ### 4. Handle uncommitted or unpushed work (Tier 3)
 
@@ -175,7 +175,9 @@ For each batch:
 
 If a `[gone]` branch has a non-empty diff vs `main` AND no merged PR is found via `gh`, surface it by name ("`feat/x` — upstream gone but diffs against `main` and no merged PR found, left alone") so the user can decide manually. Don't roll it into Batch B — the safety net protects the auto-delete path too.
 
-For remote-tracking refs, `git fetch --prune` in step 2 already handled stale `origin/*` refs. Don't delete anything on the remote itself.
+Where `gh` is absent (cloud sandbox), the script's merged-PR fallback silently never fires, so a squash-merged branch with post-squash drift lands in that surfaced pile instead of Batch B. Before presenting it as unresolved, check the same signal via MCP: `mcp__github__list_pull_requests` with `state: "closed"` and `head: "<owner>:<branch>"`, treating a returned PR with `merged_at` set as the merged-PR signal. On a hit, the branch joins Batch B under the usual single y/n; on a miss (or MCP unavailable), surface it by name as above.
+
+For remote-tracking refs, `git fetch --prune` in step 2 already handled stale `origin/*` refs. Don't delete anything on the remote itself — prefer deletion to happen server-side at merge time (`delete_branch: true` on the merge call), so no session ever pushes a ref deletion. In a cloud sandbox that preference is a hard limit: **the git proxy refuses remote ref deletion** — `git push origin --delete <branch>` dies with a generic `unexpected disconnect` that looks like a network blip, and the GitHub MCP server has no delete-branch tool either (see [pmgledhill102/agentic-coding-config#252](https://github.com/pmgledhill102/agentic-coding-config/issues/252)). If a remote branch genuinely needs deleting on that surface, put it in the step 14 summary as "could not prune: `<branch>` — ref deletion refused by sandbox git proxy (#252)" and leave it for the user. Never retry until it "works", and never report the prune as done.
 
 ### 7. Push main if ahead (Tier 2 — prompt)
 
@@ -189,7 +191,7 @@ If main is ahead of origin/main (shouldn't normally happen, but catches the case
 
 ### 8. Open PRs needing your action (Tier 3 — surface only)
 
-From gather section `open_prs`. If the section content is `gh-unavailable`, either skip or fall back to `mcp__github__list_pull_requests` (state=open, head filter) — the MCP path doesn't need `gh` on PATH.
+From gather section `open_prs`. On `gh-unavailable`, recover via `mcp__github__list_pull_requests` (`state: "open"`) when the GitHub MCP server is connected — the MCP path doesn't need `gh` on PATH. One honest difference: the gather filters to `--author @me`, and `list_pull_requests` has no author filter, so the recovery lists **all** open PRs on the repo — equivalent on a personal repo, worth a caveat line anywhere it isn't. If MCP is also unavailable, report `n/a (gh absent)` rather than skipping silently.
 
 Categorise and present:
 
@@ -207,9 +209,9 @@ From gather section `stashes`. If non-empty, surface count + entries. Don't drop
 
 ### 10. Open issues assigned to you (Tier 3 — surface)
 
-From gather section `gh_assigned` (silently skipped when the repo has no github.com origin or `gh` / `jq` is unavailable). Each line is `#<n> <title>` — an open GitHub issue assigned to you. Surface count + numbers/titles. User decides which to close — common forgetfulness pattern.
+From gather section `gh_assigned` (silently skipped when the repo has no github.com origin or `jq` is unavailable). On `gh-unavailable` there is **no MCP recovery**: `mcp__github__list_issues` cannot filter by assignee, so this line is an honest `n/a (gh absent)` — an unchecked list must never read as "nothing assigned". Otherwise each line is `#<n> <title>` — an open GitHub issue assigned to you. Surface count + numbers/titles. User decides which to close — common forgetfulness pattern.
 
-Issues whose work merged this session via a `Closes #<n>` reference in the PR body are closed automatically by GitHub on merge, so they won't appear here. Anything listed is genuinely still outstanding — if a listed issue actually shipped without the `Closes #<n>` trailer, suggest `gh issue close <n> --comment "Shipped in #<pr>"`.
+Issues whose work merged this session via a `Closes #<n>` reference in the PR body are closed automatically by GitHub on merge, so they won't appear here. Anything listed is genuinely still outstanding — if a listed issue actually shipped without the `Closes #<n>` trailer, suggest closing it: `gh issue close <n> --comment "Shipped in #<pr>"`, or where `gh` is absent, `mcp__github__add_issue_comment` followed by `mcp__github__issue_write` (method `update`, `state: "closed"`, `state_reason: "completed"`).
 
 ### 11. Stale Claude commands/bin files (Tier 1 — surface)
 
@@ -252,10 +254,10 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Branches pruned (squash-merged): `<list or "none">`
 - Stashed/committed work this run: `<describe or "none">`
 - Main rebased: `<yes/no, behind/ahead counts>`
-- `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow name + run URL>>`
-- Open PRs needing action: `<count by category, or "none">`
+- `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow name + run URL> / unknown (gh absent)>`
+- Open PRs needing action: `<count by category, "none", or "n/a (gh absent)">`
 - Stashes outstanding: `<count, or "none">`
-- Open issues assigned to you: `<count, or "none">`
+- Open issues assigned to you: `<count, "none", or "n/a (gh absent)">`
 - Stale `~/.claude/` files: `<count, or "none" / "n/a (no chezmoi)">`
 - Other worktrees: `<count, or "none">`
 - Background processes (reaped): `<count>`
@@ -280,7 +282,7 @@ On `n`: stop. The session is tidied; the user can run `retrospective` later if t
 
 ## Guardrails
 
-- **`-D` (force delete) is allowed only for Batch B of step 6** — branches that are `[upstream: gone]` AND have an empty `git diff` against `main` (or a merged PR via `gh`). Everywhere else: always `-d`. If `-d` refuses, that's signal — surface it, don't override.
+- **`-D` (force delete) is allowed only for Batch B of step 6** — branches that are `[upstream: gone]` AND have an empty `git diff` against `main` (or a merged PR, found via `gh` in the script or via the step 6 MCP recovery). Everywhere else: always `-d`. If `-d` refuses, that's signal — surface it, don't override.
 - **Never `git push --force` or `git reset --hard`.** Those aren't session-tidy operations; if they're needed, the user should drive them.
 - **Never auto-merge PRs, auto-close issues, or auto-drop stashes.** Per-item judgment lives with the user (Tier 3).
 - **Ask before every Tier 2 destructive action** (branch deletes, force-pushing). One y/n per batch is fine — don't ask per-branch if a single list is presented. There is no way to skip the prompt: a repo that wants different behaviour states it in its own `CLAUDE.md`.

--- a/home/skills/end-session/SKILL.md
+++ b/home/skills/end-session/SKILL.md
@@ -55,7 +55,7 @@ lost rather than waiting. Surface it as usual, and say so.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
-Run the parallel gather script. It does `git fetch --all --prune --tags` first, then fans out all read-only queries (status/branch/log, stashes, worktrees, merged branches, `main` CI, open PRs, assigned GitHub issues) in parallel.
+Run the parallel gather script. It does `git fetch --all --prune --tags` first, then fans out all read-only queries (status/branch/log, stashes, worktrees, merged branches, open PRs, assigned GitHub issues) in parallel. Default-branch CI is deliberately not gathered — see step 3.
 
 ```sh
 ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/end-session-gather-state
@@ -70,8 +70,7 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `stashes` | 9 | Exit 0 even when empty. |
 | `worktrees` | 13 | Exit 0 even when empty. |
 | `merged_brs` | 6 Batch A | Script appends `\|\| true` — exit 0 even if no matches. |
-| `main_ci` | 3 | Content `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Non-zero with other content = real error. |
-| `open_prs` | 8 | Same skip convention as `main_ci`. |
+| `open_prs` | 8 | Content `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = no open PRs. |
 | `gh_assigned` | 10 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = nothing in flight. Otherwise one `#<n> <title>` line per open issue assigned to me. |
 | `stale_claude_files` | 11 | Content `chezmoi-unavailable` = silent skip. Empty body (exit=0) = nothing stale. Otherwise: one path per line under `.claude/commands/` or `.claude/bin/` that's present locally but not tracked by chezmoi. |
 
@@ -108,7 +107,6 @@ Apply when **all** of the following hold (single-pass check over already-collect
 - `stashes` is empty
 - `gh_assigned` is empty (or content is `not-github` / `gh-unavailable` / `gh-unauthorized`)
 - `open_prs` is empty (or content is `gh-unavailable` / `gh-unauthorized`)
-- `main_ci` has no `failure` / `cancelled` / `timed_out` line (an `in_progress` workflow is allowed — summary still surfaces it)
 - `stale_claude_files` is empty (or content is `chezmoi-unavailable`)
 - `worktrees` has exactly one entry (just the primary)
 
@@ -129,15 +127,17 @@ If **any** predicate fails, run every step as before — a messy session's narra
 
 Folded into step 1's gather. The `fetch` section contains the output. If its exit code is non-zero, stop and surface before proceeding.
 
-### 3. Check `main` CI status (Tier 1 — surface)
+### 3. Check CI on the PRs you touched — on demand (Tier 1 — surface)
 
-From gather section `main_ci`. Parse the most recent run per workflow:
+**Repo-wide default-branch CI is deliberately not gathered (#273):** the only route without `gh` is `mcp__github__actions_list`, which dumps every run unreduced (~104K tokens, overflows context), to answer a question `end-session` rarely acts on. What matters at walk-away is whether the PR(s) you pushed this session are green — a scoped, cheap query.
 
-- **Failed**: flag loudly with `<workflow name>: <full run URL>` on its own line so the user can click straight through. The gather script already returns the URL in `main_ci` — print it inline; don't make the user chase it with a follow-up `gh run view`. A red `main` is the loudest "not clean" signal.
-- **In progress**: list with elapsed time. Means a deploy / long check is mid-flight.
-- **All green**: silent.
+For each PR you created or pushed to this run, check it with `mcp__github__pull_request_read` method `get_check_runs` (Actions report as check runs; `get_status` returns `total_count: 0` and is the wrong call). Summarise to pass/fail:
 
-If the repo has no remote, skip. On `gh-unavailable` / `gh-unauthorized`, recover via `mcp__github__actions_list` when connected; otherwise carry the state forward as **unknown**, not clean — this result gates the Phase 2 prompt, and an unchecked CI state should read as unchecked, never as green.
+- **Failed**: flag loudly with `<workflow name>: <run URL>` on its own line. This gates the Phase 2 prompt and the walk-away summary — a red PR you own is unfinished work, not a clean exit.
+- **In progress**: note it as running; the PR isn't confirmed green yet.
+- **All green**: say so.
+
+If no PR was touched this session, skip. Never carry an unchecked CI state forward as clean — an unqueried PR reads as **unknown**, not green.
 
 ### 4. Handle uncommitted or unpushed work (Tier 3)
 
@@ -256,7 +256,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Branches pruned (squash-merged): `<list or "none">`
 - Stashed/committed work this run: `<describe or "none">`
 - Main rebased: `<yes/no, behind/ahead counts>`
-- `main` CI status: `<green / running: N (<workflow names>) / FAILED: <workflow name + run URL>>`
+- CI on PRs touched this run: `<per-PR: green / running / FAILED: <workflow name + run URL>, or "no PR touched">`
 - Open PRs needing action: `<count by category, or "none">`
 - Stashes outstanding: `<count, or "none">`
 - Open issues assigned to you: `<count, or "none">`

--- a/home/skills/start-session/SKILL.md
+++ b/home/skills/start-session/SKILL.md
@@ -49,7 +49,7 @@ this command makes **no standalone Bash calls before the gather**.
 
 ### 1. Gather state (Tier 1 — one tool call)
 
-Run the parallel gather script. It does `git fetch --all --prune --tags` first, resolves the repo's default branch, then fans out all read-only queries (local branch state, `main` CI, ready/assigned GitHub issues) in parallel. The script compacts each section's output to keep model-visible context cost low: `fetch`'s body is suppressed on success, and `main_ci` is parsed in-script to one line per workflow.
+Run the parallel gather script. It does `git fetch --all --prune --tags` first, resolves the repo's default branch, then fans out all read-only queries (local branch state, ready/assigned GitHub issues) in parallel. The script compacts each section's output to keep model-visible context cost low: `fetch`'s body is suppressed on success. Default-branch CI is deliberately **not** gathered here — see step 4 for why, and for the on-demand alternative.
 
 ```sh
 ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/start-session-gather-state
@@ -62,7 +62,6 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 | `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
-| `main_ci` | 4 | Content `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Otherwise: first line is `workflows=<N>`; subsequent lines are `<workflow-name>=<conclusion-or-status>@<short-sha>` (one per most-recent run per workflow on `<default>`). On `failure` / `cancelled` / `timed_out`, the line ends with a trailing space-separated run URL: `<workflow-name>=<conclusion>@<short-sha> <url>`. Non-zero with other content = real error. |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |
 | `gh_ready` | 7 | Content `not-github` / `jq-unavailable` = silent skip; `gh-unavailable` / `gh-unauthorized` = recover via MCP (see exit-code rules). Empty content = no ready work. Otherwise up to 10 pipe-separated rows: `#<n>\|P<pri>\|<title>` (priority `-` when the issue has no `P0`–`P4` label). Ready = open and not directly blocked (`gh issue list --search "is:open -is:blocked"`) — direct blocks only, no transitive query. Already pre-summarised — use rows directly in the brief without further parsing. |
 | `gh_assigned` | 7 | Same skip convention as `gh_ready`. Empty content = nothing in flight. Otherwise pipe-separated rows: `#<n>\|P<pri>\|<title>` for open issues assigned to me (usually 0-3). Same row shape as `gh_ready`. |
@@ -88,7 +87,7 @@ Rules for interpreting exit codes:
 - `exit=0` with empty content: clean result (no ready work, nothing assigned, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
 - `exit != 0` with content `not-github` or `jq-unavailable`: silent skip.
-- `exit != 0` with content `gh-unavailable` or `gh-unauthorized`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
+- `exit != 0` with content `gh-unavailable` or `gh-unauthorized`: **not silent.** Recover the section with `mcp__github__list_issues` (for `gh_ready` / `gh_assigned`) when the GitHub MCP server is connected, and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
 - `exit != 0` with other content: real error — surface it before continuing.
 
 ### 2. Surface fetch result (Tier 1)
@@ -118,15 +117,14 @@ Read `local_state`, including the `upstream_status` line (`alive` / `gone` / `no
 
 Don't switch branches outside of the auto-switch case above.
 
-### 4. `main` CI status (Tier 1 — surface)
+### 4. CI status — on demand, not gathered (Tier 1)
 
-From gather section `main_ci`. The script has already deduplicated to one most-recent run per workflow on `<default>` and emitted compact lines: `<workflow-name>=<conclusion-or-status>@<short-sha>`. Failing runs include the URL on the same line: `<workflow-name>=<conclusion>@<short-sha> <url>`.
+**Default-branch CI is deliberately not fetched at session start (#273).** It was the least-actionable line in the brief — a gated default branch is rarely red, and a push surfaces a break within one cycle anyway — yet the most expensive to gather: the only route on a surface without `gh` is `mcp__github__actions_list`, which dumps every workflow run unreduced (~104K tokens, enough to overflow context) because it has no server-side field selection. Paying that every session to pre-answer a question nobody usually acts on is the opposite of what this gather is for.
 
-- **Any line where `<conclusion-or-status>` is `failure` / `cancelled` / `timed_out`**: flag in the session brief with workflow name + short-sha + run URL (the URL is on the same line — surface it inline so the user can click straight through). A red default branch is the loudest "not clean" signal — call it out before the user starts new work.
-- **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
-- **All `success`**: silent (the brief reports "green").
+So the brief carries no CI line. When CI status actually matters — you are about to build on the default branch and want to know it is green, or you are checking a PR you just pushed — query it **scoped, on demand**:
 
-If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable` / `gh-unauthorized`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
+- **A specific PR** (the common case): `mcp__github__pull_request_read` with method `get_check_runs` (GitHub Actions report as check runs, not the legacy combined status, so `get_status` shows `total_count: 0` and is the wrong call here). One PR's check runs are a few KB — summarise to pass/fail counts and surface only failures.
+- **The default branch with no PR**: the head commit's checks via the same tool against the relevant PR, or `mcp__github__actions_list` filtered to a single workflow if you genuinely need the repo-wide picture — but reach for that only when asked, given its cost.
 
 ### 5. Recent merges to `<default>` (Tier 1 — surface)
 
@@ -220,7 +218,6 @@ Always print, even when everything is clean. This is the user-facing payoff — 
 Repo:     <repo>             Branch: <branch> (<clean|dirty>)
 Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
-CI:       <green / N failing / N in-progress / n/a>
 
 Recent merges:                                      (omit when count=0)
   <short-sha>  <commit subject>
@@ -235,7 +232,6 @@ Ready to pick up next:
 
 Needs attention:
   • <pending journal drafts: N>    (omit when 0 / not paul-context)
-  • <main CI red on workflow X>    (omit when green)
   • <feature branch behind main by N>          (omit when on default, even, or auto-switched)
   • <branch upstream gone but tree dirty>      (omit unless that case fires)
   • ~/.claude is behind the repo on N file(s): <paths> — run `chezmoi apply --refresh-externals`

--- a/home/skills/start-session/SKILL.md
+++ b/home/skills/start-session/SKILL.md
@@ -84,7 +84,12 @@ Rules for interpreting exit codes:
 - `exit=0` with empty content: clean result (no ready work, nothing assigned, etc.). Treat as "none".
 - `exit=0` with content: normal data — parse it for the relevant step.
 - `exit != 0` with content `not-github` or `jq-unavailable`: silent skip.
-- `exit != 0` with content `gh-unavailable`: **not silent.** Recover the section with the MCP equivalents when the GitHub MCP server is connected — `mcp__github__actions_list` for `main_ci`, `mcp__github__list_issues` for `gh_ready` / `gh_assigned` — and use the recovered data as if the gather had produced it. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
+- `exit != 0` with content `gh-unavailable`: **not silent.** Recover each section with its MCP equivalent when the GitHub MCP server is connected. These mappings are verified, not aspirational — measured on a live cloud sandbox 2026-08-19 (see [#257](https://github.com/pmgledhill102/agentic-coding-config/issues/257)):
+  - `main_ci` → `mcp__github__actions_list`, method `list_workflow_runs`, `workflow_runs_filter` `{"branch": "<default>"}`. **Size hazard**: the unfiltered response for even a modest repo measured ~417KB, which the harness saves to a file instead of returning inline — expect to parse the saved result. Always pass a small `perPage` (5 is plenty; step 4 only needs the most recent run per workflow).
+  - `gh_ready` → `mcp__github__list_issues` with `state: OPEN` and `fields: ["number","title","labels","state"]` — verified to work cleanly. One gap: the tool cannot express `-is:blocked`, so the recovered list is **unfiltered for blocked issues**. The brief must say so (see step 7) rather than presenting it as the ready list.
+  - `gh_assigned` → **no MCP recovery exists**: `mcp__github__list_issues` cannot filter by assignee. Report `n/a (assignee filter not available via MCP)` in the brief — an honest gap, never an empty "nothing in flight".
+
+  Use recovered data as if the gather had produced it, caveats included. Only when MCP is also unavailable, report `n/a (gh absent)` in the brief, so a thin brief reads as "not gathered", never as "all clear".
 - `exit != 0` with other content: real error — surface it before continuing.
 
 ### 2. Surface fetch result (Tier 1)
@@ -122,7 +127,7 @@ From gather section `main_ci`. The script has already deduplicated to one most-r
 - **Any line where `<conclusion-or-status>` is `in_progress`**: list with the short-sha. (Elapsed time is no longer captured — gather doesn't track createdAt in the compact form. If you need it, run `gh run list` directly.)
 - **All `success`**: silent (the brief reports "green").
 
-If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
+If the content is `jq-unavailable` or the repo has no remote, report `n/a`. On `gh-unavailable`, recover via `mcp__github__actions_list` (method `list_workflow_runs`, branch-filtered, small `perPage` — details and the response-size hazard are in the exit-code rules above) when connected; otherwise report `n/a (gh absent)` — never let an ungathered section read as "green".
 
 ### 5. Recent merges to `<default>` (Tier 1 — surface)
 
@@ -244,8 +249,8 @@ Needs attention:
 Rules:
 
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
-- "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work.
-- "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items).
+- "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work. When the section was MCP-recovered, no blocked filter was applied at all — retitle it `Open issues (blocked filter unavailable):` so the reader knows some rows may be blocked.
+- "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items). When the gather reported `gh-unavailable`, this line is `n/a (assignee filter not available via MCP)` — MCP cannot recover this section.
 - "Recent merges" is sourced from gather section `recent_main_commits`. Omit the entire section when `count=0`.
 - If the repo has no GitHub origin (`gh_ready` / `gh_assigned` report `not-github` or are skipped), drop both issue sections silently (the brief still shows git/CI lines).
 - Truncate any title to ~78 columns to keep rows on one line.


### PR DESCRIPTION
Consolidates three overlapping start/end-session PRs that all edited the same gather files. #268 and #269 predated the merged #274 and this branch, so resolving them standalone would have re-conflicted; per owner decision they're folded here and closed.

## Why (the core change, #273)

The gathers fetched default-branch CI at every session start *and* end. Without `gh` (this surface, permanently — #257), that recovers via `mcp__github__actions_list`, which has no server-side field selection and dumps every workflow run: **~417KB / ~104K tokens, enough to overflow context**, to buy the least-actionable line in the brief. Measured alternative: a single PR's check runs via `pull_request_read get_check_runs` is a few KB. So CI moves from **eager + repo-wide** to **on-demand + PR-scoped**.

## Changes

**CI dropped from eager gather (#273):**
- Both gather scripts lose their `main_ci` section and emit entry.
- Both command docs replace the "main CI status" step with on-demand guidance: query the PR you're working via `get_check_runs` (Actions report as check runs, so `get_status` returns `total_count: 0` — the wrong call). start-session brief loses its `CI:` line; end-session checks CI only for PRs touched this run, still gating the summary as **unknown ≠ green**.
- `docs/end-session-design.md` diagram + section list updated.

**MCP-recovery honesty, folded from #268 (start-session):**
- Exit-code rules document the real gaps: `gh_ready` recovery via `list_issues` can't express `-is:blocked` (brief retitles to "Open issues (blocked filter unavailable)"); `gh_assigned` has **no** MCP recovery (no assignee filter) → honest `n/a`, never empty.

**MCP-recovery + ref-deletion, folded from #269 (end-session):**
- `open_prs` recovery via `list_pull_requests` with the no-author-filter caveat; `gh_assigned` → `n/a`; gh-absent issue-close via `add_issue_comment` + `issue_write`.
- **#252 hard limit in step 6**: the sandbox git proxy refuses remote ref deletion, and MCP has no delete-branch tool, so a branch needing remote deletion is reported as "could not prune (#252)", never silently claimed done; prefer `delete_branch: true` at merge time.
- The `gh-unauthorized` sentinel from #274 carried through all of the above.

## Verification

shellcheck clean; `skills-match-commands` (all 19 match), `allowlist-covers-commands`, `plugin-manifests` pass; markdownlint clean. Smoke-tested: start-session gather emits its sections with no `main_ci`.

## Supersedes

Closes #273, #268, #269. Shrinks #265 to "issues via MCP `fields`" (CI no longer gathered). Endpoint idea retired. Refs #257, #252, #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Srmh74bGAsF1GTU8m5QhuM