### PR TITLE
Link dotfiles' external instead of copying it

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,21 +87,21 @@ plugin manifests simply ride along inert.
 
 [chezmoi-externals]: https://www.chezmoi.io/reference/special-files-and-directories/chezmoiexternal-format/
 [dotfiles]: https://github.com/pmgledhill102/dotfiles
+[dotfiles-external]: https://github.com/pmgledhill102/dotfiles/blob/main/home/.chezmoiexternal.toml.tmpl
+[dotfiles#389]: https://github.com/pmgledhill102/dotfiles/issues/389
 
 ## How this gets onto your machine
 
-This repo's `home/` subdirectory is mounted at `~/.claude/` on every
-machine. The wiring lives in `dotfiles`:
+This repo's `home/` subdirectory is mounted at `~/.claude/`. The wiring
+lives in `dotfiles`, in
+[`home/.chezmoiexternal.toml.tmpl`][dotfiles-external]: an `archive`
+external that deploys this repo's `home/**` to `~/.claude/`, **on
+`personal` machines only** ([dotfiles#389]). Work machines get no
+`~/.claude/` from here.
 
-```toml
-# dotfiles' home/.chezmoiexternal.toml.tmpl
-[".claude"]
-type = "archive"
-url = "https://github.com/pmgledhill102/agentic-coding-config/archive/refs/heads/main.tar.gz"
-stripComponents = 2
-include = ["agentic-coding-config-main/home/**"]
-refreshPeriod = "168h"
-```
+That file is the source of truth and is deliberately not quoted here. A
+copy drifts — this one did, silently, when the personal-only gating was
+added.
 
 `chezmoi apply` (or `dotup`) downloads the archive, strips the
 `agentic-coding-config-main/home/` prefix, and includes only files under


### PR DESCRIPTION
Closes #285.

The README quoted `dotfiles`' `home/.chezmoiexternal.toml.tmpl` verbatim. That copy is now stale, so the fenced block is replaced with a link to the live file plus a one-line summary of its effect.

## Verified, not assumed

Cloned `pmgledhill102/dotfiles` read-only (at `1bb3abf`) and read the real file rather than trusting the issue's quote. The issue's account is correct — the stanza is wrapped in a `personal`-only conditional with a `hasKey` preamble, and the file's own comment cites `dotfiles#389`.

## One thing the issue didn't catch

The drift wasn't confined to the fenced block. The prose immediately above it read:

> This repo's `home/` subdirectory is mounted at `~/.claude/` **on every machine**.

That sentence is false for the same reason the TOML block is, and deleting the block alone would have left it standing. Fixed in the same pass — the section now states the personal-only gating in prose and adds that work machines get no `~/.claude/` from here.

## What's kept

Per the issue, the surrounding prose is this repo's own to explain and stays untouched:

- the `archive`-vs-`git-repo` rationale
- the `home/` → `~/.claude/` mental model

## Choices made

**Linked `main`, not a SHA.** The issue left this as the author's call. A permalink is more stable but hides future changes — which is precisely how this drifted. A `main` link shows the truth and cannot go stale.

**Added a line saying why it isn't quoted:** *"That file is the source of truth and is deliberately not quoted here. A copy drifts — this one did, silently, when the personal-only gating was added."* Without it, the next person to touch this section has no reason not to paste the stanza back in. This copy is already the estate's canonical example of the failure (the agent policy's Cross-Repo Work section cites it by name), so it's worth one sentence of inoculation.

## Acceptance criteria

- [x] The copied TOML block is gone from `README.md`
- [x] Replaced by a link to the live file, with the personal-only gating stated
- [x] The `archive`-vs-`git-repo` rationale and the `home/` → `~/.claude/` mental model are retained
- [x] No other file carries a copy of the stanza — grepped for `chezmoiexternal`, `stripComponents` and `refreshPeriod`; the only other hits are prose references to `refreshPeriod` and ADR-0012 naming the file, neither of which is a copy
- [x] `markdownlint-cli2` clean (0 issues, 149 files); all other gates pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgwEVt8K4rw4AjQwVWzL2P)_