### PR TITLE
promote-journal-inbox: ship it as a skill so cloud sandboxes have it

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -156,21 +156,26 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `/usr/local/bin/pre-commit`, `/usr/bin/shellcheck`, `/usr/local/bin/actionlint` | with `--with-precommit` |
 | `/usr/local/bin/gh` | the GitHub CLI, pinned release, with `--with-gh` |
 
-Whitelisted today: `retrospective`, `start-session`, `end-session`. The 15
-`setup-*` skills are held back pending a currency review — they are
-repo-scaffolding procedures a sandbox session rarely needs, and they predate
-this surface.
+Whitelisted today: `promote-journal-inbox`, `retrospective`, `start-session`,
+`end-session`. The 15 `setup-*` skills are held back pending a currency review
+— they are repo-scaffolding procedures a sandbox session rarely needs, and they
+predate this surface.
 
-All three are **composed skills** (#265, #288): each has a workstation body and
-a cloud-sandbox body built from one shared fragment set, so its artefact lives
-at `profiles/<profile>/skills/<name>/SKILL.md` and is fetched by profile,
-exactly as `AGENTS.md` and `CLAUDE.md` are. The script keeps two lists —
-`SKILLS` for one-body skills, `COMPOSED_SKILLS` for per-surface ones — and
-`SKILLS` is currently empty. It stays because the distinction is real, and
-because a new skill is more likely to need one body than two: ADR-0018
-principle 8 makes that the default. Moving a skill between the lists is part of
-adding or removing its manifest entry; get it backwards and the fetch 404s at
-install, naming the skill.
+The script keeps two lists, because there are two sources:
+
+- **`COMPOSED_SKILLS`** — the three session skills (#265, #288). Each has a
+  workstation body and a cloud-sandbox body built from one shared fragment set,
+  so its artefact lives at `profiles/<profile>/skills/<name>/SKILL.md` and is
+  fetched by profile, exactly as `AGENTS.md` and `CLAUDE.md` are.
+- **`SKILLS`** — one body for every surface, fetched from `home/skills/`.
+  `promote-journal-inbox` is the only entry (#289): its pre-flight tests the
+  repo rather than a path, and it already prefers MCP with `gh` as the
+  fallback, so nothing about it differs by surface. That is ADR-0018 principle
+  8 working as intended — one body is the default, and a per-surface pair has
+  to earn itself.
+
+Moving a skill between the lists is part of adding or removing its manifest
+entry; get it backwards and the fetch 404s at install, naming the skill.
 
 The session skills shell out to four helper scripts, delivered alongside them
 into `~/.claude/bin/`. They are not optional: the skills invoke them by name, so

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -511,12 +511,15 @@ esac
 # Getting that backwards is caught at install: the fetch 404s and the script
 # dies naming the skill, rather than a session quietly running the wrong body.
 #
-# SKILLS is empty as of #288, which composed the last of the three session
-# skills. It stays because the distinction is real and the next skill added
-# here is more likely to need one body than two — ADR-0018 principle 8 makes
-# that the default, not the exception.
+# SKILLS holds promote-journal-inbox and nothing else. It is the drain half of
+# the journal loop whose fill half runs here: a sandbox retro files a
+# journal-draft Issue, and this is what empties that inbox. One body serves
+# both surfaces — its pre-flight tests the repo rather than a path, and it
+# already prefers MCP with gh as the fallback — so it needs no composition,
+# which is ADR-0018 principle 8 working as intended rather than an omission
+# (#289).
 
-SKILLS=""
+SKILLS="promote-journal-inbox"
 COMPOSED_SKILLS="retrospective start-session end-session"
 
 # Helper scripts the session skills shell out to. They are NOT optional: the

--- a/home/skills/promote-journal-inbox/SKILL.md
+++ b/home/skills/promote-journal-inbox/SKILL.md
@@ -1,4 +1,9 @@
-Drain the journal-draft inbox for `paul-context`: move filesystem drafts from `~/dev/paul-context/_incoming/` to `journal/`, drain GitHub Issues labeled `journal-draft` from `pmgledhill102/paul-context` into `journal/`, commit each, push once, then close the drained Issues with back-links. Run from `~/dev/paul-context/` (the slash command lives in `agentic-coding-config` per the slash-commands-in-dotfiles convention; the work happens in `paul-context`).
+---
+name: promote-journal-inbox
+description: 'Drain the journal-draft inbox for paul-context: move filesystem drafts from _incoming/ to journal/, drain journal-draft-labelled Issues into journal/, commit each, push once, then close the drained Issues with back-links. Use when journal drafts are pending, when start-session reports a non-empty inbox, or when asked to promote or file journal entries. Runs from a paul-context checkout on any surface.'
+---
+
+# Promote the journal-draft inbox
 
 See `paul-context/decisions/2026-05-05-journal-inbox-promotion.md` for the design rationale.
 


### PR DESCRIPTION
Closes #289. Independent of #297/#298 — branched from `main`, different files.

`promote-journal-inbox` was one of two files in `home/commands/` with no twin under `home/skills/`, so chezmoi was its only delivery route and it did not exist on a cloud sandbox. `gcp-credentials` is the other, and the bootstrap synthesises that one at install; this had nothing.

## Why it matters more than one missing command

It is the **drain** half of a loop whose **fill** half runs on the sandbox. A retro with no reachable `paul-context` clone files a `journal-draft`-labelled Issue, and this is the only thing that empties that inbox. It also clears a dangling reference: the composed sandbox `start-session` offers to chain into `/promote-journal-inbox` on a surface that did not have it.

## No composition — and that is the point

The issue originally claimed the command was workstation-only. Checking showed the opposite, and the correction is what shrank this from P2 to P3:

- Its pre-flight tests `basename "$(git rev-parse --show-toplevel)" = "paul-context"` — the **repo**, not a path — so a clone anywhere passes.
- Step 1 already prefers `mcp__github__list_issues`, naming `gh` as "the portable fallback, **for sandbox and headless runs**". It was written anticipating this surface.

Nothing in it differs by surface, so under ADR-0018 principle 8 it gets one body: `SKILLS`, not `COMPOSED_SKILLS`. The bootstrap comment and `cloud/README.md` both say so, since "why is this one not composed" is exactly the question a future reader will have.

## One real fix while in there

The abort message hard-coded a path the test does not check:

```diff
-abort with `/promote-journal-inbox must run from ~/dev/paul-context/, not <where>`
+abort with `promote-journal-inbox must run from a paul-context checkout, not <where>`
```

It would have misdirected anyone in a container whose clone is elsewhere — a small instance of the same path-versus-repo confusion that produced the issue's wrong premise.

## Verification

`skills-match-commands.py` now covers 20 pairs and passes with no new `GENERALISATIONS` entry — the body is the command's, transformed by the same two rules the checker applies, so the pair cannot drift. `compose-context.py`, `plugin-manifests.py`, `allowlist-covers-commands.py`, `retired-paths.sh` pass; `dash -n` clean on the bootstrap; markdownlint clean over 148 files.

`cloud/bootstrap.sh` changed, and **shellcheck could not run locally** — not installable in this sandbox, egress blocks both routes. CI's shellcheck job is what covers it. The change is one variable assignment and a comment block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0121ZdYHih5Ri7g3QXfc23hD)_