### PR TITLE
Add GitHub repo settings spec and validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,19 @@ jobs:
       - name: Every helper invocation must be covered by an allow rule
         run: python3 tests/allowlist-covers-commands.py
 
+  repo-standard-spec:
+    name: repo-settings spec validity
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # setup-repo applies this file and the estate audit diffs against it, so
+      # a bad value is applied N times and then reported compliant. Checks the
+      # spec's declared invariants hold of the spec itself, then proves the
+      # validator still catches planted faults.
+      - name: The spec must hold its own invariants
+        run: python3 tests/github-repo-standard.py
+
   actionlint:
     name: Action Lint
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ sh tests/retired-paths.sh                # the prune list is safe and sectioned
 sh tests/retired-paths-test.sh           # ...and its validator still catches
 python3 tests/compose-context.py         # composed profiles and skills match their fragments
 python3 tests/allowlist-covers-commands.py  # allow rules match documented invocations
+python3 tests/github-repo-standard.py       # the repo-settings spec holds its own invariants
 
 # shell — CI scans home/bin/, cloud/ and tests/. Select by shebang: home/bin/
 # also holds a Python script, and `shellcheck home/bin/*` errors on it.

--- a/docs/github-standards.md
+++ b/docs/github-standards.md
@@ -13,6 +13,11 @@ is deferred.
 
 How this document relates to the rest of the estate:
 
+- **The values live in [`home/standards/github-repo.json`](../home/standards/github-repo.json).**
+  This document is the rationale; the spec is what `/setup-repo` applies
+  and the estate audit diffs against, in the GitHub API's own field names.
+  A value stated here and not there is not standard — change both in the
+  same PR.
 - **Skills in this repo apply it.** `/setup-repo` sets the remote half,
   `/setup-common` the in-repo half. Where a skill's instructions and this
   document disagree, this document wins and the skill has a bug.
@@ -331,14 +336,35 @@ one month:
 So the standard includes its own verification discipline:
 
 - **Declared state**: `paul-context/tools/repo-audit.sh` sweeps the estate
-  and diffs it against this document. Run it after any sweep, and
-  occasionally between.
+  and diffs it against the spec, `home/standards/github-repo.json`. Run it
+  after any sweep, and occasionally between. Until the audit's cut-over to
+  reading the spec lands (tracked in `paul-context`), it carries its own
+  copy of the expected values — the drift the spec exists to end.
 - **Observed behaviour**: after remediating a repo, watch the first PR
   through — the merge commit exists (`git log --merges --since=<fix date>`;
   date-bound it, or early history satisfies the check vacuously), the
   Dependabot PR actually merged itself, the deploy workflow actually fired.
   A settings read alone has signed off on broken repos three times; the
   behavioural check is the one that counts.
+
+## Tiers
+
+Not every repo earns the full apparatus, and the axis is **consequence**:
+what happens if a dependency in the repo turns out to be compromised. Not
+how active the repo is, not whether it is public. Three tiers, each
+extending the last, defined in the spec:
+
+| Tier | Applies to | Adds |
+| --- | --- | --- |
+| `baseline` | every repo | dependency graph, alerts, security updates |
+| `protected` | deployed or reachable | the merge-methods signature, the standard ruleset |
+| `automerge` | protected, and CI proves something | auto-merge, a required-checks rule, `AUTOMERGE_PAT` |
+
+Which repo sits in which tier is private, in `paul-context`: the spec
+carries the tiers, the private registry carries the assignments. The
+Dependabot tiers in that registry are the *file* half of the same idea;
+these are the settings half, and its Tier 0 is `baseline`, its Tier 2
+`automerge`.
 
 ## Applying this standard
 
@@ -347,6 +373,7 @@ So the standard includes its own verification discipline:
   has a bug — fix the skill, don't hand-patch the repo.
 - **Existing repos**: scripted sweep + audit, per the mechanism decision in
   `paul-context`. Archive first; sweep the smaller estate.
