### PR TITLE
Resolve a child repo when the session's cwd is their parent

### DIFF
--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -726,14 +726,15 @@ COMPOSED_SKILLS="retrospective start-session end-session"
 # skills invoke them by name, and a skill whose helper is missing fails at the
 # point of use rather than at install, which is the worst time to find out.
 #
-# start-session-claude-drift is here because start-session-gather-state runs it
-# as "$(dirname "$0")/start-session-claude-drift" -- a sibling dependency that
-# nothing in the skill text mentions, so it would be easy to omit and hard to
-# diagnose.
+# start-session-claude-drift and session-repo-resolve are here because the
+# gather scripts run them as "$(dirname "$0")/<name>" -- sibling dependencies
+# that nothing in the skill text mentions, so they would be easy to omit and
+# hard to diagnose. session-repo-resolve is the shared one: both gathers call
+# it, and without it both silently fall back to the old cwd-only check.
 #
 # They land in ~/.claude/bin because that is where the skills spell their
 # invocation: "~/.claude/bin/<script>", on every surface.
-BIN_SCRIPTS="start-session-gather-state start-session-claude-drift end-session-gather-state end-session-squash-merged"
+BIN_SCRIPTS="start-session-gather-state start-session-claude-drift session-repo-resolve end-session-gather-state end-session-squash-merged"
 
 # Defensive: the credential-helper section above already creates this, but the
 # dependency is invisible from here and a reordering would break it silently.

--- a/context/skills/end-session/03-pre-flight.md
+++ b/context/skills/end-session/03-pre-flight.md
@@ -1,9 +1,9 @@
 ## Pre-flight
 
-This command **requires a git-backed repository**. Run the bare command below and branch on its exit code — don't paste a compound `||` / `&&` form, which won't match any single allow rule and will trigger a permission prompt.
+This command **requires a git-backed repository** — but it does not check for one itself. The gather script does, and it looks one level down before giving up: a container handed several repos as siblings starts the session in their parent, where a bare `git rev-parse` fails while the repo being worked in sits directly beneath.
 
-```sh
-git rev-parse --is-inside-work-tree
-```
+So make **no standalone Bash call before the gather**. Run the gather (Phase 1) and branch on what it reports:
 
