### PR TITLE
A missing binary is not a lint finding

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -117,11 +117,26 @@ line no longer says what happened:
 
 ```text
 [bootstrap] profile -> claude-cloud-sandbox
-[bootstrap] caps    :  gcloud=yes precommit=yes hooks=yes gh=no
+[bootstrap] caps    :  gcloud=yes precommit=yes hooks=yes gh=no terraform=no
 ```
 
 The same set is written to `~/.agents/.bootstrap-manifest`, which is where to
 look when a container is behaving as though something is missing.
+
+`--with-terraform` installs `terraform`, `tflint` and `checkov`, so a repo
+whose `.pre-commit-config.yaml` calls the Terraform hooks can actually run
+them. Off for every profile — `terraform` alone is a large download for a
+container that may never open a `.tf` file. It installs inside
+`--with-precommit`, since serving that config is the whole reason the binaries
+are here: `--with-terraform --no-precommit` installs nothing.
+
+Their absence is no longer a blocked push. `precommit-claude-hook` classifies
+a hook that fails purely because its binary is missing as *not checked* and
+lets the command through, naming what went unchecked (#335). Before that,
+every push in a container without these tools needed `--no-verify` — five out
+of five in one session, which is how a guard stops being a guard. So this flag
+buys **coverage**, not the ability to push: add it to an environment that
+genuinely does Terraform work and wants those hooks enforced.
 
 `--with-gh` installs the GitHub CLI from a pinned release — but **do not add
 it to Anthropic-hosted environments**. Measured 2026-08-19: the egress proxy
@@ -243,13 +258,14 @@ Revocation levels and what to do about a possibly-exposed token or request key:
 | `~/.claude/skills/<name>` | symlink to the above, for Claude Code |
 | `~/.agents/AGENTS.md` | the composed policy profile |
 | `~/.claude/CLAUDE.md` | the Claude adapter profile (Claude profiles only) |
-| `~/.claude/bin/<script>` | the four session helper scripts |
+| `~/.claude/bin/<script>` | the five session helper scripts |
 | `~/.agents/.bootstrap-manifest` | what this run installed: ref, SHA, profile, skills, helpers |
 | `~/.config/git/hooks/pre-commit` | global git hook, with `--with-precommit` |
 | `~/.claude/settings.json` | harness hook wiring, with `--with-hooks` (merged, not replaced) |
 | `~/.claude/bin/*-claude-hook` | the three harness hook scripts, with `--with-hooks` |
 | `/usr/local/bin/pre-commit`, `/usr/bin/shellcheck`, `/usr/local/bin/actionlint`, `markdownlint-cli2` (npm global) | with `--with-precommit` |
 | `/usr/local/bin/gh` | the GitHub CLI, pinned release, with `--with-gh` |
+| `/usr/local/bin/terraform`, `/usr/local/bin/tflint`, `checkov` | the Terraform toolchain, with `--with-terraform` |
 
 Whitelisted today: `promote-journal-inbox`, `retrospective`, `start-session`,
 `end-session`. The other **16** skills under `home/skills/` are held back

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -117,7 +117,7 @@ line no longer says what happened:
 
 ```text
 [bootstrap] profile -> claude-cloud-sandbox
-[bootstrap] caps    :  gcloud=yes precommit=yes hooks=yes gh=no terraform=no
+[bootstrap] caps    :  gcloud=yes precommit=yes hooks=yes gh=no terraform=yes
 ```
 
 The same set is written to `~/.agents/.bootstrap-manifest`, which is where to
@@ -125,18 +125,20 @@ look when a container is behaving as though something is missing.
 
 `--with-terraform` installs `terraform`, `tflint` and `checkov`, so a repo
 whose `.pre-commit-config.yaml` calls the Terraform hooks can actually run
-them. Off for every profile — `terraform` alone is a large download for a
-container that may never open a `.tf` file. It installs inside
-`--with-precommit`, since serving that config is the whole reason the binaries
-are here: `--with-terraform --no-precommit` installs nothing.
+them. **On by default for a sandbox**, like `--with-precommit` and for the
+same reason: a disposable container rebuilt from a script has no developer
+setup to protect, so a gate that is present beats a download that is avoided.
+`--no-terraform` is the refund for an environment that does no Terraform work.
+It installs inside `--with-precommit`, since serving that config is the whole
+reason the binaries are here: `--with-terraform --no-precommit` installs
+nothing.
 
-Their absence is no longer a blocked push. `precommit-claude-hook` classifies
-a hook that fails purely because its binary is missing as *not checked* and
-lets the command through, naming what went unchecked (#335). Before that,
-every push in a container without these tools needed `--no-verify` — five out
-of five in one session, which is how a guard stops being a guard. So this flag
-buys **coverage**, not the ability to push: add it to an environment that
-genuinely does Terraform work and wants those hooks enforced.
+This buys **coverage**, not the ability to push. A container without these
+tools pushes fine: `precommit-claude-hook` classifies a hook that fails purely
+because its binary is missing as *not checked* and lets the command through,
+naming what went unchecked (#335). Before that fix, every push in such a
+container needed `--no-verify` — five out of five in one session, which is how
+a guard stops being a guard.
 
 `--with-gh` installs the GitHub CLI from a pinned release — but **do not add
 it to Anthropic-hosted environments**. Measured 2026-08-19: the egress proxy

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -48,6 +48,15 @@
 # #257, cleanup on #273. Off for every profile; the flag exists for surfaces
 # whose egress genuinely reaches the GitHub API, e.g. self-hosted environments.
 #
+# --with-terraform installs terraform, tflint and checkov, so a repo whose
+# .pre-commit-config.yaml calls the Terraform hooks can actually run them.
+# Off for every profile: terraform alone is a large download for a container
+# that may never open a .tf file. Their absence no longer blocks anything --
+# precommit-claude-hook reports a hook whose binary is missing as not checked
+# rather than failed (#335) -- so this buys coverage, not the ability to push.
+# Installed inside --with-precommit, since serving that config is the whole
+# reason they are here: --with-terraform --no-precommit installs nothing.
+#
 # <REF> is what everything else is fetched from, and should match the ref this
 # script was itself fetched from, so a run cannot straddle two versions. Pin it
 # to a tag or commit in anything durable — a branch means
@@ -86,6 +95,7 @@ WITH_GCLOUD=
 WITH_PRECOMMIT=
 WITH_HOOKS=
 WITH_GH=
+WITH_TERRAFORM=
 PROFILE=claude-cloud-sandbox
 
 while [ $# -gt 0 ]; do
@@ -98,6 +108,8 @@ while [ $# -gt 0 ]; do
         --no-hooks) WITH_HOOKS=0 ;;
         --with-gh) WITH_GH=1 ;;
         --no-gh) WITH_GH=0 ;;
+        --with-terraform) WITH_TERRAFORM=1 ;;
+        --no-terraform) WITH_TERRAFORM=0 ;;
         --profile)
             shift
             [ $# -gt 0 ] || die "--profile needs a value"
@@ -157,6 +169,14 @@ WITH_GCLOUD=$(resolve "$WITH_GCLOUD" "$def_gcloud")
 WITH_PRECOMMIT=$(resolve "$WITH_PRECOMMIT" "$def_precommit")
 WITH_HOOKS=$(resolve "$WITH_HOOKS" "$def_hooks")
 WITH_GH=$(resolve "$WITH_GH" 0)
+# terraform/tflint/checkov are off by default for the same reason gh is: they
+# are a large download for a container that may never open a .tf file, and the
+# repos that do need them know who they are. What makes off-by-default safe is
+# that their absence is no longer a blocked push -- precommit-claude-hook now
+# reports a hook whose binary is missing as not checked rather than failed
+# (#335). Before that fix, "off" meant every push in the container needed
+# --no-verify, which is why installing them looked mandatory.
+WITH_TERRAFORM=$(resolve "$WITH_TERRAFORM" 0)
 
 RAW="https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/${REF}"
 
@@ -259,7 +279,7 @@ log "installing from ${REF}"
 # often than the setup script that built it.
 on_off() { [ "$1" -eq 1 ] && echo "yes" || echo "no"; }
 log "profile -> $PROFILE"
-log "caps    :  gcloud=$(on_off "$WITH_GCLOUD") precommit=$(on_off "$WITH_PRECOMMIT") hooks=$(on_off "$WITH_HOOKS") gh=$(on_off "$WITH_GH")"
+log "caps    :  gcloud=$(on_off "$WITH_GCLOUD") precommit=$(on_off "$WITH_PRECOMMIT") hooks=$(on_off "$WITH_HOOKS") gh=$(on_off "$WITH_GH") terraform=$(on_off "$WITH_TERRAFORM")"
 
 # There is deliberately no apt step here.
 #
@@ -540,6 +560,53 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     command -v markdownlint-cli2 > /dev/null 2>&1 ||
         die "markdownlint-cli2 installed but is not on PATH"
     log "mdlint  -> $(command -v markdownlint-cli2) ($(markdownlint-cli2 --version 2>&1 | head -1))"
+
+    # The Terraform toolchain, opt-in. A repo's .pre-commit-config.yaml can
+    # call terraform_fmt, terraform_validate, terraform_tflint and checkov;
+    # without the binaries those hooks fail with exit 127 rather than finding
+    # anything. precommit-claude-hook classifies that as not-checked and lets
+    # the push through (#335), so this is about being able to CHECK, not about
+    # being able to push.
+    #
+    # Off by default because terraform alone is a large download for a
+    # container that may never open a .tf file. An environment doing Terraform
+    # work adds --with-terraform to its one line.
+    if [ "$WITH_TERRAFORM" -eq 1 ]; then
+        # Same pinned-release pattern, and the same github.com 403 note, as
+        # actionlint above.
+        if ! command -v terraform > /dev/null 2>&1; then
+            TF_VER=1.9.8
+            fetch "https://releases.hashicorp.com/terraform/${TF_VER}/terraform_${TF_VER}_linux_amd64.zip" \
+                "$TMP/terraform.zip" ||
+                die "could not download terraform ${TF_VER}"
+            unzip -o -q "$TMP/terraform.zip" -d "$TMP" terraform ||
+                die "could not unpack terraform — is unzip present?"
+            install -m 0755 "$TMP/terraform" /usr/local/bin/terraform ||
+                die "could not install terraform"
+        fi
+        log "terrafm -> $(command -v terraform) ($(terraform version | head -1))"
+
+        if ! command -v tflint > /dev/null 2>&1; then
+            TFL_VER=0.53.0
+            fetch "https://github.com/terraform-linters/tflint/releases/download/v${TFL_VER}/tflint_linux_amd64.zip" \
+                "$TMP/tflint.zip" ||
+                die "could not download tflint ${TFL_VER}"
+            unzip -o -q "$TMP/tflint.zip" -d "$TMP" tflint ||
+                die "could not unpack tflint"
+            install -m 0755 "$TMP/tflint" /usr/local/bin/tflint ||
+                die "could not install tflint"
+        fi
+        log "tflint  -> $(command -v tflint)"
+
+        # checkov is a Python tool, so it takes the same pip route as
+        # pre-commit rather than a release tarball.
+        command -v checkov > /dev/null 2>&1 ||
+            pip_install checkov ||
+            die "could not install checkov from PyPI"
+        command -v checkov > /dev/null 2>&1 ||
+            die "checkov reported installed but is not on PATH"
+        log "checkov -> $(command -v checkov)"
+    fi
 
     command -v pre-commit > /dev/null 2>&1 ||
         pip_install pre-commit ||

--- a/cloud/bootstrap.sh
+++ b/cloud/bootstrap.sh
@@ -49,13 +49,14 @@
 # whose egress genuinely reaches the GitHub API, e.g. self-hosted environments.
 #
 # --with-terraform installs terraform, tflint and checkov, so a repo whose
-# .pre-commit-config.yaml calls the Terraform hooks can actually run them.
-# Off for every profile: terraform alone is a large download for a container
-# that may never open a .tf file. Their absence no longer blocks anything --
-# precommit-claude-hook reports a hook whose binary is missing as not checked
-# rather than failed (#335) -- so this buys coverage, not the ability to push.
-# Installed inside --with-precommit, since serving that config is the whole
-# reason they are here: --with-terraform --no-precommit installs nothing.
+# .pre-commit-config.yaml calls the Terraform hooks can actually run them. On
+# by default for a sandbox, like pre-commit; --no-terraform is the refund for
+# an environment that does no Terraform work and wants the download back.
+# This buys coverage, not the ability to push: their absence no longer blocks
+# anything, since precommit-claude-hook reports a hook whose binary is missing
+# as not checked rather than failed (#335). Installed inside --with-precommit,
+# since serving that config is the whole reason they are here:
+# --with-terraform --no-precommit installs nothing.
 #
 # <REF> is what everything else is fetched from, and should match the ref this
 # script was itself fetched from, so a run cannot straddle two versions. Pin it
@@ -161,22 +162,27 @@ case "$PROFILE" in
     *) def_hooks=0 ;;
 esac
 case "$PROFILE" in
