### PR TITLE
Redesign bootstrap.sh: profile-driven defaults and resilient fetches

### DIFF
--- a/adrs/0016-capability-delivery-principles.md
+++ b/adrs/0016-capability-delivery-principles.md
@@ -140,6 +140,12 @@ This does not forbid the plugin route. It scopes it: use it for **project
 configuration**, where per-repo declaration is the point, and not for
 **environment capability**, where it is a tax.
 
+The principle applies to installers too, not only to committed config.
+`cloud/bootstrap.sh` derives its capability defaults from the profile name, so
+a `claude-*` profile gets the harness hooks and a `codex-*` one does not —
+`~/.claude/settings.json` is a Claude mechanism, and installing it alongside a
+Codex profile put four files in the container that nothing there reads.
+
 ### 4. Portable content, provider-specific delivery
 
 The portability commitment in ADR-0014 is about *content* — SKILL.md
@@ -170,10 +176,17 @@ the thing being configured is genuinely per-repo.
 Where a provider surface must hold something, it holds **one line** that
 defers to versioned content in this repo:
 
-```bash
-#!/bin/bash
-curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/v1.3.0/cloud/bootstrap.sh | bash
+```sh
+PROFILE=claude-cloud-sandbox
+REF=v1.3.0
+curl -sSL ".../agentic-coding-config/$REF/cloud/bootstrap.sh" -o /tmp/bootstrap.sh
+sh /tmp/bootstrap.sh "$REF" --profile "$PROFILE"
 ```
+
+(Amended 2026-08-27. As first written this example carried a `#!/bin/bash`
+line; a setup-script field is pasted beneath a header the harness supplies, so
+that line never selects an interpreter, and a live environment lost its `#` in
+transit and exited 127 before `curl` ran. `cloud/README.md` has the detail.)
 
 Two properties make this work:
 

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -23,13 +23,43 @@ Set these three things once per environment, at
 
 ### 1. Setup script
 
-```bash
-#!/bin/bash
+```sh
 # Rev: 1
-curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/main/cloud/bootstrap.sh \
-  | sh -s -- main --with-gcloud || true
+
+curl -sSL --retry 3 --retry-delay 2 \
+  https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/main/cloud/bootstrap.sh \
+  -o /tmp/bootstrap.sh || echo "[setup] could not fetch bootstrap.sh"
+
+{ sh /tmp/bootstrap.sh main --with-gcloud; echo $? > /tmp/bootstrap.rc; } 2>&1 \
+  | tee /tmp/bootstrap.log
+
+echo "[setup] bootstrap exit=$(cat /tmp/bootstrap.rc 2>/dev/null) at $(date -u +%FT%TZ)"
 exit 0
 ```
+
+**Do not put a shebang in this field.** The harness writes the field's contents
+into a generated `/tmp/init-script-*.sh` beneath a header of its own and runs
+that, so a `#!/bin/bash` you paste is never line 1 and never takes effect. Intact
+it is a comment; lose the `#` in transit and it becomes a command, which is how a
+live environment produced this:
+
+```text
+Setup script failed with exit code 127.
+/tmp/init-script-2496021182.sh: line 3: !/bin/bash: No such file or directory
+```
+
+Line 3 is the field's line 1. Nothing had run yet — not `curl`, not the
+bootstrap — and the session was already over. Omitting the line removes the whole
+class of failure, and costs nothing, because the harness supplies the interpreter.
+
+For the same reason, keep the field POSIX. Which shell the harness uses is its
+choice, not yours, so a bashism only works by luck — the form above avoids
+`PIPESTATUS` by parking the exit status in a file, which is why the bootstrap
+runs inside `{ … }` rather than being piped directly into `tee`.
+
+Downloading the bootstrap to a file rather than piping it into `sh` is also
+deliberate: it separates "could not fetch" from "ran and failed", and it keeps
+the run's own exit status reachable.
 
 Drop `--with-gcloud` for an environment that does no Google Cloud work; it
 saves a ~96 MB download and declares what kind of environment this is.
@@ -53,17 +83,24 @@ snapshot built the first time. Bump the number to force a rebuild.
 
 Pin a tag instead of `main` for anything beyond development:
 
-```bash
-  | sh -s -- v0.1.0 --with-gcloud || true
+```sh
+  .../v0.1.0/cloud/bootstrap.sh -o /tmp/bootstrap.sh
+sh /tmp/bootstrap.sh v0.1.0 --with-gcloud
 ```
+
+Both occurrences change together — the ref that fetches the script and the ref
+it installs everything else from — so that a run cannot straddle two versions.
 
 A mutable ref means any compromise of this repo reaches every sandbox that
 starts afterwards. A tag also names, in the session's own log, which version it
 is running.
 
-`|| true` belongs to the caller, not the script: a non-zero exit fails the whole
-session, while `bootstrap.sh` deliberately fails loudly so that a partial
-install is visible rather than silent.
+The trailing `exit 0` belongs to the caller, not the script: a non-zero exit
+fails the whole session, while `bootstrap.sh` deliberately fails loudly so that
+a partial install is visible rather than silent. Swallowing the status is a
+choice the environment makes, which is why the snippet still records the real
+one in its `[setup] bootstrap exit=` line and keeps `/tmp/bootstrap.log` — a
+session that came up half-installed can be diagnosed from inside itself.
 
 ### 2. Allowed domains
 

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -24,18 +24,31 @@ Set these three things once per environment, at
 ### 1. Setup script
 
 ```sh
