### PR TITLE
Scope the heredoc rule to the surface that pays for it

### DIFF
--- a/context/fragments/core.md
+++ b/context/fragments/core.md
@@ -74,7 +74,7 @@ stated rather than inferred from where it sits.
 ## Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript
 
 ## Process Guidelines
 

--- a/context/fragments/core.md
+++ b/context/fragments/core.md
@@ -74,8 +74,7 @@ stated rather than inferred from where it sits.
 ## Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in shell commands — heredocs create multi-line commands that defeat prefix-matched permission rules, and ANSI-C quoting gets flagged for hiding characters
-- Prefer a tool's `--*-file` flag over inline content for anything multi-line: `--body-file=PATH` for issues and PRs, `--input` for API JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — the positive form of the heredoc ban above
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
 
 ## Process Guidelines
 

--- a/context/fragments/env-cloud-sandbox.md
+++ b/context/fragments/env-cloud-sandbox.md
@@ -24,6 +24,13 @@ or in the environment's setup script.
 - **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
   A command that exists on the workstation is not necessarily present here.
 
+## Heredocs are fine here
+
+No prefix-matched approval list is in play, so a heredoc costs nothing here
+and the workstation's ban does not apply — use one where it is the natural
+tool. The portable preference survives on its own merits only: anything a
+human will review is still better passed as a file than inlined.
+
 ## `gh` is not installed here
 
 GitHub work goes through the MCP tools. The `gh` CLI is absent from this

--- a/context/fragments/env-cloud-sandbox.md
+++ b/context/fragments/env-cloud-sandbox.md
@@ -24,13 +24,6 @@ or in the environment's setup script.
 - **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
   A command that exists on the workstation is not necessarily present here.
 
-## Heredocs are fine here
-
-No prefix-matched approval list is in play, so a heredoc costs nothing here
-and the workstation's ban does not apply — use one where it is the natural
-tool. The portable preference survives on its own merits only: anything a
-human will review is still better passed as a file than inlined.
-
 ## `gh` is not installed here
 
 GitHub work goes through the MCP tools. The `gh` CLI is absent from this

--- a/context/fragments/env-workstation.md
+++ b/context/fragments/env-workstation.md
@@ -88,3 +88,10 @@ HOME=/tmp/chezmoi-test chezmoi init --source <path> --dry-run
 staging multi-line content (issue bodies, PR bodies) before passing it to a
 tool via `--body-file`. Note that macOS resolves `/tmp` to `/private/tmp`,
 which is why permission rules carry both spellings.
+
+**Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in
+shell commands here.** A heredoc is a multi-line command, so it matches no
+prefix-matched `Bash(...)` rule and prompts every time however ordinary it
+is; ANSI-C quoting also gets flagged for hiding characters. Stage the
+content in `/tmp` and pass it with `--body-file`, or use a surgical edit
+tool — `Edit(/tmp/**)` is auto-approved to make that path free.

--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -82,7 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript
 
 ### Process Guidelines
 

--- a/home/AGENTS.md
+++ b/home/AGENTS.md
@@ -82,8 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in shell commands — heredocs create multi-line commands that defeat prefix-matched permission rules, and ANSI-C quoting gets flagged for hiding characters
-- Prefer a tool's `--*-file` flag over inline content for anything multi-line: `--body-file=PATH` for issues and PRs, `--input` for API JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — the positive form of the heredoc ban above
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
 
 ### Process Guidelines
 

--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -82,8 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in shell commands — heredocs create multi-line commands that defeat prefix-matched permission rules, and ANSI-C quoting gets flagged for hiding characters
-- Prefer a tool's `--*-file` flag over inline content for anything multi-line: `--body-file=PATH` for issues and PRs, `--input` for API JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — the positive form of the heredoc ban above
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
 
 ### Process Guidelines
 
