### PR TITLE
Amend ADR-0014 and ADR-0016 for the withdrawn plugin channel

### DIFF
--- a/adrs/0014-portable-agent-config-architecture.md
+++ b/adrs/0014-portable-agent-config-architecture.md
@@ -4,6 +4,22 @@
   2026-08-13 by [ADR-0016](0016-capability-delivery-principles.md)** —
   which narrows decision 3: per-repo marketplace configuration is not the
   delivery route for everything it implies here. Read 0016 alongside this.
+- **Amended**: 2026-08-27 by [#312](https://github.com/pmgledhill102/agentic-coding-config/issues/312)
+  — **decisions 3, 4, 5 and 7 no longer hold.** The dual-manifest plugin was
+  published, never adopted, and has been withdrawn: `dotfiles` declined it
+  ([dotfiles#392](https://github.com/pmgledhill102/dotfiles/issues/392)) and
+  the marketplace listing was judged not worth maintaining for anyone else
+  (#48, closed). Distribution stays on the two channels this ADR set out to
+  replace — the chezmoi archive external and `cloud/bootstrap.sh`; hooks stay
+  declared in `settings.json` with their scripts at `~/.claude/bin/`; `home/`
+  is not shrinking to a residue. Decisions 1, 2 and 6 stand, and decision 1
+  has since completed: the `home/commands/` twins were retired in #313,
+  leaving skills as the only form. The reason the plugin failed is specific
+  and worth keeping — the marketplace declared `"source": "./home"`, which is
+  the `claude-workstation` composition, so it could only ever ship
+  workstation-composed context. See
+  [ADR-0018](0018-composing-agent-context-per-surface.md) for the
+  per-surface composition that turned that from a detail into a defect.
 - **Date**: 2026-08-09
 - **Tags**: claude-code, codex, opencode, skills, plugins, architecture
 - **Scope**: user (applies to all personal repos and agent surfaces)

--- a/adrs/0016-capability-delivery-principles.md
+++ b/adrs/0016-capability-delivery-principles.md
@@ -1,6 +1,13 @@
 # ADR-0016: Where capability lives — environment, repo, or content
 
 - **Status**: Accepted (2026-08-13), validated on Claude Code and Codex
+- **Amended**: 2026-08-27 by [#312](https://github.com/pmgledhill102/agentic-coding-config/issues/312)
+  — the plugin is no longer one of the delivery routes, so principle 2's row
+  for portable skills and policy is setup-script placement alone, and "two
+  distribution paths persist" is one path. The principles themselves are
+  unchanged: this ADR already argued against committing marketplace
+  declarations to a repo (principle 1), and withdrawing the plugin vindicates
+  that rather than contradicting it.
 - **Date**: 2026-08-13
 - **Tags**: architecture, cloud, plugins, portability, claude-code, codex
 - **Scope**: user (applies to all personal repos and agent surfaces)


### PR DESCRIPTION
Closes #314 — the one thing #312 deliberately left alone.

#312 withdrew the plugin and did not touch `adrs/`, on the grounds that an ADR records what was decided at the time and rewriting one in place loses the history. But two of them describe a channel that no longer exists, and a reader arriving without #311 or #312 in hand gets no signal that the decision moved.

## Amendment banner, not "Superseded"

Both ADRs decide more than the plugin, so a blanket status flip would overstate it. The repo already has the right idiom in two places:

- ADR-0014's own Status line: *"amended 2026-08-13 by ADR-0016 — which narrows decision 3"*
- ADR-0018's separate `**Amended**:` field

I used the `**Amended**` field on both. **Neither body is edited** — that is the point of the idiom, and it matches how ADR-0016 amended ADR-0014's decision 3 while leaving 0014's text standing.

## ADR-0014 — decisions 3, 4, 5 and 7 no longer hold

| Decision | Status |
| --- | --- |
| 1. Workflows become skills | **stands — and completed.** #313 retired the `home/commands/` twins, so skills really are the only form now |
| 2. Policy becomes an AGENTS.md core | stands |
| 3. Distribution is a dual-manifest plugin | **withdrawn** |
| 4. Hooks port into the plugin, scripts referenced plugin-relative | **withdrawn** — hooks stay in `settings.json`, scripts at `~/.claude/bin/` |
| 5. `home/` shrinks to a machine-local residue | **not happening** |
| 6. The permissions allowlist is frozen | stands |
| 7. #48 re-scoped to implement this | **closed instead** |

The banner keeps the reason the plugin failed, because it is a property of this repo rather than a matter of taste and would apply again to any future attempt: `marketplace.json` declared `"source": "./home"`, which is the `claude-workstation` composition, so a plugin could only ever ship workstation-composed context. It points at ADR-0018 for the per-surface composition that turned that from a detail into a defect.

## ADR-0016 — much lighter

The plugin was one of *two* routes named in principle 2's table ("Plugin, or setup-script placement") and one of the "two distribution paths persist" consequences. The other route survives and is now the only one.

The principles themselves are unchanged. Principle 1 already argued against committing `extraKnownMarketplaces` to a repo — *"an `extraKnownMarketplaces` block is Claude-only; committed to a repo a Codex session also reads, it is dead weight"* — so withdrawing the plugin **vindicates** this ADR rather than contradicting it. The banner says so.

## Coverage

`adrs/0012`, `0013`, `0015`, `0017` and `0018` were checked and contain no reference to the plugin channel, which satisfies #314's second acceptance criterion. `docs/reviews/strategic-review-2026-08-09.md` is left alone deliberately — it is a dated snapshot of a review, not a decision.

## Verification

markdownlint 0 issues across 126 files. `compose-context`, `retired-paths` and `allowlist-covers-commands` all pass — untouched by this change, run to confirm that.

Docs only; no behaviour change.

Closes #314. Refs #311, #312.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016QFnPJqLKtQjFbbUy3kamG

---
_Generated by [Claude Code](https://claude.ai/code/session_016QFnPJqLKtQjFbbUy3kamG)_