+PROFILE=claude-cloud-sandbox
+REF=main
 # Rev: 1
 
 curl -sSL --retry 3 --retry-delay 2 \
-  https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/main/cloud/bootstrap.sh \
+  "https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/$REF/cloud/bootstrap.sh" \
   -o /tmp/bootstrap.sh || echo "[setup] could not fetch bootstrap.sh"
 
-{ sh /tmp/bootstrap.sh main --with-gcloud; echo $? > /tmp/bootstrap.rc; } 2>&1 \
+{ sh /tmp/bootstrap.sh "$REF" --profile "$PROFILE"; echo $? > /tmp/bootstrap.rc; } 2>&1 \
   | tee /tmp/bootstrap.log
 
 echo "[setup] bootstrap exit=$(cat /tmp/bootstrap.rc 2>/dev/null) at $(date -u +%FT%TZ)"
 exit 0
 ```
+
+**The first three lines are the whole per-environment configuration.** Below
+them the script is byte-identical on every surface, which is the point: a
+Codex environment differs from a Claude one by one word, and a pinned
+environment from a tracking one by one word, in a place obvious enough that
+nobody has to read the rest to find it.
+
+`REF` is a variable rather than typed twice because it appears in two places —
+the ref this script is fetched from, and the ref it installs everything else
+from. Those straddling different versions is precisely the failure the pin
+exists to prevent, and two literals are two chances to update only one.
 
 **Do not put a shebang in this field.** The harness writes the field's contents
 into a generated `/tmp/init-script-*.sh` beneath a header of its own and runs
@@ -61,8 +74,54 @@ Downloading the bootstrap to a file rather than piping it into `sh` is also
 deliberate: it separates "could not fetch" from "ran and failed", and it keeps
 the run's own exit status reachable.
 
-Drop `--with-gcloud` for an environment that does no Google Cloud work; it
-saves a ~96 MB download and declares what kind of environment this is.
+### What a profile includes
+
+The profile selects the capabilities as well as the context, so most
+environments need no capability flags at all:
+
+| Profile | gcloud | pre-commit | hooks | gh |
+| --- | --- | --- | --- | --- |
+| `claude-cloud-sandbox` | yes | yes | yes | no |
+| `codex-cloud-sandbox` | yes | yes | no | no |
+| `*-workstation` | no | no | no | no |
+
+These are read off the profile name rather than held in a table the script
+would have to grow a row in per profile. A `claude-*` profile gets the harness
+hooks because `~/.claude/settings.json` is a Claude mechanism and Codex does not
+read it — ADR-0016 principle 3, provider-specific coupling on provider-specific
+surfaces, applied to the installer. Anything `*-cloud-sandbox` gets pre-commit
+and gcloud, because a sandbox is disposable and rebuilt from a script: the
+argument for making a developer opt into enforcement is about protecting
+somebody's laptop, and there is no laptop here. #254 is what its absence cost.
+
+`gh` is off everywhere. It is documented below as counterproductive on
+Anthropic-hosted sandboxes, so it waits for a caller who knows their egress.
+
+### Overriding a profile
+
+Every capability takes `--with-X` to force it on and `--no-X` to force it off.
+Either beats the profile wherever it sits on the line, so ordering against
+`--profile` does not matter:
+
+```sh
+sh /tmp/bootstrap.sh "$REF" --profile "$PROFILE" --no-gcloud
+```
+
+`--no-gcloud` is the one worth knowing: it saves a ~96 MB download in an
+environment that does no Google Cloud work. `--no-precommit` is the escape for
+an environment that cannot reach the Ubuntu archives, since that is the only
+part of the script needing them.
+
+The run reports what it resolved, because with defaults in play the command
+line no longer says what happened:
+
+```text
+[bootstrap] profile -> claude-cloud-sandbox
+[bootstrap] caps    :  gcloud=yes precommit=yes hooks=yes gh=no
+```
+
+The same set is written to `~/.agents/.bootstrap-manifest`, which is where to
+look when a container is behaving as though something is missing.
 
 `--with-gh` installs the GitHub CLI from a pinned release — but **do not add
 it to Anthropic-hosted environments**. Measured 2026-08-19: the egress proxy
@@ -84,12 +143,11 @@ snapshot built the first time. Bump the number to force a rebuild.
 Pin a tag instead of `main` for anything beyond development:
 
 ```sh