-If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `end-session` requires a git-backed repo — nothing to tidy, stopping. ``) and stop. Do not run any further checks, do not proceed to Phase 2.
+- **`repo_resolution`** — cwd was not a repo, exactly one repo sat beneath it, and the gather ran there. `cd` to its `repo=` value before any later step (the script's own `cd` died with it), and name the repo in the summary. No prompt: one candidate is not a choice.
+- **`repo_candidates`** — several repos sat beneath cwd. It is the only section and the script exits 2. List the candidates, ask which, `cd` there, and re-run the gather. Never guess.
+- **`not_a_git_repo`** — no repo in cwd and none beneath it. Print the line it contains and stop. Do not run any further checks, do not proceed to Phase 2.

--- a/context/skills/start-session/04-phase-1.md
+++ b/context/skills/start-session/04-phase-1.md
@@ -1,4 +1,4 @@
 ## Phase 1 — Sync
 
-Everything starts with one script call. The pre-flight check is inside it, so
+Everything starts with one script call. The pre-flight check is inside it — including working out which repo this session is in when cwd is their parent — so
 this command makes **no standalone Bash calls before the gather**.

--- a/context/skills/start-session/05-gather-sandbox.md
+++ b/context/skills/start-session/05-gather-sandbox.md
@@ -14,7 +14,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 
 | Section | Drives step(s) | Notes on exit code |
 | --- | --- | --- |
-| `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
+| `repo_resolution` | 1a, 7 | Only present when cwd was **not** itself a repo and exactly one repo sat directly beneath it — the script resolved to it and gathered there. Gives `repo=` and `name=`. `cd` to `repo=` before any later step, because the script's own `cd` died with it, and name the repo and the reason in the brief. No prompt: one candidate is not a choice. |
+| `repo_candidates` | 1a | Only present when cwd was not a repo and **several** repos sat directly beneath it, in which case it is the **only** section and the script exits 2. Gives `cwd=` and one `candidate=` line each. Tier 3: list them, ask which, `cd` there and re-run the gather. Never guess. |
+| `not_a_git_repo` | pre-flight | Only present when cwd was not a repo and no repo sat beneath it either, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`, and, under `---origin---`, the remote URL that gives you `<owner>/<repo>` for part (b). |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |

--- a/context/skills/start-session/05-gather-workstation.md
+++ b/context/skills/start-session/05-gather-workstation.md
@@ -10,7 +10,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 
 | Section | Drives step(s) | Notes on exit code |
 | --- | --- | --- |
-| `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
+| `repo_resolution` | 1a, 7 | Only present when cwd was **not** itself a repo and exactly one repo sat directly beneath it — the script resolved to it and gathered there. Gives `repo=` and `name=`. `cd` to `repo=` before any later step, because the script's own `cd` died with it, and name the repo and the reason in the brief. No prompt: one candidate is not a choice. |
+| `repo_candidates` | 1a | Only present when cwd was not a repo and **several** repos sat directly beneath it, in which case it is the **only** section and the script exits 2. Gives `cwd=` and one `candidate=` line each. Tier 3: list them, ask which, `cd` there and re-run the gather. Never guess. |
+| `not_a_git_repo` | pre-flight | Only present when cwd was not a repo and no repo sat beneath it either, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |

--- a/context/skills/start-session/12-session-brief-sandbox.md
+++ b/context/skills/start-session/12-session-brief-sandbox.md
@@ -5,6 +5,7 @@ Always print, even when everything is clean. This is the user-facing payoff — 
 ```text
 ── Session brief ──────────────────────────────
 Repo:     <repo>             Branch: <branch> (<clean|dirty>)
+          [ran in <name>; cwd <cwd> is not a repo]   (only when repo_resolution present)
 Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
 
@@ -31,6 +32,7 @@ Needs attention:
 
 Rules:
 
+- When `repo_resolution` is present, the `Repo:` line carries the second line naming which repo was resolved and why. It is never silent: a session that resolved its own repo should be able to see that it did.
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
 - The issue list is titled **"Open issues (blocked filter unavailable)"**, not "Ready to pick up next". That is not a cosmetic difference: the query in step 1(b) cannot express `-is:blocked`, so some rows may be blocked. Titling it as a ready list would assert a filter that was never applied. Sort by priority label (P0 first, `-` last), emit the top 5, and check an issue's blockers before claiming it.
 - "In progress" is the same response filtered client-side to the authenticated login. Report the real answer — including `none` when the filter genuinely returned nothing. It reads `n/a (no GitHub route)` **only** when the MCP call itself failed.

--- a/context/skills/start-session/12-session-brief-workstation.md
+++ b/context/skills/start-session/12-session-brief-workstation.md
@@ -5,6 +5,7 @@ Always print, even when everything is clean. This is the user-facing payoff — 
 ```text
 ── Session brief ──────────────────────────────
 Repo:     <repo>             Branch: <branch> (<clean|dirty>)
+          [ran in <name>; cwd <cwd> is not a repo]   (only when repo_resolution present)
 Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
 
@@ -32,6 +33,7 @@ Needs attention:
 
 Rules:
 
+- When `repo_resolution` is present, the `Repo:` line carries the second line naming which repo was resolved and why. It is never silent: a session that resolved its own repo should be able to see that it did.
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
 - "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work.
 - "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items).

--- a/context/skills/start-session/13-guardrails.md
+++ b/context/skills/start-session/13-guardrails.md
@@ -1,6 +1,7 @@
 ## Guardrails
 
-- **Pre-flight gate is non-negotiable.** Never proceed when not in a git repo.
+- **Pre-flight gate is non-negotiable.** Never proceed when there is no repo — but "cwd is not a repo" is not that. The gather looks one level down first, so the gate fires on `not_a_git_repo` (nothing beneath either), not on the bare fact that cwd is a parent directory.
+- **Never guess between candidate repos.** `repo_candidates` means several sat beneath cwd; list them and ask. One candidate resolves silently, several never do.
 - **Never auto-rebase a feature branch** onto an advanced default branch. Surface the gap and stop. The user picks the strategy.
 - **Never switch branches except when the upstream is gone and the tree is clean.** That single case (PR merged + branch auto-deleted on remote, no local uncommitted work) is auto-handled per Step 3. Otherwise, `start-session` reports state on whatever branch the user is on.
 - **Don't push anything.** Pushes belong to `end-session` (for git/`main`). `start-session` is read-mostly. (Note: if the user says yes to the journal-promote prompt, `/promote-journal-inbox` runs its own commit + push against `paul-context` — that's the promote command's contract, not a carve-out here.)

--- a/home/bin/end-session-gather-state
+++ b/home/bin/end-session-gather-state
@@ -21,6 +21,58 @@ set -uo pipefail
 
 progress() { printf '[gather] %s\n' "$*" >&2; }
 
+# --- Phase 0: resolve the repo ------------------------------------------
+# The pre-flight used to live in the skill text as a bare `git rev-parse`,
+# which stopped the command whenever cwd was not itself a repo. A container
+# handed several repos as siblings starts the session in their parent, so that
+# stopped on a session that plainly had a repo one level down.
+#
+# Same helper, same verdict, same handling as start-session-gather-state — the
+# resolution is identical on both surfaces and in both commands, so it is one
+# script rather than four copies (ADR-0018 principle 8, step 0).
+RESOLVE_OUT=$("$(dirname "$0")/session-repo-resolve" 2>/dev/null)
+RESOLVE_STATE=$(printf '%s\n' "$RESOLVE_OUT" | sed -n 's/^state=//p' | head -1)
+
+# A container installed before session-repo-resolve existed has no helper to
+# run. Degrade to the old inline check rather than reporting every repo as
+# unresolvable.
+if [ -z "$RESOLVE_STATE" ]; then
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        RESOLVE_STATE=cwd
+    else
+        RESOLVE_STATE=none
+    fi
+fi
+
+RESOLVED_REPO=""
+case "$RESOLVE_STATE" in
+    cwd)
+        : # ordinary case: the session is already standing in the repo
+        ;;
+    resolved-child)
+        RESOLVED_REPO=$(printf '%s\n' "$RESOLVE_OUT" | sed -n 's/^repo=//p' | head -1)
+        cd "$RESOLVED_REPO" || {
+            printf '===not_a_git_repo (exit=1)===\n'
+            printf 'resolved %s but could not enter it — nothing to tidy.\n\n' "$RESOLVED_REPO"
+            exit 1
+        }
+        ;;
+    ambiguous)
+        # Several candidates is the one case the script must not decide. It
+        # reports them and stops; the skill asks which.
+        printf '===repo_candidates (exit=2)===\n'
+        printf 'cwd=%s\n' "$(pwd)"
+        printf '%s\n' "$RESOLVE_OUT" | sed -n 's/^candidate=/candidate=/p'
+        printf '\n'
+        exit 2
+        ;;
+    *)
+        printf '===not_a_git_repo (exit=1)===\n'
+        printf 'end-session requires a git-backed repo — nothing to tidy.\n\n'
+        exit 1
+        ;;
+esac
+
 TMP=$(mktemp -d -t end-session-gather.XXXXXX)
 trap 'rm -rf "$TMP"' EXIT
 
@@ -204,6 +256,17 @@ emit() {
     cat "$TMP/$name.out" 2>/dev/null
     printf '\n'
 }
+
+# Only present when the repo was not the one the caller was standing in —
+# there is nothing to report when cwd was already the repo, and the caller
+# needs to chdir here itself, since this script's own cd died with it.
+if [ -n "$RESOLVED_REPO" ]; then
+    printf '===repo_resolution (exit=0)===\n'
+    printf 'state=resolved-child\n'
+    printf 'repo=%s\n' "$RESOLVED_REPO"
+    printf 'name=%s\n' "$(basename "$RESOLVED_REPO")"
+    printf '\n'
+fi
 
 printf '===fetch (exit=%s)===\n' "$FETCH_EXIT"
 cat "$TMP/fetch.out"

--- a/home/bin/session-repo-resolve
+++ b/home/bin/session-repo-resolve
@@ -1,0 +1,75 @@
+#!/bin/sh
+# session-repo-resolve — answer "which repo is this session working in?" for
+# the session gather scripts.
+#
+# The session's working directory is not always a repo. A cloud container is
+# handed several repos as siblings under one parent (agentic-coding-config,
+# paul-context, gcp-org-management), and the session starts in the parent —
+# so a bare `git rev-parse --is-inside-work-tree` fails while the repo the
+# session is plainly working in sits one level down.
+#
+# Both gather scripts need the identical answer, so it lives here once rather
+# than in two scripts or, worse, in per-surface skill fragments (ADR-0018
+# principle 8, step 0: absorb the difference in a script before splitting
+# content).
+#
+# Output protocol (stdout), one `key=value` per line:
+#
+#   state=cwd               repo=<toplevel>          exit 0
+#   state=resolved-child    repo=<path> name=<base>  exit 0
+#   state=ambiguous         candidate=<path> ...     exit 2
+#   state=none                                       exit 1
+#
+# Callers chdir to `repo=` themselves. This script only reports; it never
+# changes anything, so it is safe to run twice.
+
+set -u
+
+# Already inside a work tree: nothing to resolve. This is the overwhelmingly
+# common case and costs one git call.
+if toplevel=$(git rev-parse --show-toplevel 2>/dev/null) && [ -n "$toplevel" ]; then
+    printf 'state=cwd\n'
+    printf 'repo=%s\n' "$toplevel"
+    exit 0
+fi
+
+# Not in a repo. Look one level down, at the immediate children of cwd only.
+# A child counts when it is itself a repo *root* — `--show-toplevel` resolving
+# back to the child is what distinguishes a repo from a plain directory that
+# merely sits beneath one. Deeper recursion is deliberately not attempted: it
+# would turn a cheap check into a filesystem walk and start matching vendored
+# checkouts and fixtures.
+#
+# The `*/` glob skips dotted directories, which is wanted — ~/.claude and
+# friends are infrastructure, not the session's work.
+count=0
+candidates=
+for child in ./*/; do
+    [ -d "$child" ] || continue
+    child_abs=$(cd "$child" 2>/dev/null && pwd) || continue
+    child_top=$(git -C "$child_abs" rev-parse --show-toplevel 2>/dev/null) || continue
+    [ "$child_top" = "$child_abs" ] || continue
+    count=$((count + 1)) || true
+    candidates="$candidates$child_abs
+"
+done
+
+if [ "$count" -eq 0 ]; then
+    printf 'state=none\n'
+    exit 1
+fi
+
+if [ "$count" -eq 1 ]; then
+    repo=$(printf '%s' "$candidates" | head -1)
+    printf 'state=resolved-child\n'
+    printf 'repo=%s\n' "$repo"
+    printf 'name=%s\n' "$(basename "$repo")"
+    exit 0
+fi
+
+printf 'state=ambiguous\n'
+printf '%s' "$candidates" | while IFS= read -r c; do
+    [ -n "$c" ] || continue
+    printf 'candidate=%s\n' "$c"
+done
+exit 2

--- a/home/bin/start-session-gather-state
+++ b/home/bin/start-session-gather-state
@@ -20,13 +20,56 @@ set -uo pipefail
 
 progress() { printf '[gather] %s\n' "$*" >&2; }
 
-# --- Phase 0: pre-flight ------------------------------------------------
+# --- Phase 0: resolve the repo ------------------------------------------
 # Everything below assumes a git repo, so this has to come before the fetch.
-if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    printf '===not_a_git_repo (exit=1)===\n'
-    printf '/start-session requires a git-backed repo — nothing to sync.\n\n'
-    exit 1
+#
+# "Not a repo" is not the same as "no repo": a container handed several repos
+# as siblings starts the session in their parent, so the repo being worked in
+# is one level down. session-repo-resolve does that lookup; this script only
+# acts on its verdict. A sibling helper rather than inline code because
+# end-session-gather-state needs the identical answer.
+RESOLVE_OUT=$("$(dirname "$0")/session-repo-resolve" 2>/dev/null)
+RESOLVE_STATE=$(printf '%s\n' "$RESOLVE_OUT" | sed -n 's/^state=//p' | head -1)
+
+# A container installed before session-repo-resolve existed has no helper to
+# run. Degrade to the old inline check rather than reporting every repo as
+# unresolvable.
+if [ -z "$RESOLVE_STATE" ]; then
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        RESOLVE_STATE=cwd
+    else
+        RESOLVE_STATE=none
+    fi
 fi
+
+RESOLVED_REPO=""
+case "$RESOLVE_STATE" in
+    cwd)
+        : # ordinary case: the session is already standing in the repo
+        ;;
+    resolved-child)
+        RESOLVED_REPO=$(printf '%s\n' "$RESOLVE_OUT" | sed -n 's/^repo=//p' | head -1)
+        cd "$RESOLVED_REPO" || {
+            printf '===not_a_git_repo (exit=1)===\n'
+            printf 'resolved %s but could not enter it — nothing to sync.\n\n' "$RESOLVED_REPO"
+            exit 1
+        }
+        ;;
+    ambiguous)
+        # Several candidates is the one case the script must not decide. It
+        # reports them and stops; the skill asks which.
+        printf '===repo_candidates (exit=2)===\n'
+        printf 'cwd=%s\n' "$(pwd)"
+        printf '%s\n' "$RESOLVE_OUT" | sed -n 's/^candidate=/candidate=/p'
+        printf '\n'
+        exit 2
+        ;;
+    *)
+        printf '===not_a_git_repo (exit=1)===\n'
+        printf '/start-session requires a git-backed repo — nothing to sync.\n\n'
+        exit 1
+        ;;
+esac
 
 TMP=$(mktemp -d -t start-session-gather.XXXXXX)
 trap 'rm -rf "$TMP"' EXIT
@@ -309,6 +352,17 @@ emit() {
     cat "$TMP/$name.out" 2>/dev/null
     printf '\n'
 }
+
+# Only present when the repo was not the one the caller was standing in —
+# there is nothing to report when cwd was already the repo, and the caller
+# needs to chdir here itself, since this script's own cd died with it.
+if [ -n "$RESOLVED_REPO" ]; then
+    printf '===repo_resolution (exit=0)===\n'
+    printf 'state=resolved-child\n'
+    printf 'repo=%s\n' "$RESOLVED_REPO"
+    printf 'name=%s\n' "$(basename "$RESOLVED_REPO")"
+    printf '\n'
+fi
 
 printf '===fetch (exit=%s)===\n' "$FETCH_EXIT"
 # Suppress verbose fetch output on success (it's normal "From <remote>..." chatter

--- a/home/skills/end-session/SKILL.md
+++ b/home/skills/end-session/SKILL.md
@@ -25,13 +25,13 @@ When in doubt, downgrade a tier (Tier 1 → 2, or 2 → 3). Never upgrade silent
 
 ## Pre-flight
 
-This command **requires a git-backed repository**. Run the bare command below and branch on its exit code — don't paste a compound `||` / `&&` form, which won't match any single allow rule and will trigger a permission prompt.
+This command **requires a git-backed repository** — but it does not check for one itself. The gather script does, and it looks one level down before giving up: a container handed several repos as siblings starts the session in their parent, where a bare `git rev-parse` fails while the repo being worked in sits directly beneath.
 
-```sh
-git rev-parse --is-inside-work-tree
-```
+So make **no standalone Bash call before the gather**. Run the gather (Phase 1) and branch on what it reports:
 
-If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `end-session` requires a git-backed repo — nothing to tidy, stopping. ``) and stop. Do not run any further checks, do not proceed to Phase 2.
+- **`repo_resolution`** — cwd was not a repo, exactly one repo sat beneath it, and the gather ran there. `cd` to its `repo=` value before any later step (the script's own `cd` died with it), and name the repo in the summary. No prompt: one candidate is not a choice.
+- **`repo_candidates`** — several repos sat beneath cwd. It is the only section and the script exits 2. List the candidates, ask which, `cd` there, and re-run the gather. Never guess.
+- **`not_a_git_repo`** — no repo in cwd and none beneath it. Print the line it contains and stop. Do not run any further checks, do not proceed to Phase 2.
 
 ## Surface
 

--- a/home/skills/start-session/SKILL.md
+++ b/home/skills/start-session/SKILL.md
@@ -52,7 +52,7 @@ structured GitHub API tool over the CLI where the client offers one.
 
 ## Phase 1 — Sync
 
-Everything starts with one script call. The pre-flight check is inside it, so
+Everything starts with one script call. The pre-flight check is inside it — including working out which repo this session is in when cwd is their parent — so
 this command makes **no standalone Bash calls before the gather**.
 
 ### 1. Gather state (Tier 1 — one tool call)
@@ -67,7 +67,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 
 | Section | Drives step(s) | Notes on exit code |
 | --- | --- | --- |
-| `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
+| `repo_resolution` | 1a, 7 | Only present when cwd was **not** itself a repo and exactly one repo sat directly beneath it — the script resolved to it and gathered there. Gives `repo=` and `name=`. `cd` to `repo=` before any later step, because the script's own `cd` died with it, and name the repo and the reason in the brief. No prompt: one candidate is not a choice. |
+| `repo_candidates` | 1a | Only present when cwd was not a repo and **several** repos sat directly beneath it, in which case it is the **only** section and the script exits 2. Gives `cwd=` and one `candidate=` line each. Tier 3: list them, ask which, `cd` there and re-run the gather. Never guess. |
+| `not_a_git_repo` | pre-flight | Only present when cwd was not a repo and no repo sat beneath it either, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`. |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |
@@ -191,6 +193,7 @@ Always print, even when everything is clean. This is the user-facing payoff — 
 ```text
 ── Session brief ──────────────────────────────
 Repo:     <repo>             Branch: <branch> (<clean|dirty>)
+          [ran in <name>; cwd <cwd> is not a repo]   (only when repo_resolution present)
 Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
 
@@ -218,6 +221,7 @@ Needs attention:
 
 Rules:
 
+- When `repo_resolution` is present, the `Repo:` line carries the second line naming which repo was resolved and why. It is never silent: a session that resolved its own repo should be able to see that it did.
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
 - "Ready to pick up next" is sourced from gather section `gh_ready`. Each row is already pipe-separated `#<n>|P<pri>|<title>` — split on `|`, sort by priority label (P0 first, `-` last), and emit the top 5. Ready = open and not directly blocked; the filter is direct-blocks-only, so eyeball the blocked icon before claiming work.
 - "In progress" is sourced from gather section `gh_assigned`. Same `#<n>|P<pri>|<title>` row shape; no cap (usually 0–3 items).
@@ -228,7 +232,8 @@ Rules:
 
 ## Guardrails
 
-- **Pre-flight gate is non-negotiable.** Never proceed when not in a git repo.
+- **Pre-flight gate is non-negotiable.** Never proceed when there is no repo — but "cwd is not a repo" is not that. The gather looks one level down first, so the gate fires on `not_a_git_repo` (nothing beneath either), not on the bare fact that cwd is a parent directory.
+- **Never guess between candidate repos.** `repo_candidates` means several sat beneath cwd; list them and ask. One candidate resolves silently, several never do.
 - **Never auto-rebase a feature branch** onto an advanced default branch. Surface the gap and stop. The user picks the strategy.
 - **Never switch branches except when the upstream is gone and the tree is clean.** That single case (PR merged + branch auto-deleted on remote, no local uncommitted work) is auto-handled per Step 3. Otherwise, `start-session` reports state on whatever branch the user is on.
 - **Don't push anything.** Pushes belong to `end-session` (for git/`main`). `start-session` is read-mostly. (Note: if the user says yes to the journal-promote prompt, `/promote-journal-inbox` runs its own commit + push against `paul-context` — that's the promote command's contract, not a carve-out here.)

--- a/profiles/claude-cloud-sandbox/skills/end-session/SKILL.md
+++ b/profiles/claude-cloud-sandbox/skills/end-session/SKILL.md
@@ -25,13 +25,13 @@ When in doubt, downgrade a tier (Tier 1 → 2, or 2 → 3). Never upgrade silent
 
 ## Pre-flight
 
-This command **requires a git-backed repository**. Run the bare command below and branch on its exit code — don't paste a compound `||` / `&&` form, which won't match any single allow rule and will trigger a permission prompt.
+This command **requires a git-backed repository** — but it does not check for one itself. The gather script does, and it looks one level down before giving up: a container handed several repos as siblings starts the session in their parent, where a bare `git rev-parse` fails while the repo being worked in sits directly beneath.
 
-```sh
-git rev-parse --is-inside-work-tree
-```
+So make **no standalone Bash call before the gather**. Run the gather (Phase 1) and branch on what it reports:
 
-If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `end-session` requires a git-backed repo — nothing to tidy, stopping. ``) and stop. Do not run any further checks, do not proceed to Phase 2.
+- **`repo_resolution`** — cwd was not a repo, exactly one repo sat beneath it, and the gather ran there. `cd` to its `repo=` value before any later step (the script's own `cd` died with it), and name the repo in the summary. No prompt: one candidate is not a choice.
+- **`repo_candidates`** — several repos sat beneath cwd. It is the only section and the script exits 2. List the candidates, ask which, `cd` there, and re-run the gather. Never guess.
+- **`not_a_git_repo`** — no repo in cwd and none beneath it. Print the line it contains and stop. Do not run any further checks, do not proceed to Phase 2.
 
 ## Surface
 

--- a/profiles/claude-cloud-sandbox/skills/start-session/SKILL.md
+++ b/profiles/claude-cloud-sandbox/skills/start-session/SKILL.md
@@ -62,7 +62,7 @@ more here than on a machine that will still be there tomorrow.
 
 ## Phase 1 — Sync
 
-Everything starts with one script call. The pre-flight check is inside it, so
+Everything starts with one script call. The pre-flight check is inside it — including working out which repo this session is in when cwd is their parent — so
 this command makes **no standalone Bash calls before the gather**.
 
 ### 1. Gather state (Tier 1 — one script call, one MCP call)
@@ -81,7 +81,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 
 | Section | Drives step(s) | Notes on exit code |
 | --- | --- | --- |
-| `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
+| `repo_resolution` | 1a, 7 | Only present when cwd was **not** itself a repo and exactly one repo sat directly beneath it — the script resolved to it and gathered there. Gives `repo=` and `name=`. `cd` to `repo=` before any later step, because the script's own `cd` died with it, and name the repo and the reason in the brief. No prompt: one candidate is not a choice. |
+| `repo_candidates` | 1a | Only present when cwd was not a repo and **several** repos sat directly beneath it, in which case it is the **only** section and the script exits 2. Gives `cwd=` and one `candidate=` line each. Tier 3: list them, ask which, `cd` there and re-run the gather. Never guess. |
+| `not_a_git_repo` | pre-flight | Only present when cwd was not a repo and no repo sat beneath it either, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`, and, under `---origin---`, the remote URL that gives you `<owner>/<repo>` for part (b). |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |
@@ -233,6 +235,7 @@ Always print, even when everything is clean. This is the user-facing payoff — 
 ```text
 ── Session brief ──────────────────────────────
 Repo:     <repo>             Branch: <branch> (<clean|dirty>)
+          [ran in <name>; cwd <cwd> is not a repo]   (only when repo_resolution present)
 Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
 
@@ -259,6 +262,7 @@ Needs attention:
 
 Rules:
 
+- When `repo_resolution` is present, the `Repo:` line carries the second line naming which repo was resolved and why. It is never silent: a session that resolved its own repo should be able to see that it did.
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
 - The issue list is titled **"Open issues (blocked filter unavailable)"**, not "Ready to pick up next". That is not a cosmetic difference: the query in step 1(b) cannot express `-is:blocked`, so some rows may be blocked. Titling it as a ready list would assert a filter that was never applied. Sort by priority label (P0 first, `-` last), emit the top 5, and check an issue's blockers before claiming it.
 - "In progress" is the same response filtered client-side to the authenticated login. Report the real answer — including `none` when the filter genuinely returned nothing. It reads `n/a (no GitHub route)` **only** when the MCP call itself failed.
@@ -269,7 +273,8 @@ Rules:
 
 ## Guardrails
 
-- **Pre-flight gate is non-negotiable.** Never proceed when not in a git repo.
+- **Pre-flight gate is non-negotiable.** Never proceed when there is no repo — but "cwd is not a repo" is not that. The gather looks one level down first, so the gate fires on `not_a_git_repo` (nothing beneath either), not on the bare fact that cwd is a parent directory.
+- **Never guess between candidate repos.** `repo_candidates` means several sat beneath cwd; list them and ask. One candidate resolves silently, several never do.
 - **Never auto-rebase a feature branch** onto an advanced default branch. Surface the gap and stop. The user picks the strategy.
 - **Never switch branches except when the upstream is gone and the tree is clean.** That single case (PR merged + branch auto-deleted on remote, no local uncommitted work) is auto-handled per Step 3. Otherwise, `start-session` reports state on whatever branch the user is on.
 - **Don't push anything.** Pushes belong to `end-session` (for git/`main`). `start-session` is read-mostly. (Note: if the user says yes to the journal-promote prompt, `/promote-journal-inbox` runs its own commit + push against `paul-context` — that's the promote command's contract, not a carve-out here.)

--- a/profiles/codex-cloud-sandbox/skills/end-session/SKILL.md
+++ b/profiles/codex-cloud-sandbox/skills/end-session/SKILL.md
@@ -25,13 +25,13 @@ When in doubt, downgrade a tier (Tier 1 → 2, or 2 → 3). Never upgrade silent
 
 ## Pre-flight
 
-This command **requires a git-backed repository**. Run the bare command below and branch on its exit code — don't paste a compound `||` / `&&` form, which won't match any single allow rule and will trigger a permission prompt.
+This command **requires a git-backed repository** — but it does not check for one itself. The gather script does, and it looks one level down before giving up: a container handed several repos as siblings starts the session in their parent, where a bare `git rev-parse` fails while the repo being worked in sits directly beneath.
 
-```sh
-git rev-parse --is-inside-work-tree
-```
+So make **no standalone Bash call before the gather**. Run the gather (Phase 1) and branch on what it reports:
 
-If the exit code is non-zero (or stdout is not `true`), print a single-line warning (`` `end-session` requires a git-backed repo — nothing to tidy, stopping. ``) and stop. Do not run any further checks, do not proceed to Phase 2.
+- **`repo_resolution`** — cwd was not a repo, exactly one repo sat beneath it, and the gather ran there. `cd` to its `repo=` value before any later step (the script's own `cd` died with it), and name the repo in the summary. No prompt: one candidate is not a choice.
+- **`repo_candidates`** — several repos sat beneath cwd. It is the only section and the script exits 2. List the candidates, ask which, `cd` there, and re-run the gather. Never guess.
+- **`not_a_git_repo`** — no repo in cwd and none beneath it. Print the line it contains and stop. Do not run any further checks, do not proceed to Phase 2.
 
 ## Surface
 

--- a/profiles/codex-cloud-sandbox/skills/start-session/SKILL.md
+++ b/profiles/codex-cloud-sandbox/skills/start-session/SKILL.md
@@ -62,7 +62,7 @@ more here than on a machine that will still be there tomorrow.
 
 ## Phase 1 — Sync
 
-Everything starts with one script call. The pre-flight check is inside it, so
+Everything starts with one script call. The pre-flight check is inside it — including working out which repo this session is in when cwd is their parent — so
 this command makes **no standalone Bash calls before the gather**.
 
 ### 1. Gather state (Tier 1 — one script call, one MCP call)
@@ -81,7 +81,9 @@ Output is a sectioned stream. Each section starts with `===<name> (exit=<N>)===`
 
 | Section | Drives step(s) | Notes on exit code |
 | --- | --- | --- |
-| `not_a_git_repo` | pre-flight | Only present when the gather ran outside a git repo, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
+| `repo_resolution` | 1a, 7 | Only present when cwd was **not** itself a repo and exactly one repo sat directly beneath it — the script resolved to it and gathered there. Gives `repo=` and `name=`. `cd` to `repo=` before any later step, because the script's own `cd` died with it, and name the repo and the reason in the brief. No prompt: one candidate is not a choice. |
+| `repo_candidates` | 1a | Only present when cwd was not a repo and **several** repos sat directly beneath it, in which case it is the **only** section and the script exits 2. Gives `cwd=` and one `candidate=` line each. Tier 3: list them, ask which, `cd` there and re-run the gather. Never guess. |
+| `not_a_git_repo` | pre-flight | Only present when cwd was not a repo and no repo sat beneath it either, in which case it is the **only** section and the script exits 1. Print the line it contains and stop; every other step assumes a repo. |
 | `fetch` | 2 (folded in) | Body is empty on success (exit=0). Non-zero = network/auth issue — body contains the error; surface before proceeding. |
 | `local_state` | 3, 7 | Includes branch, dirty/clean, ahead/behind upstream, ahead/behind `origin/<default>`, and, under `---origin---`, the remote URL that gives you `<owner>/<repo>` for part (b). |
 | `recent_main_commits` | 5 | First line is `count=<N>` (commits that merged into `origin/<default>` since the previous local tip). When non-zero, subsequent lines are `<short-sha> <subject>`, capped at 10. Empty when caught up. |
@@ -233,6 +235,7 @@ Always print, even when everything is clean. This is the user-facing payoff — 
 ```text
 ── Session brief ──────────────────────────────
 Repo:     <repo>             Branch: <branch> (<clean|dirty>)
+          [ran in <name>; cwd <cwd> is not a repo]   (only when repo_resolution present)
 Sync:     <default> <ahead/behind/even>   upstream <ahead/behind/even/gone/n/a>
           [auto-switched <feature> → <default> (upstream gone)]    (only when Step 3 auto-switched)
 
@@ -259,6 +262,7 @@ Needs attention:
 
 Rules:
 
+- When `repo_resolution` is present, the `Repo:` line carries the second line naming which repo was resolved and why. It is never silent: a session that resolved its own repo should be able to see that it did.
 - Sections with nothing to say collapse to a single `none` line; "Needs attention" is omitted entirely when empty.
 - The issue list is titled **"Open issues (blocked filter unavailable)"**, not "Ready to pick up next". That is not a cosmetic difference: the query in step 1(b) cannot express `-is:blocked`, so some rows may be blocked. Titling it as a ready list would assert a filter that was never applied. Sort by priority label (P0 first, `-` last), emit the top 5, and check an issue's blockers before claiming it.
 - "In progress" is the same response filtered client-side to the authenticated login. Report the real answer — including `none` when the filter genuinely returned nothing. It reads `n/a (no GitHub route)` **only** when the MCP call itself failed.
@@ -269,7 +273,8 @@ Rules:
 
 ## Guardrails
 
-- **Pre-flight gate is non-negotiable.** Never proceed when not in a git repo.
+- **Pre-flight gate is non-negotiable.** Never proceed when there is no repo — but "cwd is not a repo" is not that. The gather looks one level down first, so the gate fires on `not_a_git_repo` (nothing beneath either), not on the bare fact that cwd is a parent directory.
+- **Never guess between candidate repos.** `repo_candidates` means several sat beneath cwd; list them and ask. One candidate resolves silently, several never do.
 - **Never auto-rebase a feature branch** onto an advanced default branch. Surface the gap and stop. The user picks the strategy.
 - **Never switch branches except when the upstream is gone and the tree is clean.** That single case (PR merged + branch auto-deleted on remote, no local uncommitted work) is auto-handled per Step 3. Otherwise, `start-session` reports state on whatever branch the user is on.
 - **Don't push anything.** Pushes belong to `end-session` (for git/`main`). `start-session` is read-mostly. (Note: if the user says yes to the journal-promote prompt, `/promote-journal-inbox` runs its own commit + push against `paul-context` — that's the promote command's contract, not a carve-out here.)


### PR DESCRIPTION
Closes #338

## What changed

New `home/bin/session-repo-resolve`, called by both gather scripts. When cwd is not itself a repo, it looks one level down before anything gives up.

| cwd | Beneath it | Result |
| --- | --- | --- |
| is a repo | — | `state=cwd` — unchanged, one extra `git` call |
| not a repo | exactly one repo | `state=resolved-child` — gather runs there, brief names it |
| not a repo | several repos | `state=ambiguous` — candidates surfaced, user picks, never guessed |
| not a repo | none | `state=none` — unchanged: warn and stop |

## Why a sibling helper

Both gathers need the identical answer, and the answer is identical on both surfaces — so it wants no surface variant and no duplication (ADR-0018 principle 8, step 0: absorb the difference in a script before splitting content). There is precedent: `start-session-claude-drift` is already a sibling invoked as `$(dirname "$0")/…`, and the bootstrap's `BIN_SCRIPTS` comment already explains that hazard. `session-repo-resolve` is added to that list, and the comment now names it as the shared one.

It reports and never acts — no `cd`, no writes — so it is safe to run twice.

## What the skills gained

Only what to do with the verdict, which is the few lines the issue predicted:

- Two new rows in both `05-gather-*` fragments (`repo_resolution`, `repo_candidates`), and the `not_a_git_repo` row reworded to say it now means *no repo beneath either*.
- `end-session/03-pre-flight.md` rewritten. It previously instructed a bare `git rev-parse --is-inside-work-tree` **before** the gather — precisely the check that stopped on a parent directory. It now defers to the gather, so neither command makes a standalone Bash call first.
- The session brief carries `ran in <name>; cwd <cwd> is not a repo` when resolution fired. Never silent — a session that resolved its own repo should be able to see that it did.
- Guardrails reworded: the gate is still non-negotiable, but "cwd is not a repo" is no longer the same as "there is no repo", and several candidates are never guessed between.

## The one thing callers must do

The script's `cd` dies with the script, so `repo_resolution` tells the caller to `cd` there itself before any later step. Both skill bodies say so.

## Backward compatibility

A container installed before this helper existed has nothing to run. Both gathers detect the empty verdict and fall back to the old inline `git rev-parse` check, rather than reporting every repo as unresolvable.

## Acceptance criteria

- [x] cwd not a repo + exactly one child repo → runs there, says which repo and why
- [x] cwd not a repo + several child repos → candidate list surfaced, user picks
- [x] cwd not a repo + none → unchanged: one-line warning, stop
- [x] Resolution lives in the gather scripts, not per-surface fragments
- [x] Both skills regenerated

## Verification

Exercised against this very container, which is the reported failure case:

```
$ cd /home/user && ~/.claude/bin/start-session-gather-state
===repo_candidates (exit=2)===
cwd=/home/user
candidate=/home/user/agentic-coding-config
candidate=/home/user/gcp-org-management
candidate=/home/user/paul-context

$ cd <parent with one clone> && start-session-gather-state
===repo_resolution (exit=0)===
state=resolved-child
repo=…/onechild/acc
name=acc
===fetch (exit=0)===
…
```

Also checked: cwd inside a repo (`state=cwd`), cwd in a repo subdirectory (`state=cwd`, resolves to the toplevel), an empty directory (`state=none`, exit 1), and a repo root whose children are plain subdirectories (`state=cwd`, not mistaken for candidates — a child counts only when `--show-toplevel` resolves back to the child itself).

All gates green: markdownlint (127 files), the four shell test scripts, `compose-context.py`, `allowlist-covers-commands.py`, and shellcheck across `home/bin`, `cloud/` and `tests/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7qvq6xA45bmcen9gBfTnZ)_