### PR TITLE
Sandbox lifetime: use the broker's real terms, not "durable, carrying monthly spend"

### DIFF
--- a/context/skills/end-session/19a-gcp-projects.md
+++ b/context/skills/end-session/19a-gcp-projects.md
@@ -16,12 +16,16 @@ From gather section `gcp_projects`. The first line is `state=`:
 
 For each `created=` line, surface:
 
-> created `<project>` — this repo's sandbox, built by this session's approval. Shared, durable, and carrying monthly spend.
+> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and already scheduled to expire.
 
 **Surface only. Never offer to delete it, and never delete it.**
 
-That prohibition is the whole point of the step, so it is worth stating why rather than leaving it as a rule to be reasoned around. The broker resolves a repo to its sandbox project and creates one only when the repo has none. The project therefore belongs to the **repo**, not to the session that happened to be first: every later session on that repo resolves to the same project, and other sessions may hold live grants on it right now. Deleting it at session end would take out shared infrastructure that nothing else recreates, on the reasoning that this session made it — which is true and irrelevant.
+That prohibition is the whole point of the step, so it is worth stating why rather than leaving it as a rule to be reasoned around, and there are two independent reasons.
 
-What this step is for is the other half of that fact. An approval can authorise a project *and its ongoing monthly spend*, and the session that caused it is the one walking away minutes later. Naming it here puts the commitment in front of the person who made it, at the one moment they are looking.
+**It is not yours to delete.** The broker resolves a repo to its sandbox project and creates one only when the repo has none, so the project belongs to the **repo**, not to the session that happened to be first. Every later session on that repo resolves to it, and another session may hold a live grant on it right now — the helper warns about exactly that. Deleting it would strand that work and cost the next session a fresh human approval plus the two-to-three minute provisioning wait, on the reasoning that this session made it: true, and irrelevant.
+
+**There is nothing to clean up anyway.** A sandbox carries its own expiry and the broker deletes it when it lapses; a grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost — it is a thing already scheduled to disappear. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
+
+What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its expiry, that is `/sandbox extend` during the work, not a decision to take on the way out.
 
 If the project genuinely should not exist — wrong repo, an experiment abandoned — that is a deliberate teardown someone does knowing what else depends on it, not a tidy-up at the end of a session.

--- a/context/skills/end-session/19a-gcp-projects.md
+++ b/context/skills/end-session/19a-gcp-projects.md
@@ -16,7 +16,7 @@ From gather section `gcp_projects`. The first line is `state=`:
 
 For each `created=` line, surface:
 
-> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and already scheduled to expire.
+> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and auto-deleted when its TTL lapses (7 days by default).
 
 **Surface only. Never offer to delete it, and never delete it.**
 
@@ -24,8 +24,8 @@ That prohibition is the whole point of the step, so it is worth stating why rath
 
 **It is not yours to delete.** The broker resolves a repo to its sandbox project and creates one only when the repo has none, so the project belongs to the **repo**, not to the session that happened to be first. Every later session on that repo resolves to it, and another session may hold a live grant on it right now — the helper warns about exactly that. Deleting it would strand that work and cost the next session a fresh human approval plus the two-to-three minute provisioning wait, on the reasoning that this session made it: true, and irrelevant.
 
-**There is nothing to clean up anyway.** A sandbox carries its own expiry and the broker deletes it when it lapses; a grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost — it is a thing already scheduled to disappear. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
+**There is nothing to clean up anyway.** A sandbox is created with a fixed TTL and a budget cap — today 7 days and £25/mo, composed by the broker and printed on the approval card — and a scheduled job deletes it when the TTL lapses. A grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost: it is deleted, and capped in the meantime. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
 
-What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its expiry, that is `/sandbox extend` during the work, not a decision to take on the way out.
+What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its TTL, that is `/sandbox extend` during the work — capped at 30 days, and deliberately not automatic, since a sandbox extended on every use would never expire at all. Not a decision to take on the way out.
 
 If the project genuinely should not exist — wrong repo, an experiment abandoned — that is a deliberate teardown someone does knowing what else depends on it, not a tidy-up at the end of a session.