-    *-cloud-sandbox) def_precommit=1; def_gcloud=1 ;;
-    *) def_precommit=0; def_gcloud=0 ;;
+    *-cloud-sandbox) def_precommit=1; def_gcloud=1; def_terraform=1 ;;
+    *) def_precommit=0; def_gcloud=0; def_terraform=0 ;;
 esac
 
 WITH_GCLOUD=$(resolve "$WITH_GCLOUD" "$def_gcloud")
 WITH_PRECOMMIT=$(resolve "$WITH_PRECOMMIT" "$def_precommit")
 WITH_HOOKS=$(resolve "$WITH_HOOKS" "$def_hooks")
 WITH_GH=$(resolve "$WITH_GH" 0)
-# terraform/tflint/checkov are off by default for the same reason gh is: they
-# are a large download for a container that may never open a .tf file, and the
-# repos that do need them know who they are. What makes off-by-default safe is
-# that their absence is no longer a blocked push -- precommit-claude-hook now
-# reports a hook whose binary is missing as not checked rather than failed
-# (#335). Before that fix, "off" meant every push in the container needed
-# --no-verify, which is why installing them looked mandatory.
-WITH_TERRAFORM=$(resolve "$WITH_TERRAFORM" 0)
+# terraform/tflint/checkov follow pre-commit: on for a sandbox, off elsewhere.
+# Same argument as --with-precommit above -- a sandbox is disposable and rebuilt
+# from a script, so there is no laptop here whose setup someone is protecting,
+# and a gate that is present is worth more than a download that is avoided.
+# --no-terraform is the refund for an environment that does no Terraform work.
+#
+# The download is the real cost and it is why this is a per-profile default
+# rather than unconditional. What it is NOT is a way to unblock pushes:
+# precommit-claude-hook reports a hook whose binary is missing as not checked
+# rather than failed (#335), so a container without these tools pushes fine.
+# Before that fix "off" meant every push needed --no-verify, which made
+# installing them look mandatory for the wrong reason.
+WITH_TERRAFORM=$(resolve "$WITH_TERRAFORM" "$def_terraform")
 
 RAW="https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/${REF}"
 