@@ -276,6 +275,13 @@ HOME=/tmp/chezmoi-test chezmoi init --source <path> --dry-run
 staging multi-line content (issue bodies, PR bodies) before passing it to a
 tool via `--body-file`. Note that macOS resolves `/tmp` to `/private/tmp`,
 which is why permission rules carry both spellings.
+
+**Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in
+shell commands here.** A heredoc is a multi-line command, so it matches no
+prefix-matched `Bash(...)` rule and prompts every time however ordinary it
+is; ANSI-C quoting also gets flagged for hiding characters. Stage the
+content in `/tmp` and pass it with `--body-file`, or use a surgical edit
+tool — `Edit(/tmp/**)` is auto-approved to make that path free.
 
 ## Claude Code adapter
 

--- a/home/CLAUDE.md
+++ b/home/CLAUDE.md
@@ -82,7 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript
 
 ### Process Guidelines
 

--- a/profiles/claude-cloud-sandbox/AGENTS.md
+++ b/profiles/claude-cloud-sandbox/AGENTS.md
@@ -82,7 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript
 
 ### Process Guidelines
 

--- a/profiles/claude-cloud-sandbox/AGENTS.md
+++ b/profiles/claude-cloud-sandbox/AGENTS.md
@@ -82,8 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in shell commands — heredocs create multi-line commands that defeat prefix-matched permission rules, and ANSI-C quoting gets flagged for hiding characters
-- Prefer a tool's `--*-file` flag over inline content for anything multi-line: `--body-file=PATH` for issues and PRs, `--input` for API JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — the positive form of the heredoc ban above
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
 
 ### Process Guidelines
 

--- a/profiles/claude-cloud-sandbox/CLAUDE.md
+++ b/profiles/claude-cloud-sandbox/CLAUDE.md
@@ -82,7 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript
 
 ### Process Guidelines
 
@@ -210,13 +210,6 @@ or in the environment's setup script.
   about live GCP state"**.
 - **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
   A command that exists on the workstation is not necessarily present here.
-
-### Heredocs are fine here
-
-No prefix-matched approval list is in play, so a heredoc costs nothing here
-and the workstation's ban does not apply — use one where it is the natural
-tool. The portable preference survives on its own merits only: anything a
-human will review is still better passed as a file than inlined.
 
 ### `gh` is not installed here
 

--- a/profiles/claude-cloud-sandbox/CLAUDE.md
+++ b/profiles/claude-cloud-sandbox/CLAUDE.md
@@ -82,8 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in shell commands — heredocs create multi-line commands that defeat prefix-matched permission rules, and ANSI-C quoting gets flagged for hiding characters
-- Prefer a tool's `--*-file` flag over inline content for anything multi-line: `--body-file=PATH` for issues and PRs, `--input` for API JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — the positive form of the heredoc ban above
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
 
 ### Process Guidelines
 
@@ -211,6 +210,13 @@ or in the environment's setup script.
   about live GCP state"**.
 - **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
   A command that exists on the workstation is not necessarily present here.
+
+### Heredocs are fine here
+
+No prefix-matched approval list is in play, so a heredoc costs nothing here
+and the workstation's ban does not apply — use one where it is the natural
+tool. The portable preference survives on its own merits only: anything a
+human will review is still better passed as a file than inlined.
 
 ### `gh` is not installed here
 

--- a/profiles/codex-cloud-sandbox/AGENTS.md
+++ b/profiles/codex-cloud-sandbox/AGENTS.md
@@ -82,7 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript
 
 ### Process Guidelines
 
@@ -210,13 +210,6 @@ or in the environment's setup script.
   about live GCP state"**.
 - **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
   A command that exists on the workstation is not necessarily present here.
-
-### Heredocs are fine here
-
-No prefix-matched approval list is in play, so a heredoc costs nothing here
-and the workstation's ban does not apply — use one where it is the natural
-tool. The portable preference survives on its own merits only: anything a
-human will review is still better passed as a file than inlined.
 
 ### `gh` is not installed here
 