-  .../v0.1.0/cloud/bootstrap.sh -o /tmp/bootstrap.sh
-sh /tmp/bootstrap.sh v0.1.0 --with-gcloud
+REF=v0.1.0
 ```
 
-Both occurrences change together — the ref that fetches the script and the ref
-it installs everything else from — so that a run cannot straddle two versions.
+One word, one place — which is why `REF` is a variable rather than the two
+literals it replaced.
 
 A mutable ref means any compromise of this repo reaches every sandbox that
 starts afterwards. A tag also names, in the session's own log, which version it
@@ -236,9 +294,7 @@ Sandboxes bypassed the pre-commit framework entirely until `--with-precommit`:
 the binary was absent and no `.git/hooks/pre-commit` existed, so a repo's
 committed `.pre-commit-config.yaml` did nothing here (#254).
 
-```sh
-  | sh -s -- <REF> --with-precommit
-```
+On by default for every `*-cloud-sandbox` profile; `--no-precommit` opts out.
 
 It installs `pre-commit`, plus `shellcheck` and `actionlint`, which this
 estate's config runs as `language: system` hooks — they use the binary on
@@ -247,10 +303,16 @@ if the binaries are present. Installing them is the point; the config's `SKIP=`
 escape is for a laptop missing one, and normalising it would leave enforcement
 that is routinely skipped.
 
-Opt-in for two reasons: it is the only part of this script needing the Ubuntu
-archives, so an environment that cannot reach them keeps working by not asking;
-and the one line an environment carries should declare what kind of environment
-it is.
+It used to be opt-in for two reasons: it is the only part of this script needing
+the Ubuntu archives, so an environment that cannot reach them keeps working by
+not asking; and the one line an environment carries should declare what kind of
+environment it is.
+
+The second reason is now served better by `--profile`, which declares the same
+thing at less cost. The first survives as `--no-precommit`, but it is an escape
+rather than a default: an enforcement mechanism that arrives only when someone
+remembers to ask for it is the state #254 described, and the whole point of a
+sandbox being rebuilt from a script is that nobody has to remember.
 
 **The hook is global, via `core.hooksPath`, not `pre-commit install` per repo.**
 This script runs from an environment setup script whose ordering against the
@@ -280,9 +342,9 @@ returns the failure into its context — so the agent reads the message and fixe
 the cause rather than simply being stopped. Both are worth having; neither
 replaces the other.
 
-```sh
-  | sh -s -- <REF> --with-precommit --with-hooks
-```
+Both are on by default for `claude-*` sandbox profiles. A Codex profile gets
+pre-commit but not the harness hooks, because Codex does not read
+`~/.claude/settings.json`.
 
 Viable because a container-created `~/.claude/settings.json` **is** honoured —
 measured 2026-08-18 by planting one and watching a `PreToolUse` hook fire eight
@@ -342,8 +404,7 @@ hooks in a container-created `~/.claude/settings.json` are honoured at all
 codex-cloud-sandbox`:
 
 ```sh
-curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh \
-  | sh -s -- <REF> --profile codex-cloud-sandbox
+PROFILE=codex-cloud-sandbox
 ```
 
 The environment declares which harness it is rather than the script sniffing
@@ -367,11 +428,13 @@ Re-run the bootstrap directly; no environment edit, no restart:
 
 ```sh
 curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/main/cloud/bootstrap.sh \
-  | sh -s -- main --with-gcloud
+  -o /tmp/bootstrap.sh
+sh /tmp/bootstrap.sh main --profile claude-cloud-sandbox
 ```
 
-Keep `--with-gcloud` even where gcloud exists: it skips the download but is also
-the branch that installs the gcloud wrapper.
+Do not add `--no-gcloud` here even where gcloud already exists: the install is
+skipped anyway when it is on `PATH`, and that same branch is what installs the
+gcloud wrapper.
 
 Skills are read when the agent starts, so a newly installed skill appears after
 the session restarts or resumes. The helper is usable immediately.

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -42,7 +42,13 @@
 #
 # This script fails loudly: a half-installed toolkit is worse than none, and the
 # caller is better placed to decide tolerance. A cloud setup script, which fails
-# the whole session on a non-zero exit, should append `|| true`.
+# the whole session on a non-zero exit, should end with `exit 0`.
+#
+# What it should NOT carry is a shebang. A vendor setup-script field is pasted
+# into a generated script beneath a header of the harness's own, so the line is
+# never line 1 and never selects an interpreter -- and a `#!` that loses its `#`
+# somewhere in that journey becomes a command, exiting 127 before this script is
+# even fetched. cloud/README.md carries the working snippet.
 #
 # It installs no credentials and reads none. What it places is public content
 # from a public repo.
@@ -84,6 +90,93 @@ command -v curl > /dev/null 2>&1 || die "curl is required"
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT INT TERM
 