--- a/context/skills/end-session/20-summary-sandbox.md
+++ b/context/skills/end-session/20-summary-sandbox.md
@@ -14,6 +14,6 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `n/a (sandbox — container discarded)`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and auto-deleted at its TTL, so it is never deleted here
 - Could not prune (remote ref deletion refused): `<list or omit>`
 - Anything skipped/surfaced: `<list>`

--- a/context/skills/end-session/20-summary-sandbox.md
+++ b/context/skills/end-session/20-summary-sandbox.md
@@ -14,6 +14,6 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `n/a (sandbox — container discarded)`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared and durable, never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
 - Could not prune (remote ref deletion refused): `<list or omit>`
 - Anything skipped/surfaced: `<list>`

--- a/context/skills/end-session/20-summary-workstation.md
+++ b/context/skills/end-session/20-summary-workstation.md
@@ -14,5 +14,5 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `<count, or "none">`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared and durable, never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
 - Anything skipped/surfaced: `<list>`

--- a/context/skills/end-session/20-summary-workstation.md
+++ b/context/skills/end-session/20-summary-workstation.md
@@ -14,5 +14,5 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `<count, or "none">`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and auto-deleted at its TTL, so it is never deleted here
 - Anything skipped/surfaced: `<list>`

--- a/docs/runbooks/sandbox-gcp-credentials.md
+++ b/docs/runbooks/sandbox-gcp-credentials.md
@@ -40,10 +40,13 @@ in blast radius and in how fast they take effect.
 The broker resolves a repo to its sandbox project and creates one only when the
 repo has none, so the project belongs to the repo rather than to whichever session
 was first to ask: later sessions on the same repo resolve to it, and others may
-hold live grants on it right now. `gcp-credentials created` reports such a project
-so its monthly spend is visible to whoever caused it — it is not a teardown list.
-Retiring a sandbox project is a deliberate act taken knowing what else depends on
-it, not a tidy-up at the end of a session.
+hold live grants on it right now. A sandbox also carries its own expiry and the
+broker deletes it when that lapses — a grant is clamped to it, which is why a 24h
+grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox
+is not a leak accumulating cost, and `gcp-credentials created` is a record of what
+this session brought into being, not a teardown list. Retiring one early is a
+deliberate act taken knowing what else depends on it; extending one past its
+expiry is `/sandbox extend`.
 
 ### 1. `release` — this machine stops using the credentials
 

--- a/docs/runbooks/sandbox-gcp-credentials.md
+++ b/docs/runbooks/sandbox-gcp-credentials.md
@@ -40,13 +40,14 @@ in blast radius and in how fast they take effect.
 The broker resolves a repo to its sandbox project and creates one only when the
 repo has none, so the project belongs to the repo rather than to whichever session
 was first to ask: later sessions on the same repo resolve to it, and others may
-hold live grants on it right now. A sandbox also carries its own expiry and the
-broker deletes it when that lapses — a grant is clamped to it, which is why a 24h
-grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox
-is not a leak accumulating cost, and `gcp-credentials created` is a record of what
-this session brought into being, not a teardown list. Retiring one early is a
-deliberate act taken knowing what else depends on it; extending one past its
-expiry is `/sandbox extend`.
+hold live grants on it right now. A sandbox is also created with a fixed TTL and a
+budget cap — today 7 days and £25/mo, printed on the approval card — and a
+scheduled job deletes it when the TTL lapses (gcp-org-management ADR 008, ADR 022).
+A grant is clamped to that expiry, which is why one can come back shorter than
+asked for. So an unattended sandbox is not a leak accumulating cost, and
+`gcp-credentials created` is a record of what this session brought into being, not
+a teardown list. Retiring one early is a deliberate act taken knowing what else
+depends on it; extending one is `/sandbox extend`, capped at 30 days.
 
 ### 1. `release` — this machine stops using the credentials
 