--- a/profiles/codex-cloud-sandbox/AGENTS.md
+++ b/profiles/codex-cloud-sandbox/AGENTS.md
@@ -82,8 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in shell commands — heredocs create multi-line commands that defeat prefix-matched permission rules, and ANSI-C quoting gets flagged for hiding characters
-- Prefer a tool's `--*-file` flag over inline content for anything multi-line: `--body-file=PATH` for issues and PRs, `--input` for API JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — the positive form of the heredoc ban above
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
 
 ### Process Guidelines
 
@@ -211,6 +210,13 @@ or in the environment's setup script.
   about live GCP state"**.
 - **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
   A command that exists on the workstation is not necessarily present here.
+
+### Heredocs are fine here
+
+No prefix-matched approval list is in play, so a heredoc costs nothing here
+and the workstation's ban does not apply — use one where it is the natural
+tool. The portable preference survives on its own merits only: anything a
+human will review is still better passed as a file than inlined.
 
 ### `gh` is not installed here
 

--- a/profiles/codex-workstation/AGENTS.md
+++ b/profiles/codex-workstation/AGENTS.md
@@ -82,8 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in shell commands — heredocs create multi-line commands that defeat prefix-matched permission rules, and ANSI-C quoting gets flagged for hiding characters
-- Prefer a tool's `--*-file` flag over inline content for anything multi-line: `--body-file=PATH` for issues and PRs, `--input` for API JSON. Cleaner than `--body "$(cat …)"`, avoids quoting edge cases, and renders correctly — the positive form of the heredoc ban above
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
 
 ### Process Guidelines
 
@@ -276,6 +275,13 @@ HOME=/tmp/chezmoi-test chezmoi init --source <path> --dry-run
 staging multi-line content (issue bodies, PR bodies) before passing it to a
 tool via `--body-file`. Note that macOS resolves `/tmp` to `/private/tmp`,
 which is why permission rules carry both spellings.
+
+**Do NOT use heredocs (`cat <<'EOF'`) or ANSI-C quoting (`$'...\n...'`) in
+shell commands here.** A heredoc is a multi-line command, so it matches no
+prefix-matched `Bash(...)` rule and prompts every time however ordinary it
+is; ANSI-C quoting also gets flagged for hiding characters. Stage the
+content in `/tmp` and pass it with `--body-file`, or use a surgical edit
+tool — `Edit(/tmp/**)` is auto-approved to make that path free.
 
 ## Codex adapter
 

--- a/profiles/codex-workstation/AGENTS.md
+++ b/profiles/codex-workstation/AGENTS.md
@@ -82,7 +82,7 @@ stated rather than inferred from where it sits.
 ### Commit & PR Style
 
 - Prefer several short paragraphs to one long line in commit messages; state what changed and why, not just what. Use repeated `-m` flags for the paragraphs (`git commit -m "Title" -m "Body" -m "Co-Authored-By: ..."`) rather than an editor or a heredoc
-- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript. Heredocs are not banned everywhere: on a surface whose permission rules are prefix-matched they cost an approval prompt per use, and the environment guidance says so where that applies
+- **For multi-line content, prefer a file over inline.** Use a tool's `--*-file` flag (`--body-file=PATH` for issues and PRs, `--input` for API JSON) or a surgical edit tool, rather than `--body "$(cat …)"` — it avoids quoting edge cases, renders correctly, and keeps the command readable in a transcript
 
 ### Process Guidelines
 


### PR DESCRIPTION
Closes #278.

## What changed

The heredoc ban moves out of the portable core and into the workstation environment fragment. The sandbox gets nothing — see below.

| Fragment | Before | After |
| --- | --- | --- |
| `core.md` | Ban + workstation-specific rationale, then a second bullet restating the positive form with a portable rationale | One bullet: prefer a file over inline content, for reasons that hold everywhere. No mention of heredocs |
| `env-workstation.md` | — | The ban, with the friction it actually prevents, beside the `/tmp` staging advice and the `Edit(/tmp/**)` grant |
| `env-cloud-sandbox.md` | — | **Nothing.** Deliberately |