+# --- fetch: every download in this script goes through here ---------------
+#
+# A bare `curl -sSfL` is a single attempt. This script makes roughly a dozen
+# of them across three hosts, so a run's success is the product of a dozen
+# independent chances of a transient blip -- and a blip here fails the whole
+# session, not just the fetch. Retries turn a class of failures that used to
+# need a human back into a two-second pause.
+#
+# --retry-connrefused and --retry-all-errors are what make it cover the cases
+# that actually happen: without them curl retries transient *transport*
+# errors only, and a proxy answering 502 while it warms up is not one.
+# --connect-timeout bounds a black-holed connection (no RST, no response),
+# which otherwise hangs until the harness's own setup timeout kills the run
+# with far less to go on than a curl error. --speed-limit/--speed-time bound
+# the other stall -- a connection that opens, dribbles, and never finishes --
+# without the collateral damage a tight --max-time would do to the gcloud
+# tarball, which is 96 MB and legitimately slow on a bad link.
+#
+# --retry-all-errors landed in curl 7.71 (--retry-connrefused in 7.52); the
+# sandbox image ships 8.5.0. An older curl rejects an unknown option rather
+# than ignoring it, which would fail every fetch, so probe for the newer of
+# the two and drop both if it is absent. `--help all` is itself 7.73+, so an
+# older curl fails the probe and takes the fallback -- which is the answer
+# wanted in that case anyway.
+CURL_RETRY_OPTS='--retry 3 --retry-delay 2 --retry-connrefused --retry-all-errors'
+if ! curl --help all 2>/dev/null | grep -q -- --retry-all-errors; then
+    CURL_RETRY_OPTS='--retry 3 --retry-delay 2'
+fi
+
+fetch() {
+    # fetch <url> <dest>
+    # shellcheck disable=SC2086  # CURL_RETRY_OPTS is a deliberate word list
+    curl -sSfL $CURL_RETRY_OPTS \
+        --connect-timeout 15 --speed-limit 1024 --speed-time 30 --max-time 600 \
+        "$1" -o "$2"
+}
+
+# --- apt_update: refresh Ubuntu's own sources, and only those --------------
+#
+# `apt-get update` returns non-zero if ANY configured source fails, and a
+# sandbox image carries sources this script has no interest in: deadsnakes,
+# ondrej/php and docker.list all ship in /etc/apt/sources.list.d/. Where
+# egress policy blocks a PPA -- which it does in some environments and not
+# others -- a bare update fails on a repository nothing here needs, and the
+# only package actually wanted (shellcheck) is in the Ubuntu archive.
+#
+# So point apt at Ubuntu's list alone and blank SourceParts, which is the
+# directory the third-party entries live in. noble and later put the archive
+# entries in deb822 /etc/apt/sources.list.d/ubuntu.sources; jammy and earlier
+# in /etc/apt/sources.list. Try whichever exists, then an unrestricted update
+# as a last resort for an image laid out like neither.
+#
+# The return value is advisory. Callers should attempt the install regardless:
+# a refresh that could not reach the archive still leaves whatever package
+# lists the image was built with, and those are frequently enough.
+apt_update() {
+    for _src in /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list; do
+        [ -s "$_src" ] || continue
+        if apt-get update -qq \
+            -o Dir::Etc::SourceList="$_src" \
+            -o Dir::Etc::SourceParts=/dev/null > /dev/null 2>&1; then
+            return 0
+        fi
+    done
+    apt-get update -qq > /dev/null 2>&1
+}
+
+# --- pip_install: PyPI, whatever this image calls pip ----------------------
+#
+# `pip` is not always on PATH where `pip3` is, and Ubuntu 24.04 ships a PEP 668
+# EXTERNALLY-MANAGED marker that makes a system-wide install refuse outright.
+# Refusing is right on a workstation and pointless in a container that exists
+# for one session and is thrown away, so retry with --break-system-packages --
+# a flag pip only grew in 23.0, hence the retry rather than passing it first.
+pip_install() {
+    _pkg="$1"
+    for _pip in "pip" "pip3" "python3 -m pip"; do
+        command -v "${_pip%% *}" > /dev/null 2>&1 || continue
+        # shellcheck disable=SC2086  # deliberate word split: "python3 -m pip"
+        $_pip install --quiet --no-input "$_pkg" > /dev/null 2>&1 && return 0
+        # shellcheck disable=SC2086
+        $_pip install --quiet --no-input --break-system-packages "$_pkg" \
+            > /dev/null 2>&1 && return 0
+    done
+    return 1
+}
+
 log "installing from ${REF}"
 
 # There is deliberately no apt step here.
@@ -120,8 +213,8 @@ log "installing from ${REF}"
 # that costs a second human approval.
 
 if [ "$WITH_GCLOUD" -eq 1 ] && ! command -v gcloud > /dev/null 2>&1; then
-    curl -sSL -o "$TMP/gcloud.tar.gz" \
-        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz ||
+    fetch https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz \
+        "$TMP/gcloud.tar.gz" ||
         die "could not download the gcloud SDK — is dl.google.com on the allowlist?"
     tar -xzf "$TMP/gcloud.tar.gz" -C /opt || die "could not unpack the gcloud SDK"
     # --path-update false, then symlink: a PATH line appended to a shell profile
@@ -221,7 +314,7 @@ else
     mkdir -p "$BIN_DIR"
 fi
 
-curl -sSfL "$RAW/home/bin/gcp-credentials" -o "$TMP/gcp-credentials" ||
+fetch "$RAW/home/bin/gcp-credentials" "$TMP/gcp-credentials" ||
     die "could not fetch the helper from $REF"
 # Refuse an error page rendered as a script. A 404 from a bad ref is HTML, and
 # `sh` would run it and report something baffling.
