### PR TITLE
Route journal drafts through /tmp so the inbox works on any checkout

### DIFF
--- a/context/skills/retrospective/10-8-execute.md
+++ b/context/skills/retrospective/10-8-execute.md
@@ -5,9 +5,10 @@
 1. **journal** (always first):
    - **Derive the filename.** `<source-repo-slug>` = sanitised basename of `git remote get-url origin` from the current cwd (lowercase, `[a-z0-9-]+`). If no git remote, use `basename "$PWD"`. `<topic-slug>` = kebab-cased session summary, ≤5 words. `<filename>` = `<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md`.
    - **Resolve same-project same-day collisions** at write-time: if the target already exists, append `-2`, `-3`, … before `.md` until unique. Filesystem path checks `<pc>/_incoming/<filename>`; Issue path checks for an open Issue with the same title (rare in practice — same project, same day, same topic — but the suffix prevents silent merge of two distinct retros).
-   - **Pick the inbox path:**
-     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `Write` the journal markdown to `<pc>/_incoming/<filename>`. **No git operations against `paul-context`.**
-     - **GitHub Issue fallback** (`<pc>` unset, or its `_incoming/` is not writable): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Edit(/tmp/**)` is auto-allowed, and `Edit` rules cover the `Write` tool), then file as a labeled Issue:
+   - **Stage the draft first, always.** `Write` the journal markdown to `/tmp/<filename>`. `Edit(/tmp/**)` is auto-allowed on every surface (and `Edit` rules cover the `Write` tool), so this write always succeeds and the draft exists on disk before any route is chosen. Nothing below can lose it.
+   - **Then deliver it:**
+     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `cp /tmp/<filename> "<pc>/_incoming/<filename>"`. `Bash(cp *)` is auto-allowed, so this needs no permission rule naming a checkout root and works wherever the clone sits. **No git operations against `paul-context`.** If the copy fails, fall through to the Issue route rather than stopping.
+     - **GitHub Issue fallback** (`<pc>` unset, its `_incoming/` is not writable, or the copy above failed): file the already-staged `/tmp/<filename>` as a labeled Issue:
 
        Create the issue on `pmgledhill102/paul-context` with the
        `journal-draft` label and the title `journal: <filename-without-.md>`,

--- a/home/commands/retrospective.md
+++ b/home/commands/retrospective.md
@@ -182,9 +182,10 @@ Wait for explicit confirmation. Don't proceed on ambiguous input.
 1. **journal** (always first):
    - **Derive the filename.** `<source-repo-slug>` = sanitised basename of `git remote get-url origin` from the current cwd (lowercase, `[a-z0-9-]+`). If no git remote, use `basename "$PWD"`. `<topic-slug>` = kebab-cased session summary, ≤5 words. `<filename>` = `<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md`.
    - **Resolve same-project same-day collisions** at write-time: if the target already exists, append `-2`, `-3`, … before `.md` until unique. Filesystem path checks `<pc>/_incoming/<filename>`; Issue path checks for an open Issue with the same title (rare in practice — same project, same day, same topic — but the suffix prevents silent merge of two distinct retros).
-   - **Pick the inbox path:**
-     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `Write` the journal markdown to `<pc>/_incoming/<filename>`. **No git operations against `paul-context`.**
-     - **GitHub Issue fallback** (`<pc>` unset, or its `_incoming/` is not writable): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Edit(/tmp/**)` is auto-allowed, and `Edit` rules cover the `Write` tool), then file as a labeled Issue:
+   - **Stage the draft first, always.** `Write` the journal markdown to `/tmp/<filename>`. `Edit(/tmp/**)` is auto-allowed on every surface (and `Edit` rules cover the `Write` tool), so this write always succeeds and the draft exists on disk before any route is chosen. Nothing below can lose it.
+   - **Then deliver it:**
+     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `cp /tmp/<filename> "<pc>/_incoming/<filename>"`. `Bash(cp *)` is auto-allowed, so this needs no permission rule naming a checkout root and works wherever the clone sits. **No git operations against `paul-context`.** If the copy fails, fall through to the Issue route rather than stopping.
+     - **GitHub Issue fallback** (`<pc>` unset, its `_incoming/` is not writable, or the copy above failed): file the already-staged `/tmp/<filename>` as a labeled Issue:
 
        Create the issue on `pmgledhill102/paul-context` with the
        `journal-draft` label and the title `journal: <filename-without-.md>`,

--- a/home/settings.json
+++ b/home/settings.json
@@ -323,8 +323,7 @@
       "Read(~/.claude/retros.md)",
       "Read(~/.claude/settings.json)",
       "Edit(/private/tmp/**)",
-      "Edit(/tmp/**)",
-      "Edit(~/dev/paul-context/_incoming/**)"
+      "Edit(/tmp/**)"
     ]
   },
   "hooks": {

--- a/home/settings.json.md
+++ b/home/settings.json.md
@@ -678,18 +678,42 @@ that otherwise discourages the structured-body pattern.
   is handed to Claude as `/private/tmp/claude-<uid>/...`), so the
   `/tmp/**` glob alone can miss. Both spellings are kept: Linux has no
   such symlink and uses the `/tmp/**` form.
-- `Edit(~/dev/paul-context/_incoming/**)` — journal-draft inbox for
-  the cross-repo retrospective skill. Drafts land here and are later
-  promoted into `paul-context/journal/` by `/promote-journal-inbox`
-  (run from `~/dev/paul-context/`). The directory is `.gitignored` in
-  the `paul-context` repo, so anything written here is local-only
-  until promotion — content can't pollute `paul-context`'s git
-  history regardless of what gets written. This single user-level
-  rule replaces what would otherwise be N per-project
-  `Edit(~/dev/paul-context/journal/**)` grants plus git-on-paul-context
-  permissions in every project that runs `/end-session`. See
-  `paul-context/decisions/2026-05-05-journal-inbox-promotion.md` for
-  the full rationale.
+
+**Removed: `Edit(~/dev/paul-context/_incoming/**)`.** This granted the
+journal-draft inbox for the cross-repo retrospective skill, naming one
+machine's layout. #300 taught that skill to discover a `paul-context`
+checkout wherever it sits, which left the rule covering only the
+conventional location — so a retro standing in a checkout anywhere else
+(a cloud session has it at `/home/user/paul-context`) picked the
+filesystem route and only then hit the allow rules. Interactively that
+is a prompt; headless it is a denial with no recovery, because the
+skill's guard is `[ -w "<pc>/_incoming" ]` — a *filesystem* writability
+test, not a permission test — so the Issue fallback had already been
+skipped by the time the write failed, and the retro's whole output was
+lost at the last step (#303).
+
+The fix is in the skill, not in a broader rule. `/retrospective` now
+stages every draft to `/tmp/<filename>` first and copies it into
+`<pc>/_incoming/` from there, so the only write path is one that
+`Edit(/tmp/**)` and `Bash(cp *)` already cover — on any checkout root,
+on any surface — and a failed copy falls through to the Issue route
+with the draft still on disk. That makes this rule dead config, and a
+rule granting nothing is worse than no rule: it reads as coverage.
+
+The alternative was broadening the glob to something like
+`Edit(**/paul-context/_incoming/**)`. Not taken, because whether a
+leading `**/` is honoured by the permission matcher is unverified —
+the three surviving `Edit` rules are all anchored absolute paths, and
+the `/tmp` vs `/private/tmp` pair above is this file's own precedent
+for enumerating spellings rather than trusting the matcher to unify
+them. Staging through `/tmp` sidesteps the question entirely.
+
+Unchanged: `_incoming/` is `.gitignored` in `paul-context`, so drafts
+are local-only until `/promote-journal-inbox` drains them into
+`journal/`; that command runs from a `paul-context` checkout, wherever
+it sits. See
+`paul-context/decisions/2026-05-05-journal-inbox-promotion.md` for the
+full rationale.
 
 ## Never allow
 

--- a/home/skills/retrospective/SKILL.md
+++ b/home/skills/retrospective/SKILL.md
@@ -187,9 +187,10 @@ Wait for explicit confirmation. Don't proceed on ambiguous input.
 1. **journal** (always first):
    - **Derive the filename.** `<source-repo-slug>` = sanitised basename of `git remote get-url origin` from the current cwd (lowercase, `[a-z0-9-]+`). If no git remote, use `basename "$PWD"`. `<topic-slug>` = kebab-cased session summary, ≤5 words. `<filename>` = `<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md`.
    - **Resolve same-project same-day collisions** at write-time: if the target already exists, append `-2`, `-3`, … before `.md` until unique. Filesystem path checks `<pc>/_incoming/<filename>`; Issue path checks for an open Issue with the same title (rare in practice — same project, same day, same topic — but the suffix prevents silent merge of two distinct retros).
-   - **Pick the inbox path:**
-     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `Write` the journal markdown to `<pc>/_incoming/<filename>`. **No git operations against `paul-context`.**
-     - **GitHub Issue fallback** (`<pc>` unset, or its `_incoming/` is not writable): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Edit(/tmp/**)` is auto-allowed, and `Edit` rules cover the `Write` tool), then file as a labeled Issue:
+   - **Stage the draft first, always.** `Write` the journal markdown to `/tmp/<filename>`. `Edit(/tmp/**)` is auto-allowed on every surface (and `Edit` rules cover the `Write` tool), so this write always succeeds and the draft exists on disk before any route is chosen. Nothing below can lose it.
+   - **Then deliver it:**
+     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `cp /tmp/<filename> "<pc>/_incoming/<filename>"`. `Bash(cp *)` is auto-allowed, so this needs no permission rule naming a checkout root and works wherever the clone sits. **No git operations against `paul-context`.** If the copy fails, fall through to the Issue route rather than stopping.
+     - **GitHub Issue fallback** (`<pc>` unset, its `_incoming/` is not writable, or the copy above failed): file the already-staged `/tmp/<filename>` as a labeled Issue:
 
        Create the issue on `pmgledhill102/paul-context` with the
        `journal-draft` label and the title `journal: <filename-without-.md>`,