-- **Changing this standard**: PR against this file, then a sweep to apply
-  it and an audit run to confirm — a standard changed without a sweep is
-  just a wish.
+- **Changing this standard**: one PR against this file **and the spec**
+  (`tests/github-repo-standard.py` keeps the spec self-consistent), then a
+  sweep to apply it and an audit run to confirm — a standard changed
+  without a sweep is just a wish.

--- a/home/skills/setup-repo/SKILL.md
+++ b/home/skills/setup-repo/SKILL.md
@@ -115,34 +115,35 @@ Apply **one ruleset** targeting the default branch. Create it with
 an existing ruleset for the default branch, update it in place with
 `gh api -X PUT repos/{owner}/{repo}/rulesets/{ruleset_id} --input <file>`
 rather than creating a second one. Do not use heredocs to pass the JSON —
-write a temporary file and pass it with `--input`. The payload:
+write a temporary file and pass it with `--input`.
 
-```json
-{
-  "name": "default-branch",
-  "target": "branch",
-  "enforcement": "active",
-  "bypass_actors": [],
-  "conditions": { "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] } },
-  "rules": [
-    { "type": "deletion" },
-    { "type": "non_fast_forward" },
-    { "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": false,
-        "require_code_owner_review": false,
-        "require_last_push_approval": false,
-        "required_review_thread_resolution": false
-      } },
-    { "type": "required_status_checks",
-      "parameters": {
-        "strict_required_status_checks_policy": true,
-        "required_status_checks": [ { "context": "<detected check name>" } ]
-      } }
-  ]
-}
+The payload is the spec's `protected` ruleset. Take it from there rather
+than retyping it, so this skill cannot drift from the standard:
+
+```sh
+SPEC="${CLAUDE_STANDARDS_SPEC:-$HOME/.claude/standards/github-repo.json}"
+jq '.tiers.protected.ruleset' "$SPEC" > ruleset.json
 ```
+
+The spec ships `required_status_checks` with an **empty** contexts list,
+deliberately (its `no-fake-contexts` invariant: a context string that never
+reports blocks every PR forever, so the spec must not be able to ship one).
+Fill it from the names derived above, or drop the rule when the repo has no
+CI:
+
+```sh
+# CI exists: require exactly the detected contexts
+jq --argjson ctx '[{"context":"ci"},{"context":"lint"}]' \
+  '(.rules[] | select(.type == "required_status_checks")
+     | .parameters.required_status_checks) = $ctx' ruleset.json > ruleset.final.json
+
+# no CI: omit the rule rather than requiring an empty list
+jq 'del(.rules[] | select(.type == "required_status_checks"))' ruleset.json > ruleset.final.json
+```
+
+On a surface where `~/.claude/standards/` was not delivered, read the raw
+copy of `home/standards/github-repo.json` from this repo's `main` — never
+reconstruct the payload from memory.
 
 - Approvals are 0 because this is a single-human estate: requiring an approval the same human must give adds a click, not a control — the PR and its CI are the control
 - The **empty bypass list is what `enforce_admins` bought under classic protection**: with no bypass actors the rules bind admin-level tokens and coding agents too. Add the narrowest actor only when something concretely breaks without it
@@ -213,8 +214,24 @@ In `--labels-only` mode, verify with `gh label list` alone — confirm the nine 
 
 After a full run, verify the configuration took effect:
 
-- Run `gh repo view --json deleteBranchOnMerge,squashMergeAllowed,mergeCommitAllowed,rebaseMergeAllowed` and confirm values match — expect `mergeCommitAllowed` and `squashMergeAllowed` true, `rebaseMergeAllowed` false
-- Run `gh api "repos/{owner}/{repo}/rules/branches/{default_branch}" --jq '[.[].type]'` and confirm the effective rules are exactly the standard set — `pull_request`, `non_fast_forward`, `deletion`, plus `required_status_checks` where CI exists — and specifically that `required_linear_history` is **absent**: if present, merge commits are blocked and step 5 did not apply as intended
+- Diff the repository settings against the spec, key for key, in the API's
+  own field names so nothing is translated by hand. Use `protected` for a
+  repo without auto-merge; add the `automerge` overlay where it has it:
+
+  ```sh
+  SPEC="${CLAUDE_STANDARDS_SPEC:-$HOME/.claude/standards/github-repo.json}"
+  jq -S '.tiers.protected.repository' "$SPEC" > expected.json
+  # auto-merge repo: jq -S '.tiers.protected.repository + .tiers.automerge.repository' "$SPEC" > expected.json
+  gh api "repos/{owner}/{repo}" \
+    | jq -S --slurpfile e expected.json 'with_entries(select(.key | IN($e[0] | keys[])))' > actual.json
+  diff expected.json actual.json && echo "repository settings match the spec"
+  ```
+
+  A non-empty diff is a **stop-and-fix**, not a line in the summary. A
+  mismatch here that was noted and not acted on is how 29 repos ended up
+  with merge commits disabled (#352): re-run the failing step and diff
+  again before reporting done.
+- Run `gh api "repos/{owner}/{repo}/rules/branches/{default_branch}" --jq '[.[].type]'` and confirm the effective rules are the spec's `rules_required` for the tier (`jq '.tiers.protected.rules_required' "$SPEC"`), plus `required_status_checks` where CI exists — and specifically that `required_linear_history` is **absent**: if present, merge commits are blocked and step 5 did not apply as intended
 - Where step 5 migrated a classic rule, confirm `gh api repos/{owner}/{repo}/branches/{default_branch}/protection` now returns 404 — here that is the desired end state, meaning the ruleset alone carries the rules
 - Confirm the required contexts equal the derived list exactly — no extras surviving from before
 - Display a final summary showing all applied settings

--- a/home/standards/github-repo.json
+++ b/home/standards/github-repo.json
@@ -1,0 +1,115 @@
+{
+  "version": 1,
+  "standard": "docs/github-standards.md",
+  "read_from": [
+    "$HOME/.claude/standards/github-repo.json",
+    "https://raw.githubusercontent.com/pmgledhill102/agentic-coding-config/main/home/standards/github-repo.json"
+  ],
+  "field_names": "GitHub REST response shape: `repository` keys are GET /repos/{owner}/{repo} fields, `ruleset` is a POST /repos/{owner}/{repo}/rulesets payload. No translation layer between this file, the applier and the audit.",
+  "tier_axis": "consequence — what happens if a dependency in the repo is compromised. Not activity, not visibility, not repo kind. Assignments are private and live in paul-context.",
+  "tiers": {
+    "baseline": {
+      "applies_to": "Every repository, archived ones included where the write succeeds. Two idempotent calls, never wrong.",
+      "extends": null,
+      "security": {
+        "dependency_graph": true,
+        "vulnerability_alerts": true,
+        "security_updates": true
+      }
+    },
+    "protected": {
+      "applies_to": "Deployed or reachable: the code runs somewhere, or something else depends on it.",
+      "extends": "baseline",
+      "repository": {
+        "allow_merge_commit": true,
+        "allow_squash_merge": true,
+        "allow_rebase_merge": false,
+        "delete_branch_on_merge": true,
+        "merge_commit_title": "PR_TITLE",
+        "merge_commit_message": "PR_BODY",
+        "squash_merge_commit_title": "PR_TITLE"
+      },
+      "ruleset": {
+        "name": "default-branch",
+        "target": "branch",
+        "enforcement": "active",
+        "bypass_actors": [],
+        "conditions": {
+          "ref_name": {
+            "include": ["~DEFAULT_BRANCH"],
+            "exclude": []
+          }
+        },
+        "rules": [
+          { "type": "deletion" },
+          { "type": "non_fast_forward" },
+          {
+            "type": "pull_request",
+            "parameters": {
+              "required_approving_review_count": 0,
+              "dismiss_stale_reviews_on_push": false,
+              "require_code_owner_review": false,
+              "require_last_push_approval": false,
+              "required_review_thread_resolution": false
+            }
+          },
+          {
+            "type": "required_status_checks",
+            "parameters": {
+              "strict_required_status_checks_policy": true,
+              "required_status_checks": []
+            }
+          }
+        ]
+      },
+      "rules_required": ["deletion", "non_fast_forward", "pull_request"],
+      "rules_when_ci": ["required_status_checks"],
+      "classic_branch_protection": "none"
+    },
+    "automerge": {
+      "applies_to": "Protected, and the CI proves something. Auto-merge on a repo whose checks are a formality is a slower way of not reading the diff.",
+      "extends": "protected",
+      "repository": {
+        "allow_auto_merge": true
+      },
+      "rules_required": ["required_status_checks"],
+      "dependabot_secrets": ["AUTOMERGE_PAT"]
+    }
+  },
+  "invariants": [
+    {
+      "id": "no-linear-history",
+      "holds": "No tier's ruleset contains a required_linear_history rule, and no classic protection enables it.",
+      "because": "It forbids merge commits on the branch regardless of allow_merge_commit, and the failure surfaces at merge time on a green, approved PR."
+    },
+    {
+      "id": "auto-merge-needs-a-gate",
+      "holds": "Any tier asserting allow_auto_merge: true requires a required_status_checks rule with at least one context.",
+      "because": "Without a required check, `gh pr merge --auto` merges immediately. The wait for CI comes from the ruleset, not the flag."
+    },
+    {
+      "id": "merge-commit-available",
+      "holds": "Any tier asserting merge methods has allow_merge_commit: true and allow_rebase_merge: false.",
+      "because": "Merge is the estate default; rebase is never. Disabling squash alone returns 422 because GitHub requires one method to remain, so a change here is one combined call."
+    },
+    {
+      "id": "empty-bypass",
+      "holds": "The ruleset's bypass_actors is empty.",
+      "because": "That is what enforce_admins bought under classic protection: the rules bind admin tokens and coding agents too."
+    },
+    {
+      "id": "no-fake-contexts",
+      "holds": "The spec's required_status_checks list is empty; contexts are filled per repo from a real completed run.",
+      "because": "A context string that never reports blocks every PR forever. The spec must not be able to ship one."
+    }
+  ],
+  "unspecified": {
+    "allow_forking": "Decision pending in paul-context (#114). The private baseline carries a value; this spec does not until the standard does.",
+    "actions_allowed": "Decision pending in paul-context (#114): `all` vs `selected`, sequenced with SHA-pinning (#44).",
+    "has_wiki, has_projects, has_discussions, has_issues": "Decision pending in paul-context (#19). setup-repo currently turns wiki and projects off; that is the skill's choice, not yet the standard's.",
+    "default_workflow_permissions, can_approve_pull_request_reviews": "Not stated by the standard. The audit collects both; nothing asserts them.",
+    "allow_update_branch": "setup-repo enables it; the standard is silent.",
+    "squash_merge_commit_message": "The standard sets the squash title only.",
+    "required_status_checks contexts": "Per repo, deliberately, until the checks-and-CI section of the standard is settled."
+  }
+}

--- a/tests/github-repo-standard.py
+++ b/tests/github-repo-standard.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""The repo-settings spec must be valid, self-consistent and safe to apply.
+
+`home/standards/github-repo.json` is the single machine-readable statement of
+the estate's GitHub repo standard. `setup-repo` applies it and the estate
+audit diffs against it, so a mistake here is applied N times and then reported
+as compliant. This validates the properties that matter:
+
+  - every tier's `extends` chain resolves, without cycles
+  - each `repository` key is a real GET /repos field, so a typo cannot become
+    a silently unchecked setting
+  - the invariants the spec declares are true of the spec itself: no
+    linear-history rule, an empty bypass list, no shipped status-check
+    contexts, auto-merge only alongside a required-checks rule, and merge
+    commits available wherever merge methods are asserted
+  - no tier names a repository: assignments are private and live elsewhere
+
+Run with no arguments to validate the committed spec. The last section feeds
+the validator a deliberately broken copy, so a validator that stops catching
+things fails CI rather than passing it.
+"""
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SPEC = ROOT / "home" / "standards" / "github-repo.json"
+
+# Fields of GET /repos/{owner}/{repo} that a tier may assert. Anything else in
+# a `repository` block is a typo, and a typo is worse than an omission: the
+# applier ignores it and the audit never checks it.
+REPOSITORY_FIELDS = {
+    "allow_merge_commit", "allow_squash_merge", "allow_rebase_merge",
+    "allow_auto_merge", "allow_update_branch", "delete_branch_on_merge",
+    "merge_commit_title", "merge_commit_message",
+    "squash_merge_commit_title", "squash_merge_commit_message",
+    "allow_forking", "web_commit_signoff_required",
+    "has_issues", "has_wiki", "has_projects", "has_discussions",
+}
+SECURITY_FIELDS = {"dependency_graph", "vulnerability_alerts", "security_updates"}
+RULE_TYPES = {
+    "deletion", "non_fast_forward", "pull_request", "required_status_checks",
+    "required_linear_history", "required_signatures", "creation", "update",
+    "required_deployments", "code_scanning", "workflows", "tag_name_pattern",
+    "branch_name_pattern", "commit_message_pattern",
+}
+PROHIBITED_RULES = {"required_linear_history"}
+TIER_KEYS = {
+    "applies_to", "extends", "repository", "security", "ruleset",
+    "rules_required", "rules_when_ci", "classic_branch_protection",
+    "dependabot_secrets",
+}
+
+
+def resolve(tiers, name, seen=()):
+    """The tier with its ancestors folded in. Child keys win; lists concatenate."""
+    if name in seen:
+        raise ValueError(f"extends cycle: {' -> '.join(seen + (name,))}")
+    tier = tiers[name]
+    parent = tier.get("extends")
+    base = resolve(tiers, parent, seen + (name,)) if parent else {}
+    out = copy.deepcopy(base)
+    for key, value in tier.items():
+        if key in ("extends", "applies_to"):
+            continue
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key].update(value)
+        elif isinstance(value, list) and isinstance(out.get(key), list):
+            out[key] = out[key] + [v for v in value if v not in out[key]]
+        else:
+            out[key] = value
+    return out
+
+
+def validate(spec):
+    """Every problem found, as a list of strings. Empty means valid."""
+    problems = []
+
+    if spec.get("version") != 1:
+        problems.append(f"version must be 1, got {spec.get('version')!r}")
+
+    tiers = spec.get("tiers") or {}
+    if not tiers:
+        return problems + ["no tiers"]
+
+    for name, tier in tiers.items():
+        unknown = set(tier) - TIER_KEYS
+        if unknown:
+            problems.append(f"{name}: unknown keys {sorted(unknown)}")
+        parent = tier.get("extends")
+        if parent is not None and parent not in tiers:
+            problems.append(f"{name}: extends unknown tier {parent!r}")
+        bad = set(tier.get("repository", {})) - REPOSITORY_FIELDS
+        if bad:
+            problems.append(f"{name}: repository keys are not GET /repos fields: {sorted(bad)}")
+        bad = set(tier.get("security", {})) - SECURITY_FIELDS
+        if bad:
+            problems.append(f"{name}: unknown security keys {sorted(bad)}")
+
+    if "pmgledhill102/" in json.dumps(tiers):
+        problems.append("a tier names a repository; assignments are private and belong in paul-context")
+
+    for name in tiers:
+        try:
+            tier = resolve(tiers, name)
+        except ValueError as e:
+            problems.append(str(e))
+            continue
+
+        repo = tier.get("repository", {})
+        ruleset = tier.get("ruleset")
+        rules = {r["type"]: r for r in (ruleset or {}).get("rules", [])}
+
+        for rule in rules:
+            if rule not in RULE_TYPES:
+                problems.append(f"{name}: unknown ruleset rule type {rule!r}")
+        for rule in PROHIBITED_RULES & set(rules):
+            problems.append(f"{name}: prohibited rule {rule} in ruleset")
+        for rule in PROHIBITED_RULES & set(tier.get("rules_required", []) + tier.get("rules_when_ci", [])):
+            problems.append(f"{name}: prohibited rule {rule} listed as required")
+
+        if ruleset is not None:
+            if ruleset.get("bypass_actors"):
+                problems.append(f"{name}: bypass_actors must be empty")
+            if ruleset.get("enforcement") != "active":
+                problems.append(f"{name}: ruleset enforcement must be active")
+            include = ruleset.get("conditions", {}).get("ref_name", {}).get("include")
+            if include != ["~DEFAULT_BRANCH"]:
+                problems.append(f"{name}: ruleset must target ~DEFAULT_BRANCH only, got {include!r}")
+            rsc = rules.get("required_status_checks", {}).get("parameters", {})
+            if rsc.get("required_status_checks"):
+                problems.append(f"{name}: spec ships status-check contexts; they are per-repo")
+            for listed in tier.get("rules_required", []) + tier.get("rules_when_ci", []):
+                if listed not in rules:
+                    problems.append(f"{name}: {listed} is required but absent from the ruleset payload")
+
+        if repo.get("allow_auto_merge") is True:
+            if "required_status_checks" not in tier.get("rules_required", []):
+                problems.append(f"{name}: allow_auto_merge without required_status_checks in rules_required")
+
+        asserts_merge = {"allow_merge_commit", "allow_squash_merge", "allow_rebase_merge"} & set(repo)
+        if asserts_merge:
+            if repo.get("allow_merge_commit") is not True:
+                problems.append(f"{name}: asserts merge methods but allow_merge_commit is not true")
+            if repo.get("allow_rebase_merge") is not False:
+                problems.append(f"{name}: asserts merge methods but allow_rebase_merge is not false")
+            if not any(repo.get(k) for k in asserts_merge):
+                problems.append(f"{name}: no merge method enabled")
+
+    return problems
+
+
+def main():
+    spec = json.loads(SPEC.read_text())
+    problems = validate(spec)
+    for p in problems:
+        print(f"FAIL {SPEC.relative_to(ROOT)}: {p}")
+    if problems:
+        return 1
+    print(f"ok   {SPEC.relative_to(ROOT)}: {len(spec['tiers'])} tiers, "
+          f"{len(spec.get('invariants', []))} invariants")
+
+    # The validator must still catch things. Each mutation breaks one property
+    # the spec relies on; a validator that passes any of them is the bug.
+    broken = {
+        "linear history": lambda s: s["tiers"]["protected"]["ruleset"]["rules"].append(
+            {"type": "required_linear_history"}),
+        "bypass actor": lambda s: s["tiers"]["protected"]["ruleset"]["bypass_actors"].append(
+            {"actor_id": 1, "actor_type": "Integration", "bypass_mode": "always"}),
+        "shipped context": lambda s: s["tiers"]["protected"]["ruleset"]["rules"][3]["parameters"]
+            ["required_status_checks"].append({"context": "ci"}),
+        "auto-merge ungated": lambda s: s["tiers"]["automerge"].__setitem__("rules_required", []),
+        "merge disabled": lambda s: s["tiers"]["protected"]["repository"].__setitem__(
+            "allow_merge_commit", False),
+        "typo field": lambda s: s["tiers"]["protected"]["repository"].__setitem__(
+            "allow_merge_commits", True),
+        "named repo": lambda s: s["tiers"]["automerge"].__setitem__(
+            "applies_to", "pmgledhill102/example"),
+        "extends cycle": lambda s: s["tiers"]["baseline"].__setitem__("extends", "automerge"),
+    }
+    missed = []
+    for label, mutate in broken.items():
+        s = copy.deepcopy(spec)
+        mutate(s)
+        if not validate(s):
+            missed.append(label)
+    if missed:
+        print(f"FAIL validator does not catch: {', '.join(missed)}")
+        return 1
+    print(f"ok   validator catches all {len(broken)} planted faults")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Introduces a machine-readable specification for the GitHub repository standard and a validator to ensure it remains self-consistent and safe to apply.

## Summary

The GitHub repository standard has lived in `docs/github-standards.md` as prose. This change extracts the concrete settings into a machine-readable spec (`home/standards/github-repo.json`) that `/setup-repo` applies and the estate audit diffs against, eliminating the gap where hand-transcribed values could drift from the documented standard.

## Key Changes

- **New spec file** (`home/standards/github-repo.json`): Defines three tiers (`baseline`, `protected`, `automerge`) with their repository settings, rulesets, and security configurations. Includes declared invariants that the spec itself must satisfy.

- **New validator** (`tests/github-repo-standard.py`): Validates the spec's structural integrity:
  - Resolves `extends` chains without cycles
  - Confirms all `repository` keys are real GitHub API fields (typos cannot become silent misconfigurations)
  - Enforces the spec's own invariants: no linear-history rules, empty bypass lists, no shipped status-check contexts, auto-merge only with required checks, merge commits available where merge methods are asserted
  - Prevents repository names from appearing in the tiers (assignments are private)
  - Includes planted faults to prove the validator still catches problems

- **Updated skill documentation** (`home/skills/setup-repo/SKILL.md`): Directs `/setup-repo` to read the ruleset payload from the spec rather than hardcoding it, and provides `jq` recipes to fill in per-repo CI contexts and verify settings match the spec.

- **Updated standard document** (`docs/github-standards.md`): Clarifies that values live in the spec, documents the tier system, and notes that standard changes require updating both the document and the spec.

- **CI integration** (`.github/workflows/ci.yml`): Adds a `repo-standard-spec` job that runs the validator on every commit, catching spec drift before it ships.

## Implementation Details

The validator uses a `resolve()` function to fold inheritance chains (child keys win, lists concatenate), then checks each resolved tier against the constraints. The spec ships `required_status_checks` with an empty contexts list deliberately — the invariant `no-fake-contexts` prevents the spec from shipping a context string that never reports, which would block every PR forever. Per-repo contexts are filled by `/setup-repo` from detected CI runs.

The planted-fault section at the end of the validator proves it catches: linear history rules, bypass actors, shipped contexts, ungated auto-merge, disabled merge commits, typo fields, named repositories, and extends cycles. A validator that passes any of these is the bug, not the spec.

## Worth knowing before merge

- Only settled policy is in the spec. Forking, `allowed_actions`, wiki/projects and workflow-token permissions sit in an `unspecified` block naming the issue that decides each, so the spec cannot pre-empt an open decision.
- Tiers follow the private mechanism decision's amendment B (by consequence, not activity). `baseline` therefore does not assert merge methods; when the estate audit later cuts over to reading the spec, dormant repos will drop out of its merge-method finding by policy, not by remediation.
- `home/standards/` reaches workstations through the existing `home/**` chezmoi include. The cloud bootstrap fetches named files, so sandboxes read the raw copy from `main`; the skill says so. `cloud/bootstrap.sh` is untouched.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJWKwtHuA4KVCyUwSz1Pia