@@ -262,7 +355,7 @@ log "compat  -> $HOME/.claude/bin/gcp-credentials -> $BIN_DIR/gcp-credentials"
 # invoked it unprompted. What a symlinked skill directory does is the part still
 # worth watching; if Claude stops listing the skill, that is why.
 
-curl -sSfL "$RAW/home/commands/gcp-credentials.md" -o "$TMP/gcp-credentials.md" ||
+fetch "$RAW/home/commands/gcp-credentials.md" "$TMP/gcp-credentials.md" ||
     die "could not fetch the skill from $REF"
 
 # SKILL.md wants frontmatter the command format does not carry. The first line
@@ -323,11 +416,16 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     # laptop missing one, and normalising it would leave enforcement that is
     # routinely skipped, which is not enforcement.
     if ! command -v shellcheck > /dev/null 2>&1; then
-        if ! apt-get update -qq > /dev/null 2>&1; then
-            die "apt-get update failed — are the Ubuntu archives reachable?"
-        fi
-        if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq shellcheck > /dev/null 2>&1; then
-            die "could not install shellcheck"
+        # A failed refresh is reported, not fatal. It used to die here, which
+        # meant a blocked PPA -- a repository nothing in this script wants --
+        # took down an install that the image's existing package lists would
+        # have satisfied. apt_update narrows the sources to Ubuntu's own, so
+        # a failure now means the archives really are unreachable; even then,
+        # let the install be the thing that decides.
+        apt_update || log "warn: apt refresh failed, trying the install anyway"
+        if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq shellcheck \
+            > /dev/null 2>&1; then
+            die "could not install shellcheck — are the Ubuntu archives reachable?"
         fi
     fi
     log "shellck -> $(command -v shellcheck)"
@@ -338,8 +436,8 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     # against github.com reads as an egress block and is not one.
     if ! command -v actionlint > /dev/null 2>&1; then
         AL_VER=1.7.7
-        curl -sSfL -o "$TMP/actionlint.tar.gz" \
-            "https://github.com/rhysd/actionlint/releases/download/v${AL_VER}/actionlint_${AL_VER}_linux_amd64.tar.gz" ||
+        fetch "https://github.com/rhysd/actionlint/releases/download/v${AL_VER}/actionlint_${AL_VER}_linux_amd64.tar.gz" \
+            "$TMP/actionlint.tar.gz" ||
             die "could not download actionlint ${AL_VER}"
         tar -xzf "$TMP/actionlint.tar.gz" -C "$TMP" actionlint || die "could not unpack actionlint"
         install -m 0755 "$TMP/actionlint" /usr/local/bin/actionlint || die "could not install actionlint"
@@ -347,7 +445,7 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     log "actionl -> $(command -v actionlint)"
 
     command -v pre-commit > /dev/null 2>&1 ||
-        pip install --quiet --no-input pre-commit > /dev/null 2>&1 ||
+        pip_install pre-commit ||
         die "could not install pre-commit from PyPI"
     log "precmit -> $(command -v pre-commit) ($(pre-commit --version))"
 
@@ -403,8 +501,8 @@ fi
 
 if [ "$WITH_GH" -eq 1 ] && ! command -v gh > /dev/null 2>&1; then
     GH_VER=2.97.0
-    curl -sSfL -o "$TMP/gh.tar.gz" \
-        "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz" ||
+    fetch "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz" \
+        "$TMP/gh.tar.gz" ||
         die "could not download gh ${GH_VER}"
     tar -xzf "$TMP/gh.tar.gz" -C "$TMP" "gh_${GH_VER}_linux_amd64/bin/gh" ||
         die "could not unpack gh"
@@ -438,7 +536,7 @@ fi
 PROFILE_DIR="$HOME/.agents"
 mkdir -p "$PROFILE_DIR"
 
-curl -sSfL "$RAW/profiles/$PROFILE/AGENTS.md" -o "$TMP/AGENTS.md" ||
+fetch "$RAW/profiles/$PROFILE/AGENTS.md" "$TMP/AGENTS.md" ||
     die "could not fetch profile '$PROFILE' from $REF — check the name against profiles/ in the repo"
 
 # Same 404-as-content guard as everything else here: a bad ref or a mistyped
@@ -465,7 +563,7 @@ log "policy  -> $PROFILE_DIR/AGENTS.md (profile: $PROFILE)"
 # claims that path is the one Codex reads.
 case "$PROFILE" in
     claude-*)
-        curl -sSfL "$RAW/profiles/$PROFILE/CLAUDE.md" -o "$TMP/CLAUDE.md" ||
+        fetch "$RAW/profiles/$PROFILE/CLAUDE.md" "$TMP/CLAUDE.md" ||
             die "could not fetch the Claude adapter for profile '$PROFILE' from $REF"
         head -1 "$TMP/CLAUDE.md" | grep -q "^<!-- GENERATED" ||
             die "fetched Claude adapter is not a composed artefact"
@@ -543,7 +641,7 @@ BIN_SCRIPTS="start-session-gather-state start-session-claude-drift end-session-g
 mkdir -p "$HOME/.claude/bin"
 
 for script in $BIN_SCRIPTS; do
