### PR TITLE
ADR-0018: add principle 8, one body until a difference is proven

### DIFF
--- a/adrs/0018-composing-agent-context-per-surface.md
+++ b/adrs/0018-composing-agent-context-per-surface.md
@@ -2,6 +2,9 @@
 
 - **Status**: Proposed (2026-08-18)
 - **Date**: 2026-08-18
+- **Amended**: 2026-08-23 — principle 8 added (#291), after #265 applied the
+  framework to skill bodies and #289 showed how easily a surface difference
+  is asserted without being verified
 - **Tags**: architecture, portability, context, skills, claude-code, codex
 - **Scope**: user (applies to all personal repos and agent surfaces)
 
@@ -53,7 +56,7 @@ what makes per-surface composition worth designing.
 
 ## Decision
 
-Adopt seven principles for composing and delivering agent context.
+Adopt eight principles for composing and delivering agent context.
 
 ### 1. Determinism over conditionals
 
@@ -178,9 +181,53 @@ committed outputs match. Additionally, and specifically:
 - no sandbox profile transitively includes a workstation-only fragment
 - every composed policy artefact is reported with its line count, so the
   always-loaded budget is a number in the build rather than a surprise
+- every composed skill is reported with how many of its sections carry a
+  per-surface variant, so principle 8's bar is a number in the build too
 
-This principle is the price of the other six. Without it, principle 1
+The last two are reports, not gates. A budget overrun and a high variant
+ratio are both content decisions, and a build that failed on them would
+be a build people learn to override.
+
+This principle is the price of the others. Without it, principle 1
 converts loud failures into quiet ones.
+
+### 8. One body until a difference is proven
+
+Composition makes a surface difference cheap to express. That is the
+point, and it is also the risk: a mechanism for stating differences
+invites stating ones that are not there, and an invented difference ships
+a false statement to a surface exactly as effectively as a stale fragment
+does.
+
+**The default is one shared body.** A per-surface split is an exception
+that has to earn itself against two questions, both of which must pass:
+
+1. **Falsifiability.** Write the sandbox sentence and the workstation
+   sentence. Is each one *false* on the other surface? If the sandbox text
+   would still be true on a workstation, it is not a surface difference —
+   it is phrasing, and it belongs in the shared fragment.
+2. **Capability, not delivery.** Is the difference in what the surface
+   *can do*, or in what has been *shipped* there? A delivery gap is closed
+   by shipping the thing. Composing around an absence encodes it, and the
+   encoding outlives the absence.
+
+A pair that passes is justified where it is declared, not merely created.
+The manifest is the review point, the same way `cloud/bootstrap.sh`'s
+whitelist is the review point for which skills reach a sandbox at all.
+
+This is why principle 1 reads "binding for always-loaded policy, strong
+for everything else". The economics invert between the tiers of principle
+2, and the tier that most invites splitting is the one where splitting
+buys least:
+
+| Tier | Cost of a conditional | Cost of splitting |
+| ---- | --------------------- | ----------------- |
+| Always-loaded policy | every turn, every session, forever | low — fragments are short and declarative |
+| Skill body | ~zero until invoked | high — two long procedural texts that must stay in step |
+
+The second row is the one to watch, and its cost is not hypothetical: see
+the twin-drift trade-off below. Nothing can check that two variants of one
+section still agree, because they are supposed to differ.
 
 ## Consequences
 
@@ -221,6 +268,22 @@ converts loud failures into quiet ones.
 - **The content review is unavoidable and is not small.** Splitting
   content by surface requires deciding, line by line, which surface each
   line is true on. Much of `home/` predates the cloud surface entirely.
+- **Variant twins can drift, and no check can catch it.** A skill and its
+  command copy are guarded by byte-equality, which is what
+  `tests/skills-match-commands.py` asserts. Two composed variants of one
+  section are *deliberately* different, so the same guard is structurally
+  unavailable: a fix applied to one twin and missed on the other is
+  invisible until someone reads that surface's artefact. This is the
+  previous entry's failure reached by a second route — the first is a
+  fragment nobody revisits, this is a pair that stops agreeing — and
+  principle 8's bar is the mitigation rather than the fix. Fewer pairs,
+  fewer places for it to happen.
+- **An invented difference is indistinguishable from a real one.** The
+  build proves a variant was composed correctly, never that it needed to
+  exist. #289 is the worked example: a sandbox variant was proposed on the
+  premise that a command could not run there, when it was merely not
+  installed there. Principle 8's two questions exist because that error is
+  cheap to make and expensive to find.
 
 ### Explicitly not decided here
 
@@ -281,3 +344,6 @@ document applied to it.
   deployed-time freshness, and they are different problems
 - #247, #142, #48 — content review, chezmoi shrink, and the commands
   retirement that principle 3 completes
+- #265, #289, #291 — principle 8's origin: #265 extended composition to
+  skill bodies, #289 asserted a surface difference that turned out not to
+  exist, and #291 is the amendment that followed

--- a/tests/compose-context.py
+++ b/tests/compose-context.py
@@ -136,6 +136,40 @@ def compose(manifest, profile, output, fragments):
     return "\n".join(parts) + "\n"
 
 
+VARIANT_SUFFIX = re.compile(r"-(?:workstation|sandbox)$")
+
+
+def variant_ratio(manifest, skill):
+    """Report how many of a skill's sections carry a per-surface variant.
+
+    ADR-0018 principle 8: the default is one shared body, and a split has to
+    earn itself. This is that bar expressed as a number in the build, the same
+    way the line count expresses the always-loaded budget — a report, never a
+    gate. A high ratio is a content decision, and a build that failed on one
+    would be a build people learn to override.
+
+    It is worth watching because a variant pair is the one thing here that no
+    check can guard. A skill and its command twin must be byte-identical, so
+    drift between them fails the build; two variants of a section are supposed
+    to differ, so a fix landing on one and missing the other is silent until
+    somebody reads that surface's artefact.
+    """
+    frag_dir = ROOT / manifest["skill_fragment_dir"] / skill
+    sections, varying = set(), set()
+    for path in frag_dir.glob("*.md"):
+        stem = path.stem
+        if stem.startswith("00-head-"):
+            continue  # the head is per-output shape, not a surface variant
+        base = VARIANT_SUFFIX.sub("", stem)
+        sections.add(base)
+        if base != stem:
+            varying.add(base)
+    if not sections:
+        return ""
+    pct = round(100 * len(varying) / len(sections))
+    return f"{len(varying)}/{len(sections)} sections carry a surface variant ({pct}%)"
+
+
 def emit(output, expected, write, failures, wrote):
     """Write or verify one composed artefact. Shared by both output kinds."""
     path = ROOT / output
@@ -202,6 +236,7 @@ def main():
                 )
                 print(f"  {output:52s} {len(expected.splitlines()):4d} lines")
                 emit(output, expected, write, failures, wrote)
