### PR TITLE
Install markdownlint-cli2 in sandboxes, so the documented gate can run

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -304,11 +304,11 @@ escape is for a laptop missing one, and normalising it would leave enforcement
 that is routinely skipped.
 
 It also installs `markdownlint-cli2` from npm, pinned to the rev
-`.pre-commit-config.yaml` declares. That one is *not* a `language: system`
-hook — the hook builds its own node environment and CI uses the action — so
-committing and CI both worked without it, and only `markdownlint-cli2
-"**/*.md"`, the gate this repo documents first, could not run. Bump the pin and
-the pre-commit rev together.
+`.pre-commit-config.yaml` declares — bump the two together. That one is *not* a
+`language: system` hook: the pre-commit hook builds its own node environment
+and CI uses the action, so this install is what makes `markdownlint-cli2
+"**/*.md"` — the gate this repo documents first — runnable, since that needs
+the binary on `PATH`.
 
 It used to be opt-in for two reasons: it is the only part of this script needing
 the Ubuntu archives, so an environment that cannot reach them keeps working by

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -248,7 +248,7 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `~/.config/git/hooks/pre-commit` | global git hook, with `--with-precommit` |
 | `~/.claude/settings.json` | harness hook wiring, with `--with-hooks` (merged, not replaced) |
 | `~/.claude/bin/*-claude-hook` | the three harness hook scripts, with `--with-hooks` |
-| `/usr/local/bin/pre-commit`, `/usr/bin/shellcheck`, `/usr/local/bin/actionlint` | with `--with-precommit` |
+| `/usr/local/bin/pre-commit`, `/usr/bin/shellcheck`, `/usr/local/bin/actionlint`, `markdownlint-cli2` (npm global) | with `--with-precommit` |
 | `/usr/local/bin/gh` | the GitHub CLI, pinned release, with `--with-gh` |
 
 Whitelisted today: `promote-journal-inbox`, `retrospective`, `start-session`,
@@ -302,6 +302,13 @@ estate's config runs as `language: system` hooks — they use the binary on
 if the binaries are present. Installing them is the point; the config's `SKIP=`
 escape is for a laptop missing one, and normalising it would leave enforcement
 that is routinely skipped.
+
+It also installs `markdownlint-cli2` from npm, pinned to the rev
+`.pre-commit-config.yaml` declares. That one is *not* a `language: system`
+hook — the hook builds its own node environment and CI uses the action — so
+committing and CI both worked without it, and only `markdownlint-cli2
+"**/*.md"`, the gate this repo documents first, could not run. Bump the pin and
+the pre-commit rev together.
 
 It used to be opt-in for two reasons: it is the only part of this script needing
 the Ubuntu archives, so an environment that cannot reach them keeps working by

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -530,22 +530,11 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     fi
     log "actionl -> $(command -v actionlint)"
 
-    # markdownlint-cli2 completes the trio this block exists for. The comment
-    # opening it names markdownlint first among the three that went unenforced
-    # on 2026-08-18, yet only shellcheck and actionlint were ever installed --
-    # so `markdownlint-cli2 "**/*.md"`, the first gate CLAUDE.md documents, was
-    # the one command in that list a sandbox could not run.
-    #
-    # It hid because the other two routes were fine. Unlike those linters this
-    # is not a `language: system` hook: .pre-commit-config.yaml pulls it from
-    # the upstream repo, which builds its own node environment, and CI uses the
-    # action. So committing worked and CI worked, and only a session running
-    # the documented gate by hand got "command not found" -- which reads as a
-    # broken container rather than a missing install, and invites skipping the
-    # gate instead of fixing it.
-    #
-    # Pinned to the rev .pre-commit-config.yaml declares, so the binary on PATH
-    # and the one the hook builds are the same version. Bump them together.
+    # Serves `markdownlint-cli2 "**/*.md"`, the gate CLAUDE.md documents, which
+    # needs the binary on PATH. Unlike the two above this is not a
+    # `language: system` hook -- the pre-commit hook builds its own node
+    # environment -- so the pin here and the rev in .pre-commit-config.yaml are
+    # two versions of the same tool. Bump them together.
     if ! command -v markdownlint-cli2 > /dev/null 2>&1; then
         ML_VER=0.23.2
         command -v npm > /dev/null 2>&1 ||
@@ -553,9 +542,8 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
         npm install -g --silent "markdownlint-cli2@${ML_VER}" > /dev/null 2>&1 ||
             die "could not install markdownlint-cli2 ${ML_VER} from npm"
     fi