-    curl -sSfL "$RAW/home/bin/$script" -o "$TMP/$script" ||
+    fetch "$RAW/home/bin/$script" "$TMP/$script" ||
         die "could not fetch helper script $script from $REF"
     head -1 "$TMP/$script" | grep -q '^#!' ||
         die "fetched $script is not a script — check that $REF exists"
@@ -560,7 +658,7 @@ for skill in $SKILLS $COMPOSED_SKILLS; do
         *) src="home/skills/$skill/SKILL.md" ;;
     esac
 
-    curl -sSfL "$RAW/$src" -o "$TMP/$skill.SKILL.md" ||
+    fetch "$RAW/$src" "$TMP/$skill.SKILL.md" ||
         die "could not fetch the $skill skill from $REF ($src) — a composed skill needs a profiles/$PROFILE/skills/ entry in context/manifest.json"
 
     # Same 404-as-content guard as the helper: a bad ref returns an HTML error
@@ -613,13 +711,13 @@ if [ "$WITH_HOOKS" -eq 1 ]; then
     command -v jq > /dev/null 2>&1 || die "--with-hooks needs jq to merge settings.json"
 
     for script in prchecks-wait-claude-hook prepush-guard-claude-hook precommit-claude-hook; do
-        curl -sSfL "$RAW/home/bin/$script" -o "$TMP/$script" ||
+        fetch "$RAW/home/bin/$script" "$TMP/$script" ||
             die "could not fetch hook script $script from $REF"
         head -1 "$TMP/$script" | grep -q '^#!' || die "fetched $script is not a script"
         install -m 0755 "$TMP/$script" "$HOME/.claude/bin/$script"
     done
 
-    curl -sSfL "$RAW/home/settings.json" -o "$TMP/settings.json" ||
+    fetch "$RAW/home/settings.json" "$TMP/settings.json" ||
         die "could not fetch home/settings.json from $REF"
     jq -e '.hooks' "$TMP/settings.json" > "$TMP/hooks.json" ||
         die "home/settings.json has no .hooks block"

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -5,39 +5,52 @@
 # everything of substance stays here, versioned, instead of being pasted into a
 # vendor configuration field (ADR-0016, principle 5):
 #
-#   curl -sSL https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/<REF>/cloud/bootstrap.sh | sh -s -- <REF> [--with-gcloud] [--with-precommit] [--with-hooks] [--with-gh] [--profile <name>]
+#   sh bootstrap.sh <REF> [--profile <name>] [--with-X | --no-X ...]
 #
-# --with-gcloud installs the Google Cloud SDK as well. Opt-in, so that the one
-# line an environment carries declares what kind of environment it is.
+# --profile names the composed context profile, defaulting to
+# claude-cloud-sandbox, and is the only argument most environments need. It
+# selects the AGENTS.md/CLAUDE.md to install AND, through the rules below the
+# argument loop, which capabilities come with it. The environment declares
+# which harness it is rather than this script sniffing for one: ADR-0018
+# principle 1 puts surface differences in the delivery, and the caller is the
+# only party that knows the answer without guessing.
+#
+# What each profile resolves to today:
+#
+#                          gcloud  pre-commit  hooks  gh
+#   claude-cloud-sandbox     yes       yes      yes   no
+#   codex-cloud-sandbox      yes       yes      no    no
+#   *-workstation            no        no       no    no
+#
+# Every capability takes --with-X to force it on and --no-X to force it off,
+# and either beats the profile wherever it sits on the line. The capabilities:
+#
+# --with-gcloud installs the Google Cloud SDK, a ~96 MB download. On by default
+# for a sandbox; --no-gcloud for an environment that does no GCP work.
 #
 # --with-precommit installs the pre-commit framework and the binaries this
 # estate's hooks need, and points git at a global hook so every repo in the
-# container is covered. Opt-in for the same reason, and one more: it is the only
-# part of this script that needs the Ubuntu archives, so an environment that
-# cannot reach them keeps working by not asking for it.
+# container is covered. It is the only part of this script that needs the
+# Ubuntu archives, so --no-precommit is the escape for an environment that
+# cannot reach them.
 #
 # --with-hooks wires this estate's PreToolUse guards and PostToolUse terraform
 # hooks into ~/.claude/settings.json. Separate from --with-precommit because
 # they are different mechanisms: a git hook blocks the commit, a harness hook
-# returns the failure into the agent's context where it can act on it.
+# returns the failure into the agent's context where it can act on it. Claude
+# profiles only -- Codex does not read that file.
 #
 # --with-gh installs the GitHub CLI from a pinned release tarball, for the
 # session skills' gather scripts. NOT for Anthropic-hosted web sandboxes:
 # there the egress proxy authenticates gh for identity endpoints only and
 # 403s every repo-scoped API path, so the gather sections come back
 # gh-unauthorized rather than populated — measured 2026-08-19, lane map on
-# #257, cleanup on #273. The flag exists for surfaces whose egress genuinely
-# reaches the GitHub API, e.g. self-hosted environments.
+# #257, cleanup on #273. Off for every profile; the flag exists for surfaces
+# whose egress genuinely reaches the GitHub API, e.g. self-hosted environments.
 #