@@ -568,9 +574,10 @@ if [ "$WITH_PRECOMMIT" -eq 1 ]; then
     # the push through (#335), so this is about being able to CHECK, not about
     # being able to push.
     #
-    # Off by default because terraform alone is a large download for a
-    # container that may never open a .tf file. An environment doing Terraform
-    # work adds --with-terraform to its one line.
+    # On by default for a sandbox, off elsewhere -- the same reasoning as
+    # pre-commit itself: a disposable container rebuilt from a script has no
+    # developer setup to protect, so enforcement that is present beats a
+    # download that is avoided. --no-terraform is the refund.
     if [ "$WITH_TERRAFORM" -eq 1 ]; then
         # Same pinned-release pattern, and the same github.com 403 note, as
         # actionlint above.

--- a/home/bin/precommit-claude-hook
+++ b/home/bin/precommit-claude-hook
@@ -124,8 +124,71 @@ fi
 
 # --- Run it. Block (exit 2) on failure; silent on success. ----------------
 # shellcheck disable=SC2086
-if ! out=$(pre-commit run --hook-stage "$stage" $scope 2>&1); then
-  printf 'pre-commit (%s) failed — blocked. Fix these and re-run:\n\n%s\n' "$stage" "$out" >&2
-  exit 2
+out=$(pre-commit run --hook-stage "$stage" $scope 2>&1) && exit 0
+
+# A hook that could not RUN is not a finding. The push stage deliberately runs
+# the whole suite --all-files, so on any surface missing an optional toolchain
+# it fails hooks whose binary is simply absent: terraform, tflint and checkov
+# are not installed in a cloud sandbox, so a Go-and-Markdown-only commit hit
+# four exit-127 failures and had to be pushed with --no-verify. Five times out
+# of five, which is what turns a considered bypass into the muscle-memory
+# ending of every push command -- and the next time the hook blocks for a real
+# reason, --no-verify is already typed.
+#
+# So split the failures. Genuine findings still block exactly as before;
+# tool-absent ones are reported as not checked and let the push through. The
+# classification is deliberately tight -- a signature of the tool being missing,
+# not merely of the hook failing -- because the costly direction of error is
+# waving through a real finding.
+classify_failures() {
+    awk '
+        function flush() {
+            if (name != "" && failed) {
+                if (absent) unavail = unavail (unavail ? " " : "") name
+                else real = real (real ? " " : "") name
+            }
+            name = ""; failed = 0; absent = 0
+        }
+        # pre-commit prints one status line per hook: the name, dot padding,
+        # then the verdict. Skips carry "(no files to check)" before it.
+        /\.\.\./ && /(Passed|Failed|Skipped)$/ {
+            flush()
+            idx = index($0, "...")
+            name = substr($0, 1, idx - 1)
+            failed = ($0 ~ /Failed$/)
+            next
+        }
+        failed {
+            if ($0 ~ /exit code: 127/ ||
+                $0 ~ /command not found/ ||
+                $0 ~ /[Ee]xecutable .* not found/ ||
+                $0 ~ /binary could be found/ ||
+                $0 ~ /not found in .?PATH/) absent = 1
+        }
+        END { flush(); print "unavailable=" unavail; print "real=" real }
+    '
+}
+
+verdict=$(printf '%s\n' "$out" | classify_failures 2>/dev/null)
+unavailable=$(printf '%s\n' "$verdict" | sed -n 's/^unavailable=//p')
+real=$(printf '%s\n' "$verdict" | sed -n 's/^real=//p')
+
+# No awk, or output this parser did not recognise: fall back to blocking. An
+# unreadable result must not become a free pass.
+if [ -z "$verdict" ]; then
+    printf 'pre-commit (%s) failed — blocked. Fix these and re-run:\n\n%s\n' "$stage" "$out" >&2
+    exit 2
 fi