## Why the whole rule moves, not just the clause

#278 frames this as a misfiled *rationale*. Reading the evidence, it is a misfiled *rule*.

The ban exists because on a workstation a heredoc produces a multi-line command, which matches no prefix-matched `Bash(...)` allow rule, so it prompts every time. That is real friction and the rule earns its place there. In a cloud sandbox there is no prefix-matched approval list for a multi-line command to defeat, so the ban buys nothing and costs agents a contortion — which is why two cloud sessions violated it ~24 times without incident. Relocating only the justification would have left the ban itself asserted on a surface where it is pure tax.

## Why the sandbox says nothing rather than saying "heredocs are fine"

An earlier revision of this branch added a sandbox section explaining that the ban does not apply here. That was a rule stating the *absence* of a rule: an agent that never reads the ban does not need telling it does not apply. It bought nothing and was paid on every turn of every sandbox session.

Removing it forced a second edit. The core bullet had ended with *"and the environment guidance says so where that applies"* — a forward reference that would dangle on a surface which now says nothing about heredocs. So the core drops the heredoc clause entirely and keeps only the portable preference. No surface is promised a statement it does not receive, and silence carries the meaning: no prohibition, no note.

## Two things found while doing it

**`core.md` was arguing with itself.** It banned heredocs at line 77 and then, at line 106, coached the reader on using `python3` heredocs safely (`r'''…'''`). Both always-loaded, thirty lines apart. That is a better explanation for the violation rate than "the reason doesn't apply here" — an agent reading both reasonably concludes the ban is soft. Surface-scoping the ban dissolves the contradiction, so line 106 needs no change and gets none.

**The ban is load-bearing for a permission rule.** `home/settings.json.md:663-668` justifies the `Edit(/tmp/**)` auto-approval by citing it. That prose stays accurate: `env-workstation.md` composes into `home/CLAUDE.md`, so the workstation user-level file still forbids heredocs. No change needed there.

## Behavioural delta worth a reviewer's eye

`home/AGENTS.md` composes from `core` + `ephemeral-first` only — **no environment fragment** — so it loses the ban entirely. I believe that is correct by construction (that file is deliberately surface-agnostic), but it means a workstation agent reading `AGENTS.md` rather than `CLAUDE.md` no longer sees the rule. If that is wrong, the fix is a manifest change, not a fragment change, and it is arguably a pre-existing gap rather than one this PR creates.

## Always-loaded line count vs `main`

| File | main | this branch | delta |
| --- | --- | --- | --- |
| `home/CLAUDE.md` (workstation) | 316 | 322 | **+6** |
| `profiles/claude-cloud-sandbox/CLAUDE.md` | 263 | 262 | **−1** |
| `profiles/claude-cloud-sandbox/AGENTS.md` | 187 | 186 | **−1** |
| `home/AGENTS.md` | 187 | 186 | **−1** |

#278 priced this as text **freed**, and after the trim that holds everywhere except the workstation, which gains six lines — the surface that actually needs the rule is the only one paying for it. That is the right distribution even though it isn't a net saving overall.

The `OVER BUDGET` flags in the compose output are pre-existing — `main` is already well past the 200-line budget, and the script reports rather than fails.

## Verification

- `python3 tests/compose-context.py` — clean; artefacts regenerated and committed
- `tests/skills-match-commands.py`, `tests/plugin-manifests.py`, `tests/allowlist-covers-commands.py` — clean
- `markdownlint-cli2` — 0 issues (run via `npx`; the binary is not installed in this sandbox)
- Composed output spot-checked on both surfaces: the ban appears in `home/CLAUDE.md`, and `grep -c "Do NOT use heredocs"` returns 0 for both sandbox profiles