-# --profile names the composed context profile to install, defaulting to
-# claude-cloud-sandbox. A Codex environment passes --profile codex-cloud-sandbox.
-# The environment declares which harness it is rather than this script sniffing
-# for one: ADR-0018 principle 1 puts surface differences in the delivery, and
-# the caller is the only party that knows the answer without guessing.
-#
-# Pass the same <REF> twice on purpose: the first fetches this script, the
-# second is what it fetches everything else from, so a run cannot straddle two
-# versions. Pin <REF> to a tag or commit in anything durable — a branch means
+# <REF> is what everything else is fetched from, and should match the ref this
+# script was itself fetched from, so a run cannot straddle two versions. Pin it
+# to a tag or commit in anything durable — a branch means
 # any compromise of this repo reaches every sandbox that starts afterwards.
 #
 # This script fails loudly: a half-installed toolkit is worse than none, and the
@@ -60,18 +73,25 @@ die() { echo "[bootstrap] error: $*" >&2; exit 1; }
 
 REF="${1:-main}"
 [ $# -gt 0 ] && shift
-WITH_GCLOUD=0
-WITH_PRECOMMIT=0
-WITH_HOOKS=0
-WITH_GH=0
+# Empty means "the caller did not say", which is distinct from --no-X. The
+# profile fills in only the ones still empty, so a flag wins wherever it
+# appears on the line -- including before the --profile it contradicts.
+WITH_GCLOUD=
+WITH_PRECOMMIT=
+WITH_HOOKS=
+WITH_GH=
 PROFILE=claude-cloud-sandbox
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --with-gcloud) WITH_GCLOUD=1 ;;
+        --no-gcloud) WITH_GCLOUD=0 ;;
         --with-precommit) WITH_PRECOMMIT=1 ;;
+        --no-precommit) WITH_PRECOMMIT=0 ;;
         --with-hooks) WITH_HOOKS=1 ;;
+        --no-hooks) WITH_HOOKS=0 ;;
         --with-gh) WITH_GH=1 ;;
+        --no-gh) WITH_GH=0 ;;
         --profile)
             shift
             [ $# -gt 0 ] || die "--profile needs a value"
@@ -82,6 +102,55 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
+
+# --- what the profile implies ------------------------------------------------
+#
+# The profile already states two facts, and the defaults are read off them
+# rather than kept in a per-profile table that would need a row adding every
+# time a profile is. A table of two columns and N rows says no more than the
+# name does, and goes stale in a way the name cannot.
+#
+#   claude-*         -> hooks. ~/.claude/settings.json is a Claude mechanism;
+#                      Codex does not read it. Installing the harness hooks
+#                      alongside a Codex profile put four files in the
+#                      container that nothing there consumes -- ADR-0016
+#                      principle 3, provider-specific coupling belongs on
+#                      provider-specific surfaces, applied to the installer.
+#
+#   *-cloud-sandbox  -> pre-commit, and gcloud. A sandbox is disposable and
+#                      rebuilt from a script, so the argument for making a
+#                      developer opt into enforcement does not apply: there is
+#                      no laptop here whose setup someone is protecting. #254
+#                      is what the absence cost.
+#
+# gh is the one capability with no sensible default. It is documented as
+# actively counterproductive on Anthropic-hosted sandboxes, where the egress
+# proxy 403s every repo-scoped path, so it stays off until a caller who knows
+# their egress asks for it.
+#
+# gcloud on by default is a reversal, and worth naming as one. It used to be
+# opt-in so that "the one line an environment carries declares what kind of
+# environment it is" -- but the profile name declares that now, and better,
+# so the flag was only restating what --profile already said. The 96 MB is the
+# price; --no-gcloud is the refund for an environment that does no GCP work.
+resolve() {
+    # resolve <current> <default> -- echo the caller's answer, or the default
+    if [ -n "$1" ]; then echo "$1"; else echo "$2"; fi
+}
+
+case "$PROFILE" in
+    claude-*) def_hooks=1 ;;
+    *) def_hooks=0 ;;
+esac
+case "$PROFILE" in
+    *-cloud-sandbox) def_precommit=1; def_gcloud=1 ;;
+    *) def_precommit=0; def_gcloud=0 ;;
+esac
+
+WITH_GCLOUD=$(resolve "$WITH_GCLOUD" "$def_gcloud")
+WITH_PRECOMMIT=$(resolve "$WITH_PRECOMMIT" "$def_precommit")
+WITH_HOOKS=$(resolve "$WITH_HOOKS" "$def_hooks")
+WITH_GH=$(resolve "$WITH_GH" 0)
 
 RAW="https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/${REF}"
 
@@ -178,6 +247,13 @@ pip_install() {
 }
 
 log "installing from ${REF}"
+
+# Print the resolved set, not the flags. With defaults in play the command line
+# no longer says what a run will do, and a container is read afterwards far more
+# often than the setup script that built it.
+on_off() { [ "$1" -eq 1 ] && echo "yes" || echo "no"; }
+log "profile -> $PROFILE"
+log "caps    :  gcloud=$(on_off "$WITH_GCLOUD") precommit=$(on_off "$WITH_PRECOMMIT") hooks=$(on_off "$WITH_HOOKS") gh=$(on_off "$WITH_GH")"
 
 # There is deliberately no apt step here.
 #