--- a/home/commands/gcp-credentials.md
+++ b/home/commands/gcp-credentials.md
@@ -27,8 +27,19 @@ three-word phrase as the session — that match is what binds an approval to
 and trust model: ADR 021 in `pmgledhill102/gcp-org-management`.
 
 If the repo has no sandbox project yet, the same approval **also creates one**,
-so the card may be authorising a project and its monthly spend as well as the
-access. The build takes two to three minutes, during which the helper reports
+so the card is authorising a project as well as the access — and says so, on
+fixed terms the broker composes rather than the agent: today a £25/mo budget cap
+and auto-deletion after 7 days, extendable to at most 30 (ADR 008, ADR 022).
+Read the terms off the card rather than from here; the numbers live in that repo
+and this is a copy.
+
+That TTL is why a grant can come back shorter than asked for — see [The grant
+may be shorter than you asked for](#the-grant-may-be-shorter-than-you-asked-for)
+— and why an idle sandbox is **not** a cost that accumulates: it is deleted,
+with the budget capping what it can spend before then. Do not treat a sandbox as
+something to be tidied up.
+
+The build takes two to three minutes, during which the helper reports
 `provisioning` — see [Waiting on a human, then waiting on
 GCP](#waiting-on-a-human-then-waiting-on-gcp). Design: ADR 022.
 

--- a/home/skills/end-session/SKILL.md
+++ b/home/skills/end-session/SKILL.md
@@ -262,7 +262,7 @@ From gather section `gcp_projects`. The first line is `state=`:
 
 For each `created=` line, surface:
 
-> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and already scheduled to expire.
+> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and auto-deleted when its TTL lapses (7 days by default).
 
 **Surface only. Never offer to delete it, and never delete it.**
 
@@ -270,9 +270,9 @@ That prohibition is the whole point of the step, so it is worth stating why rath
 
 **It is not yours to delete.** The broker resolves a repo to its sandbox project and creates one only when the repo has none, so the project belongs to the **repo**, not to the session that happened to be first. Every later session on that repo resolves to it, and another session may hold a live grant on it right now — the helper warns about exactly that. Deleting it would strand that work and cost the next session a fresh human approval plus the two-to-three minute provisioning wait, on the reasoning that this session made it: true, and irrelevant.
 
-**There is nothing to clean up anyway.** A sandbox carries its own expiry and the broker deletes it when it lapses; a grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost — it is a thing already scheduled to disappear. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
+**There is nothing to clean up anyway.** A sandbox is created with a fixed TTL and a budget cap — today 7 days and £25/mo, composed by the broker and printed on the approval card — and a scheduled job deletes it when the TTL lapses. A grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost: it is deleted, and capped in the meantime. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
 
-What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its expiry, that is `/sandbox extend` during the work, not a decision to take on the way out.
+What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its TTL, that is `/sandbox extend` during the work — capped at 30 days, and deliberately not automatic, since a sandbox extended on every use would never expire at all. Not a decision to take on the way out.
 
 If the project genuinely should not exist — wrong repo, an experiment abandoned — that is a deliberate teardown someone does knowing what else depends on it, not a tidy-up at the end of a session.
 
@@ -292,7 +292,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `<count, or "none">`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and auto-deleted at its TTL, so it is never deleted here
 - Anything skipped/surfaced: `<list>`
 
 ## Phase 2 — Retrospective

--- a/home/skills/end-session/SKILL.md
+++ b/home/skills/end-session/SKILL.md
@@ -262,13 +262,17 @@ From gather section `gcp_projects`. The first line is `state=`:
 
 For each `created=` line, surface:
 
-> created `<project>` — this repo's sandbox, built by this session's approval. Shared, durable, and carrying monthly spend.
+> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and already scheduled to expire.
 
 **Surface only. Never offer to delete it, and never delete it.**
 
-That prohibition is the whole point of the step, so it is worth stating why rather than leaving it as a rule to be reasoned around. The broker resolves a repo to its sandbox project and creates one only when the repo has none. The project therefore belongs to the **repo**, not to the session that happened to be first: every later session on that repo resolves to the same project, and other sessions may hold live grants on it right now. Deleting it at session end would take out shared infrastructure that nothing else recreates, on the reasoning that this session made it — which is true and irrelevant.
+That prohibition is the whole point of the step, so it is worth stating why rather than leaving it as a rule to be reasoned around, and there are two independent reasons.
 
-What this step is for is the other half of that fact. An approval can authorise a project *and its ongoing monthly spend*, and the session that caused it is the one walking away minutes later. Naming it here puts the commitment in front of the person who made it, at the one moment they are looking.
+**It is not yours to delete.** The broker resolves a repo to its sandbox project and creates one only when the repo has none, so the project belongs to the **repo**, not to the session that happened to be first. Every later session on that repo resolves to it, and another session may hold a live grant on it right now — the helper warns about exactly that. Deleting it would strand that work and cost the next session a fresh human approval plus the two-to-three minute provisioning wait, on the reasoning that this session made it: true, and irrelevant.
+
+**There is nothing to clean up anyway.** A sandbox carries its own expiry and the broker deletes it when it lapses; a grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost — it is a thing already scheduled to disappear. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
+
+What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its expiry, that is `/sandbox extend` during the work, not a decision to take on the way out.
 
 If the project genuinely should not exist — wrong repo, an experiment abandoned — that is a deliberate teardown someone does knowing what else depends on it, not a tidy-up at the end of a session.
 
@@ -288,7 +292,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `<count, or "none">`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared and durable, never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
 - Anything skipped/surfaced: `<list>`
 
 ## Phase 2 — Retrospective

--- a/profiles/claude-cloud-sandbox/skills/end-session/SKILL.md
+++ b/profiles/claude-cloud-sandbox/skills/end-session/SKILL.md
@@ -316,13 +316,17 @@ From gather section `gcp_projects`. The first line is `state=`:
 
 For each `created=` line, surface:
 
-> created `<project>` — this repo's sandbox, built by this session's approval. Shared, durable, and carrying monthly spend.
+> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and already scheduled to expire.
 
 **Surface only. Never offer to delete it, and never delete it.**
 
-That prohibition is the whole point of the step, so it is worth stating why rather than leaving it as a rule to be reasoned around. The broker resolves a repo to its sandbox project and creates one only when the repo has none. The project therefore belongs to the **repo**, not to the session that happened to be first: every later session on that repo resolves to the same project, and other sessions may hold live grants on it right now. Deleting it at session end would take out shared infrastructure that nothing else recreates, on the reasoning that this session made it — which is true and irrelevant.
+That prohibition is the whole point of the step, so it is worth stating why rather than leaving it as a rule to be reasoned around, and there are two independent reasons.
 
-What this step is for is the other half of that fact. An approval can authorise a project *and its ongoing monthly spend*, and the session that caused it is the one walking away minutes later. Naming it here puts the commitment in front of the person who made it, at the one moment they are looking.
+**It is not yours to delete.** The broker resolves a repo to its sandbox project and creates one only when the repo has none, so the project belongs to the **repo**, not to the session that happened to be first. Every later session on that repo resolves to it, and another session may hold a live grant on it right now — the helper warns about exactly that. Deleting it would strand that work and cost the next session a fresh human approval plus the two-to-three minute provisioning wait, on the reasoning that this session made it: true, and irrelevant.
+
+**There is nothing to clean up anyway.** A sandbox carries its own expiry and the broker deletes it when it lapses; a grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost — it is a thing already scheduled to disappear. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
+
+What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its expiry, that is `/sandbox extend` during the work, not a decision to take on the way out.
 
 If the project genuinely should not exist — wrong repo, an experiment abandoned — that is a deliberate teardown someone does knowing what else depends on it, not a tidy-up at the end of a session.
 
@@ -342,7 +346,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `n/a (sandbox — container discarded)`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared and durable, never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
 - Could not prune (remote ref deletion refused): `<list or omit>`
 - Anything skipped/surfaced: `<list>`
 

--- a/profiles/claude-cloud-sandbox/skills/end-session/SKILL.md
+++ b/profiles/claude-cloud-sandbox/skills/end-session/SKILL.md
@@ -316,7 +316,7 @@ From gather section `gcp_projects`. The first line is `state=`:
 
 For each `created=` line, surface:
 
-> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and already scheduled to expire.
+> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and auto-deleted when its TTL lapses (7 days by default).
 
 **Surface only. Never offer to delete it, and never delete it.**
 
@@ -324,9 +324,9 @@ That prohibition is the whole point of the step, so it is worth stating why rath
 
 **It is not yours to delete.** The broker resolves a repo to its sandbox project and creates one only when the repo has none, so the project belongs to the **repo**, not to the session that happened to be first. Every later session on that repo resolves to it, and another session may hold a live grant on it right now — the helper warns about exactly that. Deleting it would strand that work and cost the next session a fresh human approval plus the two-to-three minute provisioning wait, on the reasoning that this session made it: true, and irrelevant.
 
-**There is nothing to clean up anyway.** A sandbox carries its own expiry and the broker deletes it when it lapses; a grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost — it is a thing already scheduled to disappear. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
+**There is nothing to clean up anyway.** A sandbox is created with a fixed TTL and a budget cap — today 7 days and £25/mo, composed by the broker and printed on the approval card — and a scheduled job deletes it when the TTL lapses. A grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost: it is deleted, and capped in the meantime. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
 
-What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its expiry, that is `/sandbox extend` during the work, not a decision to take on the way out.
+What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its TTL, that is `/sandbox extend` during the work — capped at 30 days, and deliberately not automatic, since a sandbox extended on every use would never expire at all. Not a decision to take on the way out.
 
 If the project genuinely should not exist — wrong repo, an experiment abandoned — that is a deliberate teardown someone does knowing what else depends on it, not a tidy-up at the end of a session.
 
@@ -346,7 +346,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `n/a (sandbox — container discarded)`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and auto-deleted at its TTL, so it is never deleted here
 - Could not prune (remote ref deletion refused): `<list or omit>`
 - Anything skipped/surfaced: `<list>`
 

--- a/profiles/codex-cloud-sandbox/skills/end-session/SKILL.md
+++ b/profiles/codex-cloud-sandbox/skills/end-session/SKILL.md
@@ -316,13 +316,17 @@ From gather section `gcp_projects`. The first line is `state=`:
 
 For each `created=` line, surface:
 
-> created `<project>` — this repo's sandbox, built by this session's approval. Shared, durable, and carrying monthly spend.
+> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and already scheduled to expire.
 
 **Surface only. Never offer to delete it, and never delete it.**
 
-That prohibition is the whole point of the step, so it is worth stating why rather than leaving it as a rule to be reasoned around. The broker resolves a repo to its sandbox project and creates one only when the repo has none. The project therefore belongs to the **repo**, not to the session that happened to be first: every later session on that repo resolves to the same project, and other sessions may hold live grants on it right now. Deleting it at session end would take out shared infrastructure that nothing else recreates, on the reasoning that this session made it — which is true and irrelevant.
+That prohibition is the whole point of the step, so it is worth stating why rather than leaving it as a rule to be reasoned around, and there are two independent reasons.
 
-What this step is for is the other half of that fact. An approval can authorise a project *and its ongoing monthly spend*, and the session that caused it is the one walking away minutes later. Naming it here puts the commitment in front of the person who made it, at the one moment they are looking.
+**It is not yours to delete.** The broker resolves a repo to its sandbox project and creates one only when the repo has none, so the project belongs to the **repo**, not to the session that happened to be first. Every later session on that repo resolves to it, and another session may hold a live grant on it right now — the helper warns about exactly that. Deleting it would strand that work and cost the next session a fresh human approval plus the two-to-three minute provisioning wait, on the reasoning that this session made it: true, and irrelevant.
+
+**There is nothing to clean up anyway.** A sandbox carries its own expiry and the broker deletes it when it lapses; a grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost — it is a thing already scheduled to disappear. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
+
+What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its expiry, that is `/sandbox extend` during the work, not a decision to take on the way out.
 
 If the project genuinely should not exist — wrong repo, an experiment abandoned — that is a deliberate teardown someone does knowing what else depends on it, not a tidy-up at the end of a session.
 
@@ -342,7 +346,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `n/a (sandbox — container discarded)`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared and durable, never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
 - Could not prune (remote ref deletion refused): `<list or omit>`
 - Anything skipped/surfaced: `<list>`
 

--- a/profiles/codex-cloud-sandbox/skills/end-session/SKILL.md
+++ b/profiles/codex-cloud-sandbox/skills/end-session/SKILL.md
@@ -316,7 +316,7 @@ From gather section `gcp_projects`. The first line is `state=`:
 
 For each `created=` line, surface:
 
-> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and already scheduled to expire.
+> created `<project>` — this repo's sandbox, built by this session's approval. Shared with every later session on the repo, and auto-deleted when its TTL lapses (7 days by default).
 
 **Surface only. Never offer to delete it, and never delete it.**
 
@@ -324,9 +324,9 @@ That prohibition is the whole point of the step, so it is worth stating why rath
 
 **It is not yours to delete.** The broker resolves a repo to its sandbox project and creates one only when the repo has none, so the project belongs to the **repo**, not to the session that happened to be first. Every later session on that repo resolves to it, and another session may hold a live grant on it right now — the helper warns about exactly that. Deleting it would strand that work and cost the next session a fresh human approval plus the two-to-three minute provisioning wait, on the reasoning that this session made it: true, and irrelevant.
 
-**There is nothing to clean up anyway.** A sandbox carries its own expiry and the broker deletes it when it lapses; a grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost — it is a thing already scheduled to disappear. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
+**There is nothing to clean up anyway.** A sandbox is created with a fixed TTL and a budget cap — today 7 days and £25/mo, composed by the broker and printed on the approval card — and a scheduled job deletes it when the TTL lapses. A grant is clamped to that expiry, which is why a 24h grant against a sandbox with 12h left comes back as 12h. So an unattended sandbox is not a leak accumulating cost: it is deleted, and capped in the meantime. Nothing at session end needs to act on it, which is precisely why this step reports and stops.
 
-What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its expiry, that is `/sandbox extend` during the work, not a decision to take on the way out.
+What the step is for, then, is neither cleanup nor cost: it is telling whoever caused shared infrastructure to exist that they did, at the one moment they are looking at it. If the sandbox should outlive its TTL, that is `/sandbox extend` during the work — capped at 30 days, and deliberately not automatic, since a sandbox extended on every use would never expire at all. Not a decision to take on the way out.
 
 If the project genuinely should not exist — wrong repo, an experiment abandoned — that is a deliberate teardown someone does knowing what else depends on it, not a tidy-up at the end of a session.
 
@@ -346,7 +346,7 @@ Print a concise summary. Each line says "none" loudly when clean, so noise scale
 - Other worktrees: `n/a (sandbox — container discarded)`
 - Background processes (reaped): `<count>`
 - Background processes (user-owned, surfaced): `<count>`
-- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and expires on its own, so it is never deleted here
+- GCP sandbox project created this session: `<project, "none", "n/a (no GCP grant this session)", or "n/a (broker client absent)", or "n/a (broker client predates this check)">` — surface only; it is the repo's, shared, and auto-deleted at its TTL, so it is never deleted here
 - Could not prune (remote ref deletion refused): `<list or omit>`
 - Anything skipped/surfaced: `<list>`
 


### PR DESCRIPTION
Corrects text merged in [#333](https://github.com/pmgledhill102/agentic-coding-config/pull/333), then replaces the correction's own hedged wording with the authoritative terms, read from `gcp-org-management`.

Two commits, deliberately kept separate: the first fixes what was wrong from this repo's own docs, the second upgrades it once the source of truth had been read.

## What was wrong

Step 14 told the user the sandbox project it surfaced was *"Shared, **durable**, and carrying **monthly spend**"*. Both bolded claims are false.

The root of it is `home/commands/gcp-credentials.md`, which said an approval *"may be authorising a project and its monthly spend"*. That phrasing turns a capped, self-deleting resource into an open-ended liability — and it is what sent [#331](https://github.com/pmgledhill102/agentic-coding-config/issues/331) chasing an audit for an accumulation that never happens.

## What the broker actually does

From `pmgledhill102/gcp-org-management`, read rather than inferred:

- **ADR 022** shows the approval card verbatim: `budget £25/mo · auto-deleted after 7 days`. Budget and TTL are composed by the broker; the agent supplies no provisioning parameters at all.
- **ADR 008** is the cleanup mechanism: `sandbox-expires` date labels plus a scheduled job that deletes on lapse and posts expiry warnings to Discord.
- **Extension** exists (`handleExtend`) and caps at **30 days**. Extending on every use is explicitly rejected, because an actively-used sandbox would then never expire — which would defeat ADR 008 entirely.
- The grant clamp follows from the TTL: *"A session arriving on day 6 of a 7-day sandbox would otherwise get a 24-hour grant against a project that is deleted in one."*

So a 7-day project cannot incur a month of spend, and £25/mo is a **cap**, not a commitment.

## What the step is for now

The reason that survives, and it is a good one: it tells whoever caused shared infrastructure to exist that they did. The two reasons not to delete are now stated separately, because they are independent and were previously tangled:

- **It is not yours to delete** — shared; another session may hold a live grant, so deleting strands their work and costs the next one a fresh approval plus the provisioning wait.
- **There is nothing to clean up anyway** — fixed TTL, budget cap, scheduled deletion.

Also dropped: *"shared infrastructure that nothing else recreates"*, wrong in the other direction — the next approval builds a new one. The cost of deleting is stranded work and a wasted approval, not permanence.

Added, where someone would otherwise go looking: extending is `/sandbox extend` **during the work**, capped at 30 days and deliberately manual.

## On copying another repo's facts

The numbers belong to `gcp-org-management`. Each site that quotes them says so and cites ADR 008 / ADR 022, and the skill tells the reader to take the terms off the card in front of them rather than from the copy — so drift is visible and attributed rather than silent. That is the same failure mode as #318, and the reason ADR-0015 says to reference rather than duplicate.

## Files

| File | Change |
| --- | --- |
| `home/commands/gcp-credentials.md` | the root sentence: real terms, plus why an idle sandbox is not a cost that accumulates |
| `context/skills/end-session/19a-gcp-projects.md` | step 14 body — two separated reasons, real mechanism |
| `context/skills/end-session/20-summary-{sandbox,workstation}.md` | summary line |
| `docs/runbooks/sandbox-gcp-credentials.md` | *Ending access* note |
| `home/skills/…`, `profiles/…` | regenerated |

## Related

**#331 closed as `not_planned`** — it proposed auditing for an accumulation that auto-expiry prevents.

## Checks

Full local gate suite green after each commit: markdownlint (127 files), `gcp-credentials` behaviour (81 assertions), compose-context, allowlist, precommit-hook, retired-paths ×2, shellcheck. The new cross-reference anchor resolves.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7qvq6xA45bmcen9gBfTnZ