+
+if [ -n "$real" ]; then
+    printf 'pre-commit (%s) failed — blocked. Fix these and re-run:\n\n%s\n' "$stage" "$out" >&2
+    [ -n "$unavailable" ] &&
+        printf '\nNot checked (tool not installed): %s\n' "$unavailable" >&2
+    exit 2
+fi
+
+# Only tool-absent failures. Say what went unchecked -- "not checked" must
+# never be silently indistinguishable from "passed" -- and allow the command.
+printf 'pre-commit (%s): allowed. Not checked, tool not installed: %s\n' \
+    "$stage" "$unavailable" >&2
 exit 0

--- a/tests/precommit-hook-test.sh
+++ b/tests/precommit-hook-test.sh
@@ -75,6 +75,107 @@ echo "--- escape hatch still honoured ---"
 expect "commit --no-verify"      'git commit --no-verify -m "x"'           none
 expect "push --no-verify"        'git push --no-verify'                    none
 
+
+# --- Stage 2: a hook that could not RUN is not a finding (#335) -----------
+#
+# The push stage runs the whole suite --all-files, so on a surface missing an
+# optional toolchain it fails hooks whose binary is simply absent. Blocking on
+# that made --no-verify the ending of every push, which is how a guard stops
+# being a guard.
+#
+# These run the hook end-to-end against a throwaway repo with `pre-commit`
+# stubbed on PATH, so what is asserted is the hook's real exit code -- 2 blocks
+# the tool call, 0 lets it through -- rather than a trace.
+
+WORK=$(mktemp -d) || exit 1
+trap 'rm -rf "$WORK"' EXIT
+git init -q "$WORK/repo" || exit 1
+: > "$WORK/repo/.pre-commit-config.yaml"
+mkdir -p "$WORK/bin"
+
+# run_with_stub <fixture-file> <stub-exit> -> prints "<hook exit>|<stderr>"
+run_with_stub() {
+    cat > "$WORK/bin/pre-commit" <<STUB
+#!/bin/sh
+cat "$1"
+exit $2
+STUB
+    chmod 0755 "$WORK/bin/pre-commit"
+    _err=$(printf '{"tool_input":{"command":"git push"},"cwd":"%s"}\n' "$WORK/repo" |
+        PATH="$WORK/bin:$PATH" sh "$HOOK" 2>&1 >/dev/null)
+    _code=$?
+    printf '%s|%s' "$_code" "$_err"
+}
+
+expect_push() { # label fixture stub-exit expected-code expected-stderr-grep
+    got=$(run_with_stub "$2" "$3")
+    code=${got%%|*}
+    err=${got#*|}
+    # An empty pattern asserts silence: grep finds nothing in nothing, so the
+    # "hook said nothing" case cannot be expressed as a match.
+    if [ -z "$5" ]; then
+        _match=$([ -z "$err" ] && echo yes)
+    else
+        _match=$(printf '%s' "$err" | grep -q "$5" && echo yes)
+    fi
+    if [ "$code" = "$4" ] && [ "$_match" = yes ]; then
+        PASS=$((PASS + 1))
+        printf 'ok    %-52s -> exit %s\n' "$1" "$code"
+    else
+        FAIL=$((FAIL + 1))
+        printf 'FAIL  %-52s -> exit %s (want %s, stderr matching "%s")\n' \
+            "$1" "$code" "$4" "$5"
+        printf '      stderr: %s\n' "$err"
+    fi
+}
+
+cat > "$WORK/absent.txt" <<'FIXTURE'
+trim trailing whitespace.................................................Passed
+Terraform fmt............................................................Failed
+- hook id: terraform_fmt
+- exit code: 127
+Neither Terraform nor OpenTofu binary could be found.
+Terraform validate with tflint...........................................Failed
+- hook id: terraform_tflint
+- exit code: 127
+Command 'tflint --init' failed: tflint: command not found
+go fmt...................................................................Passed
+markdownlint.............................................................Passed
+FIXTURE
+
+cat > "$WORK/real.txt" <<'FIXTURE'
+trim trailing whitespace.................................................Passed
+markdownlint.............................................................Failed
+- hook id: markdownlint-cli2
+- exit code: 1
+docs/foo.md:3:1 MD009/no-trailing-spaces Trailing spaces
+FIXTURE
+
+cat > "$WORK/mixed.txt" <<'FIXTURE'
+Terraform fmt............................................................Failed
+- hook id: terraform_fmt
+- exit code: 127
+Neither Terraform nor OpenTofu binary could be found.
+markdownlint.............................................................Failed
+- hook id: markdownlint-cli2
+- exit code: 1
+docs/foo.md:3:1 MD009/no-trailing-spaces Trailing spaces
+FIXTURE
+
+cat > "$WORK/clean.txt" <<'FIXTURE'
+trim trailing whitespace.................................................Passed
+Terraform fmt........................................(no files to check)Skipped
+markdownlint.............................................................Passed
+FIXTURE
+
+echo ""
+echo "--- a missing binary is not a finding (#335) ---"
+expect_push "all failures tool-absent -> allowed"   "$WORK/absent.txt" 1 0 'Not checked'
+expect_push "...and names what went unchecked"      "$WORK/absent.txt" 1 0 'Terraform fmt'
+expect_push "genuine finding -> still blocked"      "$WORK/real.txt"   1 2 'blocked'
+expect_push "mixed -> blocked, absence reported"    "$WORK/mixed.txt"  1 2 'Not checked'
+expect_push "everything passes -> silent allow"     "$WORK/clean.txt"  0 0 ''
+
 echo ""
 echo "passed: $PASS   failed: $FAIL"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #335

## What changed

Two things, and they buy different things — worth keeping straight.

### 1. `precommit-claude-hook` splits its failures

A hook that fails purely because its binary is absent is reported as **not checked** and does not block. Everything else blocks exactly as before.

| Situation | Before | After |
| --- | --- | --- |
| All failures tool-absent | exit 2, ~300 lines of red | exit 0, one line naming what went unchecked |
| A genuine finding | exit 2 | exit 2, unchanged |
| Mixed | exit 2 | exit 2, **plus** a line naming what went unchecked |
| Everything passes | exit 0, silent | exit 0, silent |

The tool-absent signature is `exit code: 127`, `command not found`, `[Ee]xecutable … not found`, `binary could be found`, or `not found in PATH`. Deliberately tight — keyed on *the tool being missing*, not on the hook merely failing — because the costly direction of error here is waving a real finding through. An unparseable result falls back to blocking; an unreadable answer must not become a free pass.

### 2. `--with-terraform`, on by default for a sandbox

Installs `terraform`, `tflint` and `checkov` so a repo whose config calls the Terraform hooks can actually run them. It sits inside `--with-precommit`, since serving that config is the whole reason the binaries are there — `--with-terraform --no-precommit` installs nothing.

The default follows `--with-precommit`, for the reason already written there: a sandbox is disposable and rebuilt from a script, so there is no developer setup someone is protecting, and a gate that is present beats a download that is avoided.

| Profile | Default |
| --- | --- |
| `claude-cloud-sandbox`, `codex-cloud-sandbox` | **on** |
| `codex-workstation` and anything else | off |

`--no-terraform` is the refund for an environment that does no Terraform work. The download is a real cost, and it is why this stays a per-profile default rather than becoming unconditional.

## The two halves buy different things

Worth stating plainly, because conflating them is what made the install look mandatory:

- Change **1** buys the ability to **push**. A container without these tools is no longer blocked — the hooks report as not checked.
- Change **2** buys **coverage**. A container with them actually runs the Terraform checks instead of skipping them.

Before change 1, "no terraform installed" meant every push needed `--no-verify`, so installing the toolchain looked like the fix for a push problem. It isn't. Each half now stands on its own.

## Why it was a guard that had stopped guarding

Five pushes in one `gcp-org-management` session, all five blocked, all five needing `--no-verify` — on commits touching only Go and Markdown. A bypass used five times out of five stops being a considered decision and becomes the muscle-memory ending of every push command, already typed by the time the hook blocks for a real reason.

This is #254 one layer up: that was about gates that *could not run*; this is a gate that **blocked because it could not run**, reporting a missing tool indistinguishably from a lint finding.

## Acceptance criteria

- [x] A hook failing purely because its binary is absent does not block a push
- [x] The push reports, in one line, which checks could not run and why
- [x] A genuine lint/format finding still blocks, unchanged
- [x] Verified with no `terraform`/`tflint`/`checkov`: a Go-only commit pushes without `--no-verify`, and a real finding still blocks

## Verification

`tests/precommit-hook-test.sh` gains five end-to-end cases. They stub `pre-commit` on `PATH` against a throwaway repo and assert the hook's **real exit code** — 2 blocks the tool call, 0 lets it through — rather than inspecting a trace, using the exact output shapes from the issue:

```
--- a missing binary is not a finding (#335) ---
ok    all failures tool-absent -> allowed                  -> exit 0
ok    ...and names what went unchecked                     -> exit 0
ok    genuine finding -> still blocked                     -> exit 2
ok    mixed -> blocked, absence reported                   -> exit 2
ok    everything passes -> silent allow                    -> exit 0

passed: 23   failed: 0
```

The 18 pre-existing classification tests still pass, so the #191 substring-matching invariant is intact.

Flag plumbing exercised separately (parser + default resolution, no installer run):

```
[]                                             -> terraform=1 precommit=1
[--no-terraform]                               -> terraform=0 precommit=1
[--with-terraform]                             -> terraform=1 precommit=1
[--profile codex-cloud-sandbox]                -> terraform=1 precommit=1
[--profile codex-workstation]                  -> terraform=0 precommit=0
[--profile codex-workstation --with-terraform] -> terraform=1 precommit=0
--with-bogus                                   -> die: unknown argument
```

All gates green: markdownlint (127 files), the four shell test scripts, `compose-context.py`, `allowlist-covers-commands.py`, and shellcheck across `home/bin`, `cloud/` and `tests/`. `settings.json` is untouched, so its `.md` sync gate is not in play.