-    # npm exiting 0 is not the same as the shim being reachable -- npm's global
-    # prefix is not guaranteed to be on PATH. Same post-condition as pre-commit
-    # below, and for the same reason (#319).
+    # This image carries several node installs with different global prefixes,
+    # so npm exiting 0 does not mean the shim landed anywhere on PATH.
     command -v markdownlint-cli2 > /dev/null 2>&1 ||
         die "markdownlint-cli2 installed but is not on PATH"
     log "mdlint  -> $(command -v markdownlint-cli2) ($(markdownlint-cli2 --version 2>&1 | head -1))"

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -530,6 +530,36 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     fi
     log "actionl -> $(command -v actionlint)"
 
+    # markdownlint-cli2 completes the trio this block exists for. The comment
+    # opening it names markdownlint first among the three that went unenforced
+    # on 2026-08-18, yet only shellcheck and actionlint were ever installed --
+    # so `markdownlint-cli2 "**/*.md"`, the first gate CLAUDE.md documents, was
+    # the one command in that list a sandbox could not run.
+    #
+    # It hid because the other two routes were fine. Unlike those linters this
+    # is not a `language: system` hook: .pre-commit-config.yaml pulls it from
+    # the upstream repo, which builds its own node environment, and CI uses the
+    # action. So committing worked and CI worked, and only a session running
+    # the documented gate by hand got "command not found" -- which reads as a
+    # broken container rather than a missing install, and invites skipping the
+    # gate instead of fixing it.
+    #
+    # Pinned to the rev .pre-commit-config.yaml declares, so the binary on PATH
+    # and the one the hook builds are the same version. Bump them together.
+    if ! command -v markdownlint-cli2 > /dev/null 2>&1; then
+        ML_VER=0.23.2
+        command -v npm > /dev/null 2>&1 ||
+            die "markdownlint-cli2 needs npm, which is not on PATH"
+        npm install -g --silent "markdownlint-cli2@${ML_VER}" > /dev/null 2>&1 ||
+            die "could not install markdownlint-cli2 ${ML_VER} from npm"
+    fi
+    # npm exiting 0 is not the same as the shim being reachable -- npm's global
+    # prefix is not guaranteed to be on PATH. Same post-condition as pre-commit
+    # below, and for the same reason (#319).
+    command -v markdownlint-cli2 > /dev/null 2>&1 ||
+        die "markdownlint-cli2 installed but is not on PATH"
+    log "mdlint  -> $(command -v markdownlint-cli2) ($(markdownlint-cli2 --version 2>&1 | head -1))"
+
     command -v pre-commit > /dev/null 2>&1 ||
         pip_install pre-commit ||
         die "could not install pre-commit from PyPI"

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -71,12 +71,8 @@ set -eu
 log() { echo "[bootstrap] $*"; }
 die() { echo "[bootstrap] error: $*" >&2; exit 1; }
 
-# The ref is positional and first. Guard it against a flag, because taking $1
-# unconditionally makes a caller who omits the ref install from a ref named
-# "--profile" -- and the failure surfaces as `unknown argument:
-# claude-cloud-sandbox` from the loop below, which names the profile's VALUE
-# and points at the wrong token entirely. The documented snippet always passes
-# the ref first, so this bites whoever runs the script by hand.
+# The ref is positional and first. A leading flag is left for the argument loop
+# rather than taken as the ref, so omitting the ref reports the real problem.
 REF=main
 case "${1:-}" in
     "") ;;
@@ -477,11 +473,8 @@ rm -f "$HOME/.claude/commands/gcp-credentials.md"
 
 # --- pre-commit, on request ---------------------------------------------------
 #
-# Sandboxes bypassed the pre-commit framework entirely: the binary was absent
-# and no `.git/hooks/pre-commit` existed, so a repo's committed
-# .pre-commit-config.yaml did nothing here (#254). Four consecutive PRs on
-# 2026-08-18 were committed with markdownlint, shellcheck and actionlint
-# unenforced -- they passed only because a human-equivalent ran them by hand.
+# Installs the pre-commit framework and the linters its config calls, so a
+# repo's committed .pre-commit-config.yaml actually runs here (#254).
 #
 # This is the vendor-neutral half of enforcement, and the reason it is worth
 # doing before the harness-hook half: git runs .git/hooks itself, so nothing
@@ -551,14 +544,11 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     command -v pre-commit > /dev/null 2>&1 ||
         pip_install pre-commit ||
         die "could not install pre-commit from PyPI"
-    # pip exiting 0 is not the same as the console script existing. An image
+    # pip exiting 0 is not the same as the console script existing: an image
     # carrying the pre_commit package without its shim, or a pip whose scripts
