### PR TITLE
Sandbox policy: say the delivered skill set is complete, and put repo-review in the #247 hold

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -252,9 +252,22 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `/usr/local/bin/gh` | the GitHub CLI, pinned release, with `--with-gh` |
 
 Whitelisted today: `promote-journal-inbox`, `retrospective`, `start-session`,
-`end-session`. The 15 `setup-*` skills are held back pending a currency review
-— they are repo-scaffolding procedures a sandbox session rarely needs, and they
-predate this surface.
+`end-session`. The other **16** skills under `home/skills/` are held back
+pending the currency review on
+[#247](https://github.com/pmgledhill102/agentic-coding-config/issues/247):
+
+- the **15 `setup-*` skills** — repo-scaffolding procedures a sandbox session
+  rarely needs, and they predate this surface;
+- **`repo-review`**, added to that hold on 2026-08-28. It was absent without
+  ever having been decided about — the arithmetic never closed, and #239 found
+  it as the unaccounted sixteenth. Folding it in rather than whitelisting it
+  keeps one decision in one place, but note what the hold costs while it
+  stands: `README.md` calls the skill portable, and ADR-0015 names it as the
+  audit for whether an ADR still fits its tier, so a decision recorded from a
+  sandbox cannot be currency-checked from one.
+
+That list being 16 rather than 15 is the only thing the hold is claiming. It is
+not a claim that any of the 16 is unwanted here — #247 is where that is decided.
 
 The script keeps two lists, because there are two sources:
 

--- a/context/fragments/env-cloud-sandbox.md
+++ b/context/fragments/env-cloud-sandbox.md
@@ -21,8 +21,9 @@ or in the environment's setup script.
   asking a human to run `gcloud` commands by hand. The trigger is not "I
   need to change something in GCP" but **"I am about to assert something
   about live GCP state"**.
-- **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
-  A command that exists on the workstation is not necessarily present here.
+- **Skills delivered by the bootstrap.** Those offered here are the whole set —
+  a skill on the workstation but absent here was held back deliberately, not
+  lost. Say that rather than improvising its behaviour from its name.
 
 ## `gh` is not installed here
 

--- a/profiles/claude-cloud-sandbox/CLAUDE.md
+++ b/profiles/claude-cloud-sandbox/CLAUDE.md
@@ -208,8 +208,9 @@ or in the environment's setup script.
   asking a human to run `gcloud` commands by hand. The trigger is not "I
   need to change something in GCP" but **"I am about to assert something
   about live GCP state"**.
-- **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
-  A command that exists on the workstation is not necessarily present here.
+- **Skills delivered by the bootstrap.** Those offered here are the whole set —
+  a skill on the workstation but absent here was held back deliberately, not
+  lost. Say that rather than improvising its behaviour from its name.
 
 ### `gh` is not installed here
 

--- a/profiles/codex-cloud-sandbox/AGENTS.md
+++ b/profiles/codex-cloud-sandbox/AGENTS.md
@@ -208,8 +208,9 @@ or in the environment's setup script.
   asking a human to run `gcloud` commands by hand. The trigger is not "I
   need to change something in GCP" but **"I am about to assert something
   about live GCP state"**.
-- **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
-  A command that exists on the workstation is not necessarily present here.
+- **Skills delivered by the bootstrap.** Those offered here are the whole set —
+  a skill on the workstation but absent here was held back deliberately, not
+  lost. Say that rather than improvising its behaviour from its name.
 
 ### `gh` is not installed here
 


### PR DESCRIPTION
Takes the two decisions #239 was down to — the last thing epic #249 was waiting on.

`Closes #239`

## 1. Announce-absence: fix the line that was already there

The issue was framed as "should an announcement be added, and at which tier". Checking first showed **one already existed**, at the always-loaded tier, in `context/fragments/env-cloud-sandbox.md`:

> - **Skills delivered by the bootstrap**, listed in `cloud/README.md`.
>   A command that exists on the workstation is not necessarily present here.

So the tier question had been answered in the code for some time. What that line does not do is the thing the issue was actually about: it says absence is **possible** without saying the visible set is **complete**. An agent asked for a missing skill still cannot tell whether it is absent or whether it has merely not looked hard enough — and improvising from the name is the harm that opened the issue.

Reworded to:

> - **Skills delivered by the bootstrap.** Those offered here are the whole set —
>   a skill on the workstation but absent here was held back deliberately, not
>   lost. Say that rather than improvising its behaviour from its name.

Three changes, each carrying its weight:

- **"the whole set"** — converts an unknown-unknown into a known one. An agent always knows what it *has*, since the skills listing is in its context; it never knows what it is missing. Making the present set authoritative answers the question from what is already in front of it, at no extra cost.
- **"deliberately, not lost"** — stops an absence reading as breakage.
- **"say that rather than improvising"** — the behaviour actually wanted, and previously absent altogether.

It also drops the `cloud/README.md` pointer, which does not resolve for a sandbox session working on any other repo — a dangling reference in always-loaded text.

**Cost: one line, not none.** The sandbox profile goes 262 → 263 against a 200-line budget it was already 62 over. Enumerating the 16 absent skills instead would have cost four to six lines *and* planted a second copy of the bootstrap whitelist with nothing keeping the two in sync — the #318 failure mode, in the same file.

## 2. `repo-review` folded into #247

Not whitelisted; it joins the 15 `setup-*` skills under the same currency review, so one decision lives in one place.

`cloud/README.md` now says **16** rather than 15, and names what the hold costs while it stands: `README.md` calls the skill portable ("runs on any repo"), and ADR-0015 names it as the audit for whether an ADR still fits its tier — so a decision recorded from a sandbox cannot be currency-checked from one. #247 should inherit that knowingly rather than silently. The README also states what the hold is *not* claiming: that any of the 16 is unwanted here.

## Files

| File | Change |
| --- | --- |
| `context/fragments/env-cloud-sandbox.md` | the reworded two → three lines |
| `cloud/README.md` | 15 → 16, with `repo-review` named and the cost of the hold stated |
| `profiles/claude-cloud-sandbox/CLAUDE.md`, `profiles/codex-cloud-sandbox/AGENTS.md` | regenerated (`compose-context.py --write`) |

## Checks

Full local gate suite green before pushing: markdownlint (127 files), `gcp-credentials` behaviour (81 assertions), compose-context, allowlist, precommit-hook, retired-paths ×2, shellcheck.

## After this merges

#239 closes via the trailer, and **#249 has nothing outstanding** — 13/13 sub-issues closed, with #331, #332 and #250 already moved out as standalone work. It is ready to close as completed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7qvq6xA45bmcen9gBfTnZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7qvq6xA45bmcen9gBfTnZ)_