@@ -793,6 +869,7 @@ fi
     echo "helpers=$BIN_SCRIPTS"
     echo "precommit=$WITH_PRECOMMIT"
     echo "gcloud=$WITH_GCLOUD"
+    echo "hooks=$WITH_HOOKS"
     echo "gh=$WITH_GH"
 } > "$MANIFEST"
 log "manifst -> $MANIFEST ($kind $(echo "$resolved" | cut -c1-12))"


### PR DESCRIPTION
Overhauls `cloud/bootstrap.sh` to make capability selection declarative and resilient, addressing several classes of failure observed in production.

## Summary

The bootstrap script now derives capability defaults from the profile name rather than requiring explicit flags, reducing configuration surface and making the environment's nature self-evident. Fetch operations are now resilient to transient failures and proxy issues. The setup snippet in `cloud/README.md` is simplified and made POSIX-safe.

## Key Changes

**Profile-driven defaults:**

- Capabilities (`gcloud`, `pre-commit`, `hooks`, `gh`) now default based on profile name: `claude-*` profiles get hooks, `*-cloud-sandbox` profiles get pre-commit and gcloud
- `--with-X` and `--no-X` flags override defaults and work anywhere on the command line
- Eliminates the need for most environments to specify flags at all; `--profile` alone suffices
- Fixes a live defect: `--with-hooks` alongside a `codex-*` profile installed three hook scripts and a `~/.claude/settings.json` that Codex never reads. That is ADR-0016 principle 3 (provider-specific coupling on provider-specific surfaces) applied to the installer

**Resilient fetch operations:**

- New `fetch()` function wraps all curl calls with retry logic (`--retry 3 --retry-delay 2 --retry-connrefused --retry-all-errors`)
- Probes for curl 7.71+ features and falls back gracefully on older versions
- Adds connection timeout, speed limits, and max-time bounds to prevent hangs on slow or broken links
- Replaces all bare `curl -sSL` calls throughout the script

**Improved apt handling:**

- New `apt_update()` function narrows sources to Ubuntu's archive only, avoiding failures from blocked PPAs
- Refresh failures are now advisory rather than fatal; the install attempt proceeds anyway
- Handles both deb822 format (`/etc/apt/sources.list.d/ubuntu.sources`) and legacy format

**Simplified pip installation:**

- New `pip_install()` function tries multiple pip variants and retries with `--break-system-packages` for Ubuntu 24.04 PEP 668 compliance

**Setup snippet redesign:**

- Removes shebang from the field (it never takes effect and can corrupt in transit — a live environment lost its `#` and exited 127 before `curl` ran)
- Converts to POSIX shell (no bashisms like `PIPESTATUS`)
- Downloads bootstrap to a file before executing, separating fetch failures from execution failures
- Records exit status and timestamps for diagnostics
- Uses variables (`PROFILE`, `REF`) instead of literals, so per-environment config is the first three lines and everything below is identical across surfaces

**Documentation:**

- `cloud/README.md` expanded with profile capability table, override examples, and explanation of why the setup snippet is structured as it is
- ADR-0016 principle 3 updated to note that provider-specific coupling applies to installers, not only committed config; its setup-script example amended, since as written it carried the `#!/bin/bash` line this PR removes

**Logging improvements:**

- Bootstrap now reports resolved capabilities at startup, not just command-line flags
- Manifest includes `hooks=` field for completeness

## Implementation Details

The profile-to-defaults mapping is derived from the profile name itself rather than a lookup table:

- `case "$PROFILE" in claude-*) def_hooks=1 ;;` — Claude profiles get hooks
- `case "$PROFILE" in *-cloud-sandbox) def_precommit=1; def_gcloud=1 ;;` — Sandboxes get pre-commit and gcloud

This avoids a table that would need a row per profile and go stale; the name is the source of truth.

The `resolve()` helper applies the override logic: if a flag was set (non-empty), use it; otherwise use the profile default. This works regardless of flag order on the command line.

Fetch resilience is centralized in one function, making retry policy consistent and maintainable across ~a dozen download operations.

Note that `gcloud` defaulting on is a deliberate reversal of its previous opt-in status, named as such in the code: the flag existed so the environment's one line would declare what kind of environment it is, and `--profile` now declares that more directly. `--no-gcloud` is the opt-out.

## Verification

- Full gate suite green: markdownlint (126 files), shellcheck, four shell tests, two Python tests
- Capability resolution checked across nine flag/profile combinations, including flags placed before the `--profile` they override, contradictory flags (last wins), and unknown args (still fatal)
- `bootstrap.sh` run end-to-end against a throwaway `HOME` for both `claude-cloud-sandbox` and `codex-cloud-sandbox`; the Codex run correctly produced no `CLAUDE.md` and `hooks=no`
- `fetch()`, `apt_update()` and `pip_install()` smoke-tested standalone

Closes #321

https://claude.ai/code/session_012qCCYkbcbPfAMFB4rhzzH1