### PR TITLE
Record the AUTOMERGE_PAT decision: one shared token, scoped to the tier-2 list

### DIFF
--- a/docs/github-standards.md
+++ b/docs/github-standards.md
@@ -214,6 +214,51 @@ File half (repos with CI worth trusting):
   the PAT is missing rather than falling back.
 - Merge flag: `--merge`, per the merge-methods standard.
 
+### The `AUTOMERGE_PAT`: one shared token for the estate, not one per repo
+
+Decided 2026-08-29. The auto-merge PAT is a **single shared fine-grained
+token**, whose selected-repositories list is exactly the set of repos
+running the auto-merge apparatus — no wider.
+
+- **Permissions: Contents read/write, Pull requests read/write, and the
+  forced Metadata read. Nothing else.** This is the floor, not an
+  over-grant: the approval needs the pull-requests half, and the merge
+  itself writes commits to the base branch — GitHub has no narrower
+  "may merge but not push" permission, so Contents write cannot be
+  trimmed away.
+- **Storage stays per-repo even though the token is shared.** A personal
+  account has no organisation secrets, so the same token is stored under
+  the same name in each repo's Dependabot store, which keeps the workflow
+  file byte-identical everywhere. Distribution and rotation are one loop:
+
+  ```sh
+  for r in <tier-2 repos>; do
+    gh secret set AUTOMERGE_PAT --app dependabot --repo "pmgledhill102/$r" --body "$TOKEN"
+  done
+  ```
+
+- **Why shared:** per-repo tokens multiply minting, expiry tracking and
+  rotation by the repo count to buy isolation between repositories that
+  all have the same owner — the blast-radius argument that justifies
+  per-repo credentials in a multi-tenant organisation does not apply
+  here, and every extra token is another row the PAT inventory has to
+  account for. Widening the covered set is an edit to the token's repo
+  list plus one loop iteration, never a new credential.
+- **What bounds a leaked token is the ruleset, not the token's scope.**
+  The standard ruleset requires a pull request and passing checks on the
+  default branch, with an empty bypass list — so even a stolen
+  `AUTOMERGE_PAT` cannot land anything on a default branch without real
+  CI going green first, and cannot push to it directly at all. This is
+  load-bearing, which is why **the token's repository list and the
+  ruleset rollout must be the same list**: a repo reachable by the token
+  but lacking the ruleset has none of that protection.
+- **Upgrade path, recorded rather than adopted:** a private GitHub App
+  with the same two permissions, installed on the same repo list, minting
+  short-lived installation tokens per run — no expiry dates, no rotation.
+  Adopt it the first time PAT rotation actually hurts, or if the estate
+  ever becomes an organisation; until then it is more moving parts than
+  the problem needs.
+
 This posture matches GitHub's own 2026 guidance
 ([grouping, cooldown, security-fast](https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/));
 the estate's 7-day cooldown is stricter than the platform's 3-day default,

--- a/docs/github-standards.md
+++ b/docs/github-standards.md
@@ -252,12 +252,25 @@ running the auto-merge apparatus — no wider.
   load-bearing, which is why **the token's repository list and the
   ruleset rollout must be the same list**: a repo reachable by the token
   but lacking the ruleset has none of that protection.
+- **The token's coverage cannot be audited.** A fine-grained PAT's
+  repository list is not readable from outside the token, so no sweep can
+  answer "is this repo actually in scope?" — only using the token answers
+  that. A repo added to the auto-merge tier but missed off the list fails
+  at run time, and fails *confusingly*: the secret is present and
+  non-empty, so the workflow's missing-PAT guard passes, and the failure
+  surfaces as a raw 403 from the approve step. Two controls follow, and
+  they are the only two available: add the repo to the token's list as an
+  explicit step when the auto-merge workflow is installed, and have that
+  workflow name this cause when the approve step fails.
 - **Upgrade path, recorded rather than adopted:** a private GitHub App
   with the same two permissions, installed on the same repo list, minting
   short-lived installation tokens per run — no expiry dates, no rotation.
-  Adopt it the first time PAT rotation actually hurts, or if the estate
-  ever becomes an organisation; until then it is more moving parts than
-  the problem needs.
+  It also fixes the unauditability above: an App's coverage *is* readable,
+  one call per repo (`GET /repos/{owner}/{repo}/installation`), so a sweep
+  can prove coverage instead of discovering a gap at run time. Adopt it
+  the first time PAT rotation actually hurts, when a missed repo has
+  cost real debugging, or if the estate ever becomes an organisation;
+  until then it is more moving parts than the problem needs.
 
 This posture matches GitHub's own 2026 guidance
 ([grouping, cooldown, security-fast](https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/));


### PR DESCRIPTION
## Summary

Adds one subsection to `docs/github-standards.md`'s Dependabot section: **"The `AUTOMERGE_PAT`: one shared token for the estate, not one per repo."**

Closes #359

The owner's decision from today's session, recorded with its reasoning:

- **One shared fine-grained PAT**, selected-repositories list = exactly the Tier-2 set. Per-repo tokens multiply minting/expiry/rotation by repo count to buy isolation between repos with the same owner, and each is another row for the unresolved PAT inventory (paul-context#21).
- **Permission floor with the why**: Contents R/W + Pull requests R/W + forced Metadata R. Contents write can't be trimmed — the merge writes to the base branch and GitHub has no "may merge but not push" permission. This answers the question that prompted the decision.
- **Storage stays per-repo** (no org secrets on a personal account): same token, same name, each repo's Dependabot store, distributed and rotated by one `gh secret set --app dependabot` loop.
- **The load-bearing constraint**: a leaked token is bounded by the standard ruleset (PR + passing checks + empty bypass), not by token scope — therefore *the token's repo list and the ruleset rollout must be the same list*. This couples the PAT distribution to the #348 sweep by design.
- **GitHub App recorded as upgrade path**, not adopted: short-lived installation tokens end rotation entirely; worth its moving parts when rotation first hurts or the estate becomes an org.

Companion change: `paul-context/registry/dependabot-standard.md` gets a cross-reference (separate PR in that repo — tracked there).

## Gates

`markdownlint-cli2` clean; pre-commit passes on the file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SrZzeddK9V9fDMoajJavbs)_