--- a/profiles/claude-cloud-sandbox/skills/retrospective/SKILL.md
+++ b/profiles/claude-cloud-sandbox/skills/retrospective/SKILL.md
@@ -195,9 +195,10 @@ Wait for explicit confirmation. Don't proceed on ambiguous input.
 1. **journal** (always first):
    - **Derive the filename.** `<source-repo-slug>` = sanitised basename of `git remote get-url origin` from the current cwd (lowercase, `[a-z0-9-]+`). If no git remote, use `basename "$PWD"`. `<topic-slug>` = kebab-cased session summary, ≤5 words. `<filename>` = `<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md`.
    - **Resolve same-project same-day collisions** at write-time: if the target already exists, append `-2`, `-3`, … before `.md` until unique. Filesystem path checks `<pc>/_incoming/<filename>`; Issue path checks for an open Issue with the same title (rare in practice — same project, same day, same topic — but the suffix prevents silent merge of two distinct retros).
-   - **Pick the inbox path:**
-     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `Write` the journal markdown to `<pc>/_incoming/<filename>`. **No git operations against `paul-context`.**
-     - **GitHub Issue fallback** (`<pc>` unset, or its `_incoming/` is not writable): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Edit(/tmp/**)` is auto-allowed, and `Edit` rules cover the `Write` tool), then file as a labeled Issue:
+   - **Stage the draft first, always.** `Write` the journal markdown to `/tmp/<filename>`. `Edit(/tmp/**)` is auto-allowed on every surface (and `Edit` rules cover the `Write` tool), so this write always succeeds and the draft exists on disk before any route is chosen. Nothing below can lose it.
+   - **Then deliver it:**
+     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `cp /tmp/<filename> "<pc>/_incoming/<filename>"`. `Bash(cp *)` is auto-allowed, so this needs no permission rule naming a checkout root and works wherever the clone sits. **No git operations against `paul-context`.** If the copy fails, fall through to the Issue route rather than stopping.
+     - **GitHub Issue fallback** (`<pc>` unset, its `_incoming/` is not writable, or the copy above failed): file the already-staged `/tmp/<filename>` as a labeled Issue:
 
        Create the issue on `pmgledhill102/paul-context` with the
        `journal-draft` label and the title `journal: <filename-without-.md>`,

--- a/profiles/codex-cloud-sandbox/skills/retrospective/SKILL.md
+++ b/profiles/codex-cloud-sandbox/skills/retrospective/SKILL.md
@@ -195,9 +195,10 @@ Wait for explicit confirmation. Don't proceed on ambiguous input.
 1. **journal** (always first):
    - **Derive the filename.** `<source-repo-slug>` = sanitised basename of `git remote get-url origin` from the current cwd (lowercase, `[a-z0-9-]+`). If no git remote, use `basename "$PWD"`. `<topic-slug>` = kebab-cased session summary, ≤5 words. `<filename>` = `<YYYY-MM-DD>-<source-repo-slug>-<topic-slug>.md`.
    - **Resolve same-project same-day collisions** at write-time: if the target already exists, append `-2`, `-3`, … before `.md` until unique. Filesystem path checks `<pc>/_incoming/<filename>`; Issue path checks for an open Issue with the same title (rare in practice — same project, same day, same topic — but the suffix prevents silent merge of two distinct retros).
-   - **Pick the inbox path:**
-     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `Write` the journal markdown to `<pc>/_incoming/<filename>`. **No git operations against `paul-context`.**
-     - **GitHub Issue fallback** (`<pc>` unset, or its `_incoming/` is not writable): stage the journal markdown with the `Write` tool to `/tmp/<filename>` (`Edit(/tmp/**)` is auto-allowed, and `Edit` rules cover the `Write` tool), then file as a labeled Issue:
+   - **Stage the draft first, always.** `Write` the journal markdown to `/tmp/<filename>`. `Edit(/tmp/**)` is auto-allowed on every surface (and `Edit` rules cover the `Write` tool), so this write always succeeds and the draft exists on disk before any route is chosen. Nothing below can lose it.
+   - **Then deliver it:**
+     - **Filesystem inbox** (preferred): if `<pc>` resolved and `[ -w "<pc>/_incoming" ]`, `cp /tmp/<filename> "<pc>/_incoming/<filename>"`. `Bash(cp *)` is auto-allowed, so this needs no permission rule naming a checkout root and works wherever the clone sits. **No git operations against `paul-context`.** If the copy fails, fall through to the Issue route rather than stopping.
+     - **GitHub Issue fallback** (`<pc>` unset, its `_incoming/` is not writable, or the copy above failed): file the already-staged `/tmp/<filename>` as a labeled Issue:
 
        Create the issue on `pmgledhill102/paul-context` with the
        `journal-draft` label and the title `journal: <filename-without-.md>`,


### PR DESCRIPTION
Closes #303.

Takes the issue's **option 2** — stage to a covered path, then move — rather than broadening the glob. The reasoning below is the part worth reviewing; the diff is small.

## What changed

| File | Change |
| --- | --- |
| `context/skills/retrospective/10-8-execute.md` | Draft is always `Write`-staged to `/tmp/<filename>` first, then `cp`'d into `<pc>/_incoming/`. A failed copy falls through to the Issue route. |
| `home/settings.json` | `Edit(~/dev/paul-context/_incoming/**)` removed |
| `home/settings.json.md` | Records the removal, the reasoning, and why the glob route was declined; fixes the stale "run from `~/dev/paul-context/`" claim |

Composed artefacts regenerated (`home/skills/`, `home/commands/`, both cloud profiles).

## Why not the glob

The issue asks that the exact spelling of `Edit(**/paul-context/_incoming/**)` be **verified before merge**, and it's right to. I can't verify it: this session runs in a cloud sandbox in auto mode, where no permission prompt is observable, so any claim I made about the matcher honouring a leading `**/` would be exactly the flag-shaped assumption the process guidelines say to check rather than assert.

Staging through `/tmp` removes the question rather than answering it. `Edit(/tmp/**)` and `Bash(cp *)` are both already granted and already working, so the only write path is one the allowlist covers — on any checkout root, on any surface, with no new matcher behaviour assumed. The issue notes option 2 "is arguably the cleaner fix … even if the glob does work"; I agree, and the unverifiability settles it.

## A correction to the issue's wording

The issue proposes staging to `/tmp` then **`mv`** into place. That wouldn't have worked: **`mv` is not in the allowlist.** The only matches for `Bash(mv` are `mvn compile`, `mvn test`, `mvn validate`, `mvn dependency:tree`. So an `mv` would have traded an `Edit` prompt for a `Bash` prompt and fixed nothing.

`Bash(cp *)` **is** granted (`home/settings.json:62`), so this PR uses `cp`. The staged file is left in `/tmp`, which is ephemeral scratch space and where the Issue fallback expects to find it anyway.

## The deeper defect, also fixed

The issue identifies the real problem precisely: the guard is `[ -w "<pc>/_incoming" ]`, a *filesystem* test standing in for a *permission* test. Even a correct allow rule leaves that mismatch in place for the next thing that diverges.

So the ordering is inverted. The draft is now written to `/tmp` **before** any route is chosen, and the Issue fallback explicitly accepts "the copy failed" as a trigger. Whatever goes wrong downstream, the draft exists on disk and a route remains open. That is what the issue means by *"the retro's entire output is lost at the last step"* — it can't be, now.

## Why the rule is removed rather than kept

With the skill staging through `/tmp`, `Edit(~/dev/paul-context/_incoming/**)` grants nothing any code path uses. A rule that reads as coverage but provides none is worse than no rule — it's what made this bug hard to see.

**Reviewer's call worth making explicitly:** keeping it would preserve a marginally faster path on a `~/dev` workstation (direct `Write`, no `/tmp` round-trip) at the cost of two code paths and a machine-specific path in the config. I removed it; say the word and I'll restore it.

Checked before removing: `/promote-journal-inbox` does not `Edit` or `Write` into `_incoming/` — it `mv`s *out* of it — so nothing else depended on the grant.

## Acceptance criteria

- [x] A retro in a checkout that isn't `~/dev/paul-context` reaches `_incoming/` without a permission prompt — via `Edit(/tmp/**)` + `Bash(cp *)`, both pre-existing grants
- [x] No machine-specific path outside the conventional-location fallback. The surviving `~/dev/paul-context` mentions are all rule 2 of the skill's resolution order, which the issue exempts; `settings.json.md` names it only to record the removal
- [x] `settings.json` and `settings.json.md` change together (sync gate satisfied); the `.md` records the shape and the declined alternative. It records *why the glob was not verified* rather than a verification — see above
- [x] `settings.json.md:681-689`'s stale promotion prose fixed in the same pass

## Verification

`compose-context.py`, `skills-match-commands.py`, `plugin-manifests.py`, `allowlist-covers-commands.py`, `gcp-credentials-test.sh`, `precommit-hook-test.sh`, `retired-paths.sh`, `retired-paths-test.sh` all pass. `markdownlint-cli2` 0 issues across 149 files. `home/settings.json` re-validated as JSON after the rule removal.

**Not verified, and can't be from here:** that a real workstation retro completes prompt-free end to end. The grants it relies on are pre-existing and in daily use, so the risk is low, but the first workstation retro after this merges is the actual test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgwEVt8K4rw4AjQwVWzL2P)_