-    # directory is off PATH, both satisfy the install and leave nothing to run
-    # -- observed on a live sandbox, which logged `precmit ->  ()` and stamped
-    # the manifest precommit=1 anyway (#319). The manifest is read as an
-    # attestation that the gate is *present* (#254's checklist opens with
-    # "expect precommit=1"), so observe the binary rather than inferring it
-    # from an exit code.
+    # directory is off PATH, both satisfy the install and leave nothing to run.
+    # The manifest's precommit= is read as an attestation that the gate is
+    # present, so observe the binary rather than infer it from an exit code.
     command -v pre-commit > /dev/null 2>&1 ||
         die "pre-commit reported installed but is not on PATH"
     log "precmit -> $(command -v pre-commit) ($(pre-commit --version))"
@@ -629,10 +619,8 @@ fi
 
 # --- the agent policy ---------------------------------------------------------
 #
-# Until now a sandbox got no policy at all: `ls ~/.claude/*.md` was empty, and
-# the 200-odd lines of working policy reached workstations through chezmoi and
-# nowhere else. Every session on this surface ran on whatever the opened repo
-# happened to commit (#245).
+# Delivers the working policy to a surface chezmoi never reaches, so a session
+# is not left running on whatever the opened repo happens to commit (#245).
 #
 # What lands here is a COMPOSED PROFILE, not the raw fragments. ADR-0018
 # resolves surface differences at delivery: the sandbox profile is built from
@@ -744,10 +732,7 @@ COMPOSED_SKILLS="retrospective start-session end-session"
 # diagnose.
 #
 # They land in ~/.claude/bin because that is where the skills spell their
-# invocation: "~/.claude/bin/<script>", on every surface. The skills used to say
-# "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude}/bin/<script>" so one line could serve a
-# plugin install too; that channel was withdrawn (#312) and the fallback was the
-# only branch this surface ever took, so the spelling is now plain.
+# invocation: "~/.claude/bin/<script>", on every surface.
 BIN_SCRIPTS="start-session-gather-state start-session-claude-drift end-session-gather-state end-session-squash-merged"
 
 # Defensive: the credential-helper section above already creates this, but the
@@ -804,22 +789,17 @@ done
 # and return the failure into its context, where it can read the message and
 # fix the cause rather than just being stopped. Both are worth having.
 #
-# Viable because a container-created ~/.claude/settings.json IS honoured --
-# measured 2026-08-18 by planting one and watching a PreToolUse hook fire eight
-# seconds later, with no session restart (#254). That is the third
-# documented-as-unavailable user-scope path to work from inside the container,
-# after ~/.claude/skills and ~/.claude/CLAUDE.md.
+# Viable because a container-created ~/.claude/settings.json IS honoured, with
+# no session restart -- despite user scope being documented as unavailable from
+# inside the container, as it also is for ~/.claude/skills and CLAUDE.md (#254).
 #
 # The wiring is taken from home/settings.json rather than restated here. That
 # file is the workstation's, and it already invokes ~/.claude/bin/<hook>
 # directly -- the same paths this script installs to -- so the two surfaces run
 # identical hooks from one source instead of a copy that drifts.
 #
-# There is one copy of each hook and one declaration of it. A dispatcher used to
-# sit in front of the three script hooks so a plugin-enabled workstation would
-# not run every hook twice; the plugin channel was withdrawn (#312) and the
-# dispatcher went with it. The settings file names each script directly, exactly
-# as chezmoi's does.
+# There is one copy of each hook and one declaration of it: the settings file
+# names each script directly, exactly as chezmoi's does.
 
 if [ "$WITH_HOOKS" -eq 1 ]; then
     command -v jq > /dev/null 2>&1 || die "--with-hooks needs jq to merge settings.json"
@@ -862,10 +842,8 @@ if [ "$WITH_HOOKS" -eq 1 ]; then
     # failing, which is why hooks have no hard dependency on those -- but the
     # trio is what makes them worth having.
     #
-    # Report the resolved state rather than naming the flags. Since #322 either
-    # capability can arrive from the profile with no flag typed, so a fixed
-    # "(needs --with-precommit)" told the reader the opposite of the truth in
-    # every *-cloud-sandbox container -- which turns it on by default.
+    # Report the resolved state rather than naming flags: either capability can
+    # arrive from the profile with no flag typed.
     if [ "$WITH_GH" -eq 1 ]; then gh_note=""; else gh_note=" (inactive: no gh)"; fi
     if [ "$WITH_PRECOMMIT" -eq 1 ]; then pc_note=""; else pc_note=" (inactive: no pre-commit)"; fi
     log "hooks   :  prchecks-wait, prepush-guard$gh_note, precommit$pc_note"
@@ -879,9 +857,9 @@ fi
 # days pass, so pushing to a branch does not reach new sessions -- they keep
 # restoring the snapshot built the first time (#246).
 #
-# The credential helper solved its half server-side, by sending a version the
-# broker can refuse (#182). Skills, policy and helper scripts have no server on
-# the other end, so the skew is silent unless something writes down what it did.
+# Skills, policy and helper scripts have no server on the other end to refuse a
+# stale client the way the credential helper's broker can (#182), so the skew is
+# silent unless something writes down what it did.
 #
 # `git ls-remote` rather than the GitHub API: no token, no JSON parsing, and git
 # is already required to be here. A REF that is already a commit SHA will not


### PR DESCRIPTION
`CLAUDE.md` opens its quality-gate list with `markdownlint-cli2 "**/*.md"`.
That command could not run in a cloud sandbox — the binary was never installed.
It is now, and the script's comments get a trim in the same PR.

## 1. Install markdownlint-cli2 (`Closes #327`)

The `WITH_PRECOMMIT` block installs the linters this estate's pre-commit config
calls — but only `shellcheck` and `actionlint`, never `markdownlint-cli2`.

It stayed hidden because the other two routes worked: the pre-commit hook pulls
it from the upstream repo, which builds its own node environment, and CI uses
the action. Only a session running the documented gate by hand hit it. Unlike
the other two — `language: system` hooks whose absence breaks the commit hook
immediately — nothing failed loudly.

Hit while preparing #326, which shipped with markdownlint unverified. That was
a shell-only diff so nothing was at risk, but a markdown-touching change made
the same way would reach CI unchecked.

Pinned to the rev `.pre-commit-config.yaml` declares, so the binary on `PATH`
and the one the hook builds cannot drift. Adds ~4 s to the bootstrap.

### The post-condition is load-bearing

The image carries **three** node installs — `/opt/node20`, `/opt/node21`,
`/opt/node22` — plus a `/usr/local/bin/npm` symlink pointing at node20 while
`node` resolves to node22. Each has a different global prefix, so which `npm`
wins decides whether the shim lands anywhere on `PATH`.

As shipped, `npm prefix -g` is `/opt/node22`, which is on `PATH`. Under a
different ordering the install would succeed and leave nothing runnable —
#319's failure mode exactly, so it gets #319's check.

## 2. Trim incident narrative from the comments

Reviewer note on the first commit: the new comments carried the story of how
the gap arose, which is already durable in the commit, #327 and this PR.

Applied to that block, then to the rest of the file. The test is whether a line
changes what a future editor *does*.

**Kept** — including the surprising facts that stop someone "correcting" the
design:

- "Bump these two together" (the pin and the pre-commit rev)
- "npm exiting 0 does not mean the shim landed on PATH"
- a container-created `~/.claude/settings.json` *is* honoured, despite user
  scope being documented as unavailable from inside the container
- `github.com` 403s this sandbox's curl while its release assets resolve fine —
  a naive reachability probe reads as an egress block and is not one
- the `# shellcheck ...` directive gotcha that dictates how one comment is worded
- the `core.hooksPath` trade-off, and the `git ls-remote` rationale

**Removed** — the experiments and incidents that established them:

- "Four consecutive PRs on 2026-08-18 were committed with … unenforced"
- "Until now a sandbox got no policy at all: `ls ~/.claude/*.md` was empty …"
- the story of a hook dispatcher that no longer exists, and of a
  `CLAUDE_PLUGIN_ROOT` spelling that was withdrawn
- "measured 2026-08-18 by planting one and watching a PreToolUse hook fire
  eight seconds later" (the fact stays, the experiment goes)
- my own from #326: the observed `precmit ->  ()` log, and the
  `unknown argument: claude-cloud-sandbox` reproduction

544 comment lines → 522, **no logic touched**.

## Verification

- Comments-only claim checked mechanically: filtering the trim diff for any
  changed non-comment line returns nothing
- Full gate suite green, `shellcheck` and `dash -n` clean
- **markdownlint ran locally for the first time** (126 files, 0 issues) — the
  thing this PR makes possible
- Bootstrap re-run against a fresh `HOME` after the trim; output identical

Install behaviour tested end-to-end, with the global install removed first so
the bootstrap had to do the work:

| Case | Result |
| --- | --- |
| binary absent | installs, logs `mdlint  -> …/markdownlint-cli2 (v0.23.2 …)`, gate runs afterwards |
| binary already present | skipped, no reinstall |
| `npm` absent | `error: markdownlint-cli2 needs npm, which is not on PATH` |
| `npm` exits 0, nothing on `PATH` | `error: markdownlint-cli2 installed but is not on PATH`, **manifest not stamped** |

## Docs

`cloud/README.md` updated in the same change — the installed-artefacts table,
and the pre-commit section explaining why this one is pinned rather than taken
from `PATH` like the other two.

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaYjAn81DcxFD1MuCnNKef