+            print(f"  {'':52s} {variant_ratio(manifest, skill)}")
 
     # Check 5. Every file under profiles/ must be claimed by the manifest.
     #


### PR DESCRIPTION
Closes #291.

Principle 1 says surface differences resolve at delivery. It never said whether a difference should *exist* — it is a mechanism rule with no restraint rule beside it, so once composition exists, reaching for it becomes the cheap move.

#289 is the worked example, and it was mine: filed claiming a sandbox could not drain the journal inbox, when the command turned out to be surface-portable already and merely not installed there. Acted on rather than challenged, the fix would have been a `-sandbox` fragment stating something false.

## Principle 8

Default is one shared body. A split earns itself against two questions, both of which must pass:

1. **Falsifiability** — write both sentences; is each one *false* on the other surface? If the sandbox text would still be true on a workstation, it is phrasing, not a difference.
2. **Capability, not delivery** — is it what the surface *can do*, or only what has been *shipped* there? A delivery gap is closed by shipping the thing; composing around an absence encodes it, and the encoding outlives the absence.

A pair that passes is justified where it is declared, not merely created — the manifest as review point, the same way `cloud/bootstrap.sh`'s whitelist is for which skills reach a sandbox at all.

This **completes** principle 1's "strong for everything else" clause rather than qualifying it. The economics invert between principle 2's tiers, and the tier that most invites splitting is the one where splitting buys least — a conditional in a skill body costs ~nothing until invoked, while the split costs two long procedural texts that must stay in step. Principles 1–7 are otherwise untouched.

## Two Consequences entries, not one

The issue proposed one; writing it up split it, because they are different failures:

- **Variant twins can drift, and no check can catch it.** A skill and its command copy are guarded by byte-equality. Two variants of one section are *deliberately* different, so the same guard is structurally unavailable, and a fix landing on one twin and missing the other is silent until someone reads that surface's artefact. A pair that stops agreeing.
- **An invented difference is indistinguishable from a real one.** The build proves a variant was composed correctly, never that it needed to exist. A pair that should not have existed.

Principle 8 addresses both, for different reasons. Collapsing them would have lost that.

## The variant ratio report

`compose-context.py` now prints, per composed skill, how many of its sections carry a per-surface variant:

```text
  home/skills/start-session/SKILL.md                    234 lines
  profiles/claude-cloud-sandbox/skills/start-session/SKILL.md  279 lines
                                          4/13 sections carry a surface variant (31%)
  …
                                          9/22 sections carry a surface variant (41%)
```

Principle 7 gains a bullet for it, plus a line making explicit that this and the line budget are **reports, not gates** — both are content decisions, and a build that failed on them would be a build people learn to override. That sentence was not in the issue; it seemed worth stating given the ADR is otherwise about things CI hard-fails on.

The report is separable from the text if you would rather the amendment stayed prose-only — it is one function and one call site.

## Housekeeping

- `Amended:` header line with the date and the issues that prompted it
- "seven principles" → "eight"
- "the price of the other six" → "the price of the others", so it survives the next amendment
- References entry tracing principle 8's origin: #265 → #289 → #291

`Status` deliberately left at `Proposed` — this amends a live proposal rather than promoting it.

## Verification

`compose-context.py`, `skills-match-commands.py`, `plugin-manifests.py`, `allowlist-covers-commands.py`, `retired-paths.sh` and its validator all pass; markdownlint clean over 126 files. No shell changed in this PR, so the sandbox's missing shellcheck (noted on #287) does not apply here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0121ZdYHih5Ri7g3QXfc23hD)_