### PR TITLE
Make the bootstrap's claims match what it resolved

### DIFF
--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -71,8 +71,18 @@ set -eu
 log() { echo "[bootstrap] $*"; }
 die() { echo "[bootstrap] error: $*" >&2; exit 1; }
 
-REF="${1:-main}"
-[ $# -gt 0 ] && shift
+# The ref is positional and first. Guard it against a flag, because taking $1
+# unconditionally makes a caller who omits the ref install from a ref named
+# "--profile" -- and the failure surfaces as `unknown argument:
+# claude-cloud-sandbox` from the loop below, which names the profile's VALUE
+# and points at the wrong token entirely. The documented snippet always passes
+# the ref first, so this bites whoever runs the script by hand.
+REF=main
+case "${1:-}" in
+    "") ;;
+    -*) ;;
+    *) REF="$1"; shift ;;
+esac
 # Empty means "the caller did not say", which is distinct from --no-X. The
 # profile fills in only the ones still empty, so a flag wins wherever it
 # appears on the line -- including before the --profile it contradicts.
@@ -523,6 +533,16 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     command -v pre-commit > /dev/null 2>&1 ||
         pip_install pre-commit ||
         die "could not install pre-commit from PyPI"
+    # pip exiting 0 is not the same as the console script existing. An image
+    # carrying the pre_commit package without its shim, or a pip whose scripts
+    # directory is off PATH, both satisfy the install and leave nothing to run
+    # -- observed on a live sandbox, which logged `precmit ->  ()` and stamped
+    # the manifest precommit=1 anyway (#319). The manifest is read as an
+    # attestation that the gate is *present* (#254's checklist opens with
+    # "expect precommit=1"), so observe the binary rather than inferring it
+    # from an exit code.
+    command -v pre-commit > /dev/null 2>&1 ||
+        die "pre-commit reported installed but is not on PATH"
     log "precmit -> $(command -v pre-commit) ($(pre-commit --version))"
 
     # A GLOBAL hook via core.hooksPath, not `pre-commit install` per repo.
@@ -818,12 +838,19 @@ if [ "$WITH_HOOKS" -eq 1 ]; then
         log "hooks   -> $SETTINGS (created)"
     fi
 
-    # prepush-guard needs gh, which these containers lack unless --with-gh was
-    # given (#257), so without it it exits 0 here. precommit-claude-hook needs
-    # the pre-commit framework and is a no-op without --with-precommit. Both
-    # degrade rather than failing, which is why this flag has no hard
-    # dependency on those -- but the trio is what makes it worth having.
-    log "hooks   :  prchecks-wait, prepush-guard (needs --with-gh), precommit (needs --with-precommit)"
+    # prepush-guard needs gh, which these containers lack unless gh was enabled
+    # (#257), so without it it exits 0 here. precommit-claude-hook needs the
+    # pre-commit framework and is a no-op without it. Both degrade rather than
+    # failing, which is why hooks have no hard dependency on those -- but the
+    # trio is what makes them worth having.
+    #
+    # Report the resolved state rather than naming the flags. Since #322 either
+    # capability can arrive from the profile with no flag typed, so a fixed
+    # "(needs --with-precommit)" told the reader the opposite of the truth in
+    # every *-cloud-sandbox container -- which turns it on by default.
+    if [ "$WITH_GH" -eq 1 ]; then gh_note=""; else gh_note=" (inactive: no gh)"; fi
+    if [ "$WITH_PRECOMMIT" -eq 1 ]; then pc_note=""; else pc_note=" (inactive: no pre-commit)"; fi
+    log "hooks   :  prchecks-wait, prepush-guard$gh_note, precommit$pc_note"
 fi
 
 # --- the manifest -------------------------------------------------------------


### PR DESCRIPTION
Three fixes to `cloud/bootstrap.sh`, all the same shape: **the script asserted
something it had not checked.**

Found while verifying #322 against this container, which was built three
minutes after that PR merged.

## 1. The manifest attested to a gate that might not exist (#319)

`pip` exiting 0 is not the same as the console script existing. An image
carrying the `pre_commit` package without its shim, or a `pip` whose scripts
directory is off `PATH`, both satisfy the install and leave nothing to run —
yet the manifest was stamped `precommit=1` regardless.

Applied #319's own proposal:

```sh
command -v pre-commit > /dev/null 2>&1 ||
    die "pre-commit reported installed but is not on PATH"
```

Reproduced the reported state (a `pip` stubbed to exit 0, no `pre-commit` on
`PATH`):

```text
[bootstrap] error: pre-commit reported installed but is not on PATH
exit=1
(no manifest — bootstrap died before stamping)
```

The last line is the point. Previously the run exited 0 and wrote
`precommit=1`; now it fails *before* the manifest is written, so nothing
attests to an absent gate.

## 2. The hooks summary contradicted the line above it

`bootstrap.sh:846` was a fixed string naming the flags each dependent hook once
needed. This container printed it while precommit was **enabled**:

```text
[bootstrap] caps    :  gcloud=yes precommit=yes hooks=yes gh=no
[bootstrap] hooks   :  prchecks-wait, prepush-guard (needs --with-gh), precommit (needs --with-precommit)
```

The text predates #322, when precommit was genuinely opt-in. Now
`*-cloud-sandbox` turns it on from the profile, so that parenthetical was wrong
in the default configuration of every sandbox — reading as "inert" for a hook
that was live.

Now reports resolved state, which stays true however the capability arrived:

```text
# default sandbox                → precommit
# with --no-precommit            → precommit (inactive: no pre-commit)
```

## 3. A flag-first invocation failed naming the wrong token (#325)

`REF="${1:-main}"` took `$1` unconditionally:

```console
$ sh cloud/bootstrap.sh --profile claude-cloud-sandbox
[bootstrap] error: unknown argument: claude-cloud-sandbox
```

`--profile` was swallowed as the ref, leaving its *value* as the first
unrecognised argument — so the error named the one token on the line that was
entirely correct. A `case` guard now leaves a leading `-` for the argument
loop, which either recognises it or reports it accurately.

This does not affect environments: the documented snippet always passes the ref
first. It bites whoever runs the script by hand, which is exactly what someone
does when testing a change to it.

Dropping `[ $# -gt 0 ] && shift` also removes a construct whose exit status
under `set -e` is a subtlety the `case` avoids.

## Two concerns, one branch

Fixes 1–2 are one concern (honest reporting); fix 3 is argument parsing. They
would normally be separate PRs under the single-concern rule — kept together
because this session has one assigned branch. Both are small and independently
reviewable in the diff.

## Verification

- `shellcheck` clean; `dash -n` clean (POSIX target)
- Four shell tests and both Python tests green
- markdownlint **not run** — `markdownlint-cli2` is not installed in this
  container. No markdown is touched by this diff, so it does not apply; CI will
  confirm
- Behaviour checked end-to-end against throwaway `HOME`s:
  - flag-first invocation now installs from `main`
  - ref-first invocation unchanged
  - no-argument invocation unchanged
  - `--no-precommit` produces the `(inactive: …)` note; default does not
  - the pre-commit post-condition fires and suppresses the manifest

## Not changed

#319 asks whether `gcloud`, `gh`, `shellcheck` and `actionlint` want the same
post-condition. Testing surfaced `[bootstrap] actionl -> ` printing an empty
path rather than failing — the same shape — but only because the test `PATH`
excluded `/usr/local/bin`. It is not reachable on a real container, unlike the
pre-commit case which was. Flagged in a comment on #319 rather than widening
this diff; it belongs with that sweep or with #260.

Closes #319
Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaYjAn81DcxFD1MuCnNKef

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaYjAn81DcxFD1